### PR TITLE
Using preferred @hotwired/stimulus

### DIFF
--- a/dist/application.es.js
+++ b/dist/application.es.js
@@ -1,4 +1,339 @@
-import { Controller } from 'stimulus';
+/*
+Stimulus 3.0.1
+Copyright © 2021 Basecamp, LLC
+ */
+
+function camelize(value) {
+    return value.replace(/(?:[_-])([a-z0-9])/g, (_, char) => char.toUpperCase());
+}
+function capitalize(value) {
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+function dasherize(value) {
+    return value.replace(/([A-Z])/g, (_, char) => `-${char.toLowerCase()}`);
+}
+
+function readInheritableStaticArrayValues(constructor, propertyName) {
+    const ancestors = getAncestorsForConstructor(constructor);
+    return Array.from(ancestors.reduce((values, constructor) => {
+        getOwnStaticArrayValues(constructor, propertyName).forEach(name => values.add(name));
+        return values;
+    }, new Set));
+}
+function readInheritableStaticObjectPairs(constructor, propertyName) {
+    const ancestors = getAncestorsForConstructor(constructor);
+    return ancestors.reduce((pairs, constructor) => {
+        pairs.push(...getOwnStaticObjectPairs(constructor, propertyName));
+        return pairs;
+    }, []);
+}
+function getAncestorsForConstructor(constructor) {
+    const ancestors = [];
+    while (constructor) {
+        ancestors.push(constructor);
+        constructor = Object.getPrototypeOf(constructor);
+    }
+    return ancestors.reverse();
+}
+function getOwnStaticArrayValues(constructor, propertyName) {
+    const definition = constructor[propertyName];
+    return Array.isArray(definition) ? definition : [];
+}
+function getOwnStaticObjectPairs(constructor, propertyName) {
+    const definition = constructor[propertyName];
+    return definition ? Object.keys(definition).map(key => [key, definition[key]]) : [];
+}
+(() => {
+    function extendWithReflect(constructor) {
+        function extended() {
+            return Reflect.construct(constructor, arguments, new.target);
+        }
+        extended.prototype = Object.create(constructor.prototype, {
+            constructor: { value: extended }
+        });
+        Reflect.setPrototypeOf(extended, constructor);
+        return extended;
+    }
+    function testReflectExtension() {
+        const a = function () { this.a.call(this); };
+        const b = extendWithReflect(a);
+        b.prototype.a = function () { };
+        return new b;
+    }
+    try {
+        testReflectExtension();
+        return extendWithReflect;
+    }
+    catch (error) {
+        return (constructor) => class extended extends constructor {
+        };
+    }
+})();
+
+function ClassPropertiesBlessing(constructor) {
+    const classes = readInheritableStaticArrayValues(constructor, "classes");
+    return classes.reduce((properties, classDefinition) => {
+        return Object.assign(properties, propertiesForClassDefinition(classDefinition));
+    }, {});
+}
+function propertiesForClassDefinition(key) {
+    return {
+        [`${key}Class`]: {
+            get() {
+                const { classes } = this;
+                if (classes.has(key)) {
+                    return classes.get(key);
+                }
+                else {
+                    const attribute = classes.getAttributeName(key);
+                    throw new Error(`Missing attribute "${attribute}"`);
+                }
+            }
+        },
+        [`${key}Classes`]: {
+            get() {
+                return this.classes.getAll(key);
+            }
+        },
+        [`has${capitalize(key)}Class`]: {
+            get() {
+                return this.classes.has(key);
+            }
+        }
+    };
+}
+
+function TargetPropertiesBlessing(constructor) {
+    const targets = readInheritableStaticArrayValues(constructor, "targets");
+    return targets.reduce((properties, targetDefinition) => {
+        return Object.assign(properties, propertiesForTargetDefinition(targetDefinition));
+    }, {});
+}
+function propertiesForTargetDefinition(name) {
+    return {
+        [`${name}Target`]: {
+            get() {
+                const target = this.targets.find(name);
+                if (target) {
+                    return target;
+                }
+                else {
+                    throw new Error(`Missing target element "${name}" for "${this.identifier}" controller`);
+                }
+            }
+        },
+        [`${name}Targets`]: {
+            get() {
+                return this.targets.findAll(name);
+            }
+        },
+        [`has${capitalize(name)}Target`]: {
+            get() {
+                return this.targets.has(name);
+            }
+        }
+    };
+}
+
+function ValuePropertiesBlessing(constructor) {
+    const valueDefinitionPairs = readInheritableStaticObjectPairs(constructor, "values");
+    const propertyDescriptorMap = {
+        valueDescriptorMap: {
+            get() {
+                return valueDefinitionPairs.reduce((result, valueDefinitionPair) => {
+                    const valueDescriptor = parseValueDefinitionPair(valueDefinitionPair);
+                    const attributeName = this.data.getAttributeNameForKey(valueDescriptor.key);
+                    return Object.assign(result, { [attributeName]: valueDescriptor });
+                }, {});
+            }
+        }
+    };
+    return valueDefinitionPairs.reduce((properties, valueDefinitionPair) => {
+        return Object.assign(properties, propertiesForValueDefinitionPair(valueDefinitionPair));
+    }, propertyDescriptorMap);
+}
+function propertiesForValueDefinitionPair(valueDefinitionPair) {
+    const definition = parseValueDefinitionPair(valueDefinitionPair);
+    const { key, name, reader: read, writer: write } = definition;
+    return {
+        [name]: {
+            get() {
+                const value = this.data.get(key);
+                if (value !== null) {
+                    return read(value);
+                }
+                else {
+                    return definition.defaultValue;
+                }
+            },
+            set(value) {
+                if (value === undefined) {
+                    this.data.delete(key);
+                }
+                else {
+                    this.data.set(key, write(value));
+                }
+            }
+        },
+        [`has${capitalize(name)}`]: {
+            get() {
+                return this.data.has(key) || definition.hasCustomDefaultValue;
+            }
+        }
+    };
+}
+function parseValueDefinitionPair([token, typeDefinition]) {
+    return valueDescriptorForTokenAndTypeDefinition(token, typeDefinition);
+}
+function parseValueTypeConstant(constant) {
+    switch (constant) {
+        case Array: return "array";
+        case Boolean: return "boolean";
+        case Number: return "number";
+        case Object: return "object";
+        case String: return "string";
+    }
+}
+function parseValueTypeDefault(defaultValue) {
+    switch (typeof defaultValue) {
+        case "boolean": return "boolean";
+        case "number": return "number";
+        case "string": return "string";
+    }
+    if (Array.isArray(defaultValue))
+        return "array";
+    if (Object.prototype.toString.call(defaultValue) === "[object Object]")
+        return "object";
+}
+function parseValueTypeObject(typeObject) {
+    const typeFromObject = parseValueTypeConstant(typeObject.type);
+    if (typeFromObject) {
+        const defaultValueType = parseValueTypeDefault(typeObject.default);
+        if (typeFromObject !== defaultValueType) {
+            throw new Error(`Type "${typeFromObject}" must match the type of the default value. Given default value: "${typeObject.default}" as "${defaultValueType}"`);
+        }
+        return typeFromObject;
+    }
+}
+function parseValueTypeDefinition(typeDefinition) {
+    const typeFromObject = parseValueTypeObject(typeDefinition);
+    const typeFromDefaultValue = parseValueTypeDefault(typeDefinition);
+    const typeFromConstant = parseValueTypeConstant(typeDefinition);
+    const type = typeFromObject || typeFromDefaultValue || typeFromConstant;
+    if (type)
+        return type;
+    throw new Error(`Unknown value type "${typeDefinition}"`);
+}
+function defaultValueForDefinition(typeDefinition) {
+    const constant = parseValueTypeConstant(typeDefinition);
+    if (constant)
+        return defaultValuesByType[constant];
+    const defaultValue = typeDefinition.default;
+    if (defaultValue !== undefined)
+        return defaultValue;
+    return typeDefinition;
+}
+function valueDescriptorForTokenAndTypeDefinition(token, typeDefinition) {
+    const key = `${dasherize(token)}-value`;
+    const type = parseValueTypeDefinition(typeDefinition);
+    return {
+        type,
+        key,
+        name: camelize(key),
+        get defaultValue() { return defaultValueForDefinition(typeDefinition); },
+        get hasCustomDefaultValue() { return parseValueTypeDefault(typeDefinition) !== undefined; },
+        reader: readers[type],
+        writer: writers[type] || writers.default
+    };
+}
+const defaultValuesByType = {
+    get array() { return []; },
+    boolean: false,
+    number: 0,
+    get object() { return {}; },
+    string: ""
+};
+const readers = {
+    array(value) {
+        const array = JSON.parse(value);
+        if (!Array.isArray(array)) {
+            throw new TypeError("Expected array");
+        }
+        return array;
+    },
+    boolean(value) {
+        return !(value == "0" || value == "false");
+    },
+    number(value) {
+        return Number(value);
+    },
+    object(value) {
+        const object = JSON.parse(value);
+        if (object === null || typeof object != "object" || Array.isArray(object)) {
+            throw new TypeError("Expected object");
+        }
+        return object;
+    },
+    string(value) {
+        return value;
+    }
+};
+const writers = {
+    default: writeString,
+    array: writeJSON,
+    object: writeJSON
+};
+function writeJSON(value) {
+    return JSON.stringify(value);
+}
+function writeString(value) {
+    return `${value}`;
+}
+
+class Controller {
+    constructor(context) {
+        this.context = context;
+    }
+    static get shouldLoad() {
+        return true;
+    }
+    get application() {
+        return this.context.application;
+    }
+    get scope() {
+        return this.context.scope;
+    }
+    get element() {
+        return this.scope.element;
+    }
+    get identifier() {
+        return this.scope.identifier;
+    }
+    get targets() {
+        return this.scope.targets;
+    }
+    get classes() {
+        return this.scope.classes;
+    }
+    get data() {
+        return this.scope.data;
+    }
+    initialize() {
+    }
+    connect() {
+    }
+    disconnect() {
+    }
+    dispatch(eventName, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true } = {}) {
+        const type = prefix ? `${prefix}:${eventName}` : eventName;
+        const event = new CustomEvent(type, { detail, bubbles, cancelable });
+        target.dispatchEvent(event);
+        return event;
+    }
+}
+Controller.blessings = [ClassPropertiesBlessing, TargetPropertiesBlessing, ValuePropertiesBlessing];
+Controller.targets = [];
+Controller.values = {};
 
 class input_clipboard_controller extends Controller {
   copy(event) {

--- a/dist/application.js
+++ b/dist/application.js
@@ -1,131 +1,468 @@
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('stimulus')) :
-  typeof define === 'function' && define.amd ? define(['exports', 'stimulus'], factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.TeamsharesUI = {}, global.Stimulus));
-})(this, (function (exports, stimulus) { 'use strict';
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.TeamsharesUI = {}));
+})(this, (function (exports) { 'use strict';
 
-  class input_clipboard_controller extends stimulus.Controller {
-    copy(event) {
-      const clipboardCopyEl = this.element;
-      clipboardCopyEl.classList.add("clicked");
-      setTimeout(() => {
-        clipboardCopyEl.classList.remove("clicked");
-      }, 5000);
+    /*
+    Stimulus 3.0.1
+    Copyright © 2021 Basecamp, LLC
+     */
+
+    function camelize(value) {
+        return value.replace(/(?:[_-])([a-z0-9])/g, (_, char) => char.toUpperCase());
+    }
+    function capitalize(value) {
+        return value.charAt(0).toUpperCase() + value.slice(1);
+    }
+    function dasherize(value) {
+        return value.replace(/([A-Z])/g, (_, char) => `-${char.toLowerCase()}`);
     }
 
-  }
+    function readInheritableStaticArrayValues(constructor, propertyName) {
+        const ancestors = getAncestorsForConstructor(constructor);
+        return Array.from(ancestors.reduce((values, constructor) => {
+            getOwnStaticArrayValues(constructor, propertyName).forEach(name => values.add(name));
+            return values;
+        }, new Set));
+    }
+    function readInheritableStaticObjectPairs(constructor, propertyName) {
+        const ancestors = getAncestorsForConstructor(constructor);
+        return ancestors.reduce((pairs, constructor) => {
+            pairs.push(...getOwnStaticObjectPairs(constructor, propertyName));
+            return pairs;
+        }, []);
+    }
+    function getAncestorsForConstructor(constructor) {
+        const ancestors = [];
+        while (constructor) {
+            ancestors.push(constructor);
+            constructor = Object.getPrototypeOf(constructor);
+        }
+        return ancestors.reverse();
+    }
+    function getOwnStaticArrayValues(constructor, propertyName) {
+        const definition = constructor[propertyName];
+        return Array.isArray(definition) ? definition : [];
+    }
+    function getOwnStaticObjectPairs(constructor, propertyName) {
+        const definition = constructor[propertyName];
+        return definition ? Object.keys(definition).map(key => [key, definition[key]]) : [];
+    }
+    (() => {
+        function extendWithReflect(constructor) {
+            function extended() {
+                return Reflect.construct(constructor, arguments, new.target);
+            }
+            extended.prototype = Object.create(constructor.prototype, {
+                constructor: { value: extended }
+            });
+            Reflect.setPrototypeOf(extended, constructor);
+            return extended;
+        }
+        function testReflectExtension() {
+            const a = function () { this.a.call(this); };
+            const b = extendWithReflect(a);
+            b.prototype.a = function () { };
+            return new b;
+        }
+        try {
+            testReflectExtension();
+            return extendWithReflect;
+        }
+        catch (error) {
+            return (constructor) => class extended extends constructor {
+            };
+        }
+    })();
 
-  const Inputmask = require("inputmask").default;
-
-  class input_mask_controller extends stimulus.Controller {
-    connect() {
-      Inputmask(this.data.get("pattern")).mask(this.element);
+    function ClassPropertiesBlessing(constructor) {
+        const classes = readInheritableStaticArrayValues(constructor, "classes");
+        return classes.reduce((properties, classDefinition) => {
+            return Object.assign(properties, propertiesForClassDefinition(classDefinition));
+        }, {});
+    }
+    function propertiesForClassDefinition(key) {
+        return {
+            [`${key}Class`]: {
+                get() {
+                    const { classes } = this;
+                    if (classes.has(key)) {
+                        return classes.get(key);
+                    }
+                    else {
+                        const attribute = classes.getAttributeName(key);
+                        throw new Error(`Missing attribute "${attribute}"`);
+                    }
+                }
+            },
+            [`${key}Classes`]: {
+                get() {
+                    return this.classes.getAll(key);
+                }
+            },
+            [`has${capitalize(key)}Class`]: {
+                get() {
+                    return this.classes.has(key);
+                }
+            }
+        };
     }
 
-  }
-
-  function _defineProperty(obj, key, value) {
-    if (key in obj) {
-      Object.defineProperty(obj, key, {
-        value: value,
-        enumerable: true,
-        configurable: true,
-        writable: true
-      });
-    } else {
-      obj[key] = value;
+    function TargetPropertiesBlessing(constructor) {
+        const targets = readInheritableStaticArrayValues(constructor, "targets");
+        return targets.reduce((properties, targetDefinition) => {
+            return Object.assign(properties, propertiesForTargetDefinition(targetDefinition));
+        }, {});
+    }
+    function propertiesForTargetDefinition(name) {
+        return {
+            [`${name}Target`]: {
+                get() {
+                    const target = this.targets.find(name);
+                    if (target) {
+                        return target;
+                    }
+                    else {
+                        throw new Error(`Missing target element "${name}" for "${this.identifier}" controller`);
+                    }
+                }
+            },
+            [`${name}Targets`]: {
+                get() {
+                    return this.targets.findAll(name);
+                }
+            },
+            [`has${capitalize(name)}Target`]: {
+                get() {
+                    return this.targets.has(name);
+                }
+            }
+        };
     }
 
-    return obj;
-  }
-
-  class _class$1 extends stimulus.Controller {
-    connect() {
-      this.element[this.identifier] = this;
-      this.classToToggle = this.hasToggleClass ? this.toggleClass : "hidden";
-      this.externalTargets = document.getElementsByClassName(this.data.get("externalTargetClass"));
+    function ValuePropertiesBlessing(constructor) {
+        const valueDefinitionPairs = readInheritableStaticObjectPairs(constructor, "values");
+        const propertyDescriptorMap = {
+            valueDescriptorMap: {
+                get() {
+                    return valueDefinitionPairs.reduce((result, valueDefinitionPair) => {
+                        const valueDescriptor = parseValueDefinitionPair(valueDefinitionPair);
+                        const attributeName = this.data.getAttributeNameForKey(valueDescriptor.key);
+                        return Object.assign(result, { [attributeName]: valueDescriptor });
+                    }, {});
+                }
+            }
+        };
+        return valueDefinitionPairs.reduce((properties, valueDefinitionPair) => {
+            return Object.assign(properties, propertiesForValueDefinitionPair(valueDefinitionPair));
+        }, propertyDescriptorMap);
+    }
+    function propertiesForValueDefinitionPair(valueDefinitionPair) {
+        const definition = parseValueDefinitionPair(valueDefinitionPair);
+        const { key, name, reader: read, writer: write } = definition;
+        return {
+            [name]: {
+                get() {
+                    const value = this.data.get(key);
+                    if (value !== null) {
+                        return read(value);
+                    }
+                    else {
+                        return definition.defaultValue;
+                    }
+                },
+                set(value) {
+                    if (value === undefined) {
+                        this.data.delete(key);
+                    }
+                    else {
+                        this.data.set(key, write(value));
+                    }
+                }
+            },
+            [`has${capitalize(name)}`]: {
+                get() {
+                    return this.data.has(key) || definition.hasCustomDefaultValue;
+                }
+            }
+        };
+    }
+    function parseValueDefinitionPair([token, typeDefinition]) {
+        return valueDescriptorForTokenAndTypeDefinition(token, typeDefinition);
+    }
+    function parseValueTypeConstant(constant) {
+        switch (constant) {
+            case Array: return "array";
+            case Boolean: return "boolean";
+            case Number: return "number";
+            case Object: return "object";
+            case String: return "string";
+        }
+    }
+    function parseValueTypeDefault(defaultValue) {
+        switch (typeof defaultValue) {
+            case "boolean": return "boolean";
+            case "number": return "number";
+            case "string": return "string";
+        }
+        if (Array.isArray(defaultValue))
+            return "array";
+        if (Object.prototype.toString.call(defaultValue) === "[object Object]")
+            return "object";
+    }
+    function parseValueTypeObject(typeObject) {
+        const typeFromObject = parseValueTypeConstant(typeObject.type);
+        if (typeFromObject) {
+            const defaultValueType = parseValueTypeDefault(typeObject.default);
+            if (typeFromObject !== defaultValueType) {
+                throw new Error(`Type "${typeFromObject}" must match the type of the default value. Given default value: "${typeObject.default}" as "${defaultValueType}"`);
+            }
+            return typeFromObject;
+        }
+    }
+    function parseValueTypeDefinition(typeDefinition) {
+        const typeFromObject = parseValueTypeObject(typeDefinition);
+        const typeFromDefaultValue = parseValueTypeDefault(typeDefinition);
+        const typeFromConstant = parseValueTypeConstant(typeDefinition);
+        const type = typeFromObject || typeFromDefaultValue || typeFromConstant;
+        if (type)
+            return type;
+        throw new Error(`Unknown value type "${typeDefinition}"`);
+    }
+    function defaultValueForDefinition(typeDefinition) {
+        const constant = parseValueTypeConstant(typeDefinition);
+        if (constant)
+            return defaultValuesByType[constant];
+        const defaultValue = typeDefinition.default;
+        if (defaultValue !== undefined)
+            return defaultValue;
+        return typeDefinition;
+    }
+    function valueDescriptorForTokenAndTypeDefinition(token, typeDefinition) {
+        const key = `${dasherize(token)}-value`;
+        const type = parseValueTypeDefinition(typeDefinition);
+        return {
+            type,
+            key,
+            name: camelize(key),
+            get defaultValue() { return defaultValueForDefinition(typeDefinition); },
+            get hasCustomDefaultValue() { return parseValueTypeDefault(typeDefinition) !== undefined; },
+            reader: readers[type],
+            writer: writers[type] || writers.default
+        };
+    }
+    const defaultValuesByType = {
+        get array() { return []; },
+        boolean: false,
+        number: 0,
+        get object() { return {}; },
+        string: ""
+    };
+    const readers = {
+        array(value) {
+            const array = JSON.parse(value);
+            if (!Array.isArray(array)) {
+                throw new TypeError("Expected array");
+            }
+            return array;
+        },
+        boolean(value) {
+            return !(value == "0" || value == "false");
+        },
+        number(value) {
+            return Number(value);
+        },
+        object(value) {
+            const object = JSON.parse(value);
+            if (object === null || typeof object != "object" || Array.isArray(object)) {
+                throw new TypeError("Expected object");
+            }
+            return object;
+        },
+        string(value) {
+            return value;
+        }
+    };
+    const writers = {
+        default: writeString,
+        array: writeJSON,
+        object: writeJSON
+    };
+    function writeJSON(value) {
+        return JSON.stringify(value);
+    }
+    function writeString(value) {
+        return `${value}`;
     }
 
-    classIsApplied() {
-      return this.element.classList.contains(this.classToToggle);
+    class Controller {
+        constructor(context) {
+            this.context = context;
+        }
+        static get shouldLoad() {
+            return true;
+        }
+        get application() {
+            return this.context.application;
+        }
+        get scope() {
+            return this.context.scope;
+        }
+        get element() {
+            return this.scope.element;
+        }
+        get identifier() {
+            return this.scope.identifier;
+        }
+        get targets() {
+            return this.scope.targets;
+        }
+        get classes() {
+            return this.scope.classes;
+        }
+        get data() {
+            return this.scope.data;
+        }
+        initialize() {
+        }
+        connect() {
+        }
+        disconnect() {
+        }
+        dispatch(eventName, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true } = {}) {
+            const type = prefix ? `${prefix}:${eventName}` : eventName;
+            const event = new CustomEvent(type, { detail, bubbles, cancelable });
+            target.dispatchEvent(event);
+            return event;
+        }
     }
+    Controller.blessings = [ClassPropertiesBlessing, TargetPropertiesBlessing, ValuePropertiesBlessing];
+    Controller.targets = [];
+    Controller.values = {};
 
-    toggle(event) {
-      if (!this.data.has("allowDefault")) event.preventDefault();
-      this.toggleControllerTargets();
-      this.toggleExternalTargets();
-    }
-
-    toggleOff(event) {
-      if (!this.data.has("allowDefault")) event.preventDefault();
-      if (this.classIsApplied()) this.toggle(event);
-    }
-
-    toggleControllerTargets() {
-      this.toggleableTargets.forEach(target => {
-        this.toggleElementClassList(target);
-      });
-    }
-
-    toggleExternalTargets() {
-      for (let i = 0; i < this.externalTargets.length; ++i) {
-        this.toggleElementClassList(this.externalTargets[i]);
+    class input_clipboard_controller extends Controller {
+      copy(event) {
+        const clipboardCopyEl = this.element;
+        clipboardCopyEl.classList.add("clicked");
+        setTimeout(() => {
+          clipboardCopyEl.classList.remove("clicked");
+        }, 5000);
       }
+
     }
 
-    toggleElementClassList(targetElement) {
-      targetElement.classList.toggle(this.classToToggle);
-    }
+    const Inputmask = require("inputmask").default;
 
-  }
-
-  _defineProperty(_class$1, "targets", ["toggleable"]);
-
-  _defineProperty(_class$1, "classes", ["toggle"]);
-
-  class _class extends stimulus.Controller {
-    // for now, hard-coded to work with /for-leaders page.
-    // future PR will remove hard-coded classes and add value for customizable active and inactive classes.
-    connect() {
-      this.element[this.identifier] = this;
-    }
-
-    switch(event) {
-      if (!this.data.has("allowDefault")) {
-        event.preventDefault();
+    class input_mask_controller extends Controller {
+      connect() {
+        Inputmask(this.data.get("pattern")).mask(this.element);
       }
 
-      this.deactivate();
-      this.activate(event.target);
     }
 
-    deactivate() {
-      this.switchableTargets.forEach(target => {
-        target.classList.add("hidden");
-      });
-      this.clickableTargets.forEach(target => {
-        target.classList.remove("text-gray-100", "border-gray-100");
-        target.classList.add("border-gray-900");
-      });
+    function _defineProperty(obj, key, value) {
+      if (key in obj) {
+        Object.defineProperty(obj, key, {
+          value: value,
+          enumerable: true,
+          configurable: true,
+          writable: true
+        });
+      } else {
+        obj[key] = value;
+      }
+
+      return obj;
     }
 
-    activate(currentElement) {
-      currentElement.classList.remove("border-gray-900");
-      currentElement.classList.add("text-gray-100", "border-gray-100");
-      document.querySelectorAll(`.${currentElement.id}`).forEach(element => {
-        element.classList.remove("hidden");
-      });
+    class _class$1 extends Controller {
+      connect() {
+        this.element[this.identifier] = this;
+        this.classToToggle = this.hasToggleClass ? this.toggleClass : "hidden";
+        this.externalTargets = document.getElementsByClassName(this.data.get("externalTargetClass"));
+      }
+
+      classIsApplied() {
+        return this.element.classList.contains(this.classToToggle);
+      }
+
+      toggle(event) {
+        if (!this.data.has("allowDefault")) event.preventDefault();
+        this.toggleControllerTargets();
+        this.toggleExternalTargets();
+      }
+
+      toggleOff(event) {
+        if (!this.data.has("allowDefault")) event.preventDefault();
+        if (this.classIsApplied()) this.toggle(event);
+      }
+
+      toggleControllerTargets() {
+        this.toggleableTargets.forEach(target => {
+          this.toggleElementClassList(target);
+        });
+      }
+
+      toggleExternalTargets() {
+        for (let i = 0; i < this.externalTargets.length; ++i) {
+          this.toggleElementClassList(this.externalTargets[i]);
+        }
+      }
+
+      toggleElementClassList(targetElement) {
+        targetElement.classList.toggle(this.classToToggle);
+      }
+
     }
 
-  }
+    _defineProperty(_class$1, "targets", ["toggleable"]);
 
-  _defineProperty(_class, "targets", ["switchable", "clickable"]);
+    _defineProperty(_class$1, "classes", ["toggle"]);
 
-  exports.InputClipboardController = input_clipboard_controller;
-  exports.InputMaskController = input_mask_controller;
-  exports.SwitchController = _class;
-  exports.ToggleController = _class$1;
+    class _class extends Controller {
+      // for now, hard-coded to work with /for-leaders page.
+      // future PR will remove hard-coded classes and add value for customizable active and inactive classes.
+      connect() {
+        this.element[this.identifier] = this;
+      }
 
-  Object.defineProperty(exports, '__esModule', { value: true });
+      switch(event) {
+        if (!this.data.has("allowDefault")) {
+          event.preventDefault();
+        }
+
+        this.deactivate();
+        this.activate(event.target);
+      }
+
+      deactivate() {
+        this.switchableTargets.forEach(target => {
+          target.classList.add("hidden");
+        });
+        this.clickableTargets.forEach(target => {
+          target.classList.remove("text-gray-100", "border-gray-100");
+          target.classList.add("border-gray-900");
+        });
+      }
+
+      activate(currentElement) {
+        currentElement.classList.remove("border-gray-900");
+        currentElement.classList.add("text-gray-100", "border-gray-100");
+        document.querySelectorAll(`.${currentElement.id}`).forEach(element => {
+          element.classList.remove("hidden");
+        });
+      }
+
+    }
+
+    _defineProperty(_class, "targets", ["switchable", "clickable"]);
+
+    exports.InputClipboardController = input_clipboard_controller;
+    exports.InputMaskController = input_mask_controller;
+    exports.SwitchController = _class;
+    exports.ToggleController = _class$1;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   },
   "dependencies": {
     "@github/clipboard-copy-element": "^1.1.2",
+    "@hotwired/stimulus": "^3.0.1",
+    "@tailwindcss/aspect-ratio": "^0.4.0",
+    "@tailwindcss/forms": "^0.2.1",
+    "@tailwindcss/typography": "^0.4.1",
     "@webcomponents/custom-elements": "^1.5.0",
     "inputmask": "^5.0.7",
     "material-icons": "^1.10.8",
-    "stimulus": "^2.0.0",
-    "tailwindcss": "npm:@tailwindcss/postcss7-compat",
-    "@tailwindcss/aspect-ratio": "^0.4.0",
-    "@tailwindcss/forms": "^0.2.1",
-    "@tailwindcss/typography": "^0.4.1"
+    "tailwindcss": "npm:@tailwindcss/postcss7-compat"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/src/controllers/input_clipboard_controller.js
+++ b/src/controllers/input_clipboard_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from "stimulus";
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   copy (event) {

--- a/src/controllers/input_mask_controller.js
+++ b/src/controllers/input_mask_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from "stimulus";
+import { Controller } from "@hotwired/stimulus";
 const Inputmask = require("inputmask").default;
 
 export default class extends Controller {

--- a/src/controllers/switch_controller.js
+++ b/src/controllers/switch_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from "stimulus";
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   static targets = ["switchable", "clickable"];

--- a/src/controllers/toggle_controller.js
+++ b/src/controllers/toggle_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from "stimulus";
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   static targets = ["toggleable"];

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,6 +255,11 @@
   resolved "https://registry.yarnpkg.com/@github/clipboard-copy-element/-/clipboard-copy-element-1.1.2.tgz#7a6e8042749471504d4e7cfcc47097a781db2bdb"
   integrity sha512-L6CMrcA5we0udafvoSuRCE/Ci/3xrLWKYRGup2IlhxF771bQYsQ2EB1of182pI8ZWM4oxgwzu37+igMeoZjN/A==
 
+"@hotwired/stimulus@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
+  integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz#68eb521368db76d040a6315cdb24bf2483037b9c"
@@ -322,30 +327,6 @@
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
-
-"@stimulus/core@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-2.0.0.tgz#140c85318d6a8a8210c0faf182223b8459348877"
-  integrity sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==
-  dependencies:
-    "@stimulus/mutation-observers" "^2.0.0"
-
-"@stimulus/multimap@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-2.0.0.tgz#420cfa096ed6538df4a91dbd2b2842c1779952b2"
-  integrity sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==
-
-"@stimulus/mutation-observers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz#3dbe37453bda47a6c795a90204ee8d77a799fb87"
-  integrity sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==
-  dependencies:
-    "@stimulus/multimap" "^2.0.0"
-
-"@stimulus/webpack-helpers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz#54296d2a2dffd4f962d2e802d99a3fdd84b8845f"
-  integrity sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==
 
 "@stylelint/postcss-css-in-js@^0.37.2":
   version "0.37.2"
@@ -2108,14 +2089,6 @@ specificity@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
   integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
-
-stimulus@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-2.0.0.tgz#713c8b91a72ef90914b90955f0e705f004403047"
-  integrity sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==
-  dependencies:
-    "@stimulus/core" "^2.0.0"
-    "@stimulus/webpack-helpers" "^2.0.0"
 
 string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
Looks like we had both `@hotwired/stimulus` and `stimulus` installed (latter should have become a proxy reference to `@hotwired/stimulus` in v3).