### PR TITLE
Add line-clamp plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@hotwired/stimulus": "^3.0.1",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.2.1",
+    "@tailwindcss/line-clamp": "^0.4.0",
     "@tailwindcss/typography": "^0.4.1",
     "@webcomponents/custom-elements": "^1.5.0",
     "inputmask": "^5.0.7",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -136,7 +136,8 @@ module.exports = {
   plugins: [
     require("@tailwindcss/forms"),
     require("@tailwindcss/typography"),
-    require("@tailwindcss/aspect-ratio")
+    require("@tailwindcss/aspect-ratio"),
+    require("@tailwindcss/line-clamp")
   ],
   future: {
     purgeLayersByDefault: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -414,6 +414,11 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
+"@tailwindcss/line-clamp@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.0.tgz#03353e31e77636b785f2336e8c978502cec1de81"
+  integrity sha512-HQZo6gfx1D0+DU3nWlNLD5iA6Ef4JAXh0LeD8lOGrJwEDBwwJNKQza6WoXhhY1uQrxOuU8ROxV7CqiQV4CoiLw==
+
 "@tailwindcss/typography@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.4.1.tgz#51ddbceea6a0ee9902c649dbe58871c81a831212"


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Improve-OS-navigation-0e85cc70f8814a55945f9c32bb3dcfa1)

## Description

Adds `line-clamp` plugin which allows us to truncate text with `...`. (The advantage of using this plugin instead of doing it in Rails is that it can be based on the number of lines of text rather than characters. For example, in this screenshot, we're using the class `line-clamp-2` to truncate text to 2 lines).

Needed for https://github.com/teamshares/os-app/pull/35

## Screenshots (if relevant)

<img width="227" alt="image" src="https://user-images.githubusercontent.com/97977088/168334618-af34eb5d-3c87-40de-b26f-4eebbb1ef37e.png">


**Reminder:** these changes won't be pulled into any downstream apps until you merge _this_ PR, and _then_ merge a PR _on that app_ checking in an updated `yarn.lock` (i.e. after having run `yarn upgrade @teamshares/ui`).
