### PR TITLE
Exclude nav buttons from default button styles

### DIFF
--- a/scss/_teamshares.scss
+++ b/scss/_teamshares.scss
@@ -204,8 +204,8 @@ ul a {
 
 // Form elements
 // TODO: Refactor all ts-button-primary to ts-button primary and remove from this styling
-button:not(.button-view-component, .button-icon, .icon-button-view-component),
-.ts-button:not(.button-view-component, .button-icon, .icon-button-view-component) {
+button:not(.button-view-component, .button-icon, .icon-button-view-component, .nav-button),
+.ts-button:not(.button-view-component, .button-icon, .icon-button-view-component, .nav-button) {
   appearance: none;
   border: 0;
   border-radius: 0.375rem;


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Profile-menu-dropdown-content-wrapping-4b6b4b0f4a5c457eac6a5aa2ad878dc2)

## Description

Adds `nav-button` to the list of classes excluded from default button styles. After merging this I plan to add class `nav-button` to all buttons in the new nav components in OS to avoid clashing styles.

## Screenshots (if relevant)

(Ignore content/sizing differences; it's because screenshots are from different environments & different sized browser windows)

### Before 

<img width="885" alt="image" src="https://user-images.githubusercontent.com/97977088/169368646-86e51d2d-573c-4c82-a095-b6808725d445.png">

### After

<img width="987" alt="image" src="https://user-images.githubusercontent.com/97977088/169368865-fb48ce7c-a169-439c-9cfc-b76459885a51.png">


**Reminder:** these changes won't be pulled into any downstream apps until you merge _this_ PR, and _then_ merge a PR _on that app_ checking in an updated `yarn.lock` (i.e. after having run `yarn upgrade @teamshares/ui`).
