### PR TITLE
Remove the prepare script (apparently solves yarn install issues for downstream consumers??)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 JavaScript package to share frontend UI components, styles, and configuration.
 
+## Setup
+
+When you first check this repo out, run `yarn` to install dependencies, then make sure you're run once: `yarn husky install`.  This _was_ a `prepare` script to be run automatically, but [the presence of that script name in package.json that causes weird broken-cache issues](https://github.com/yarnpkg/yarn/issues/7212#issuecomment-493720324) with downstream consumers who pull the library in via git (i.e. everyone).
+
 ## Editing javascript
 
 Note that as currently configured, downstream consumers pull in JS code from `dist/`, not from `src/`, so you need to make sure you run `yarn compile` after making any edits under `src/`.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "scripts": {
     "compile": "rollup -c",
     "compile:watch": "rollup -c -w",
-    "precommit": "lint-staged --quiet",
-    "prepare": "is-ci || husky install"
+    "precommit": "lint-staged --quiet"
   },
   "dependencies": {
     "@github/clipboard-copy-element": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",
     "husky": "^8.0.1",
-    "is-ci": "^3.0.1",
     "lint-staged": "^12.4.2",
     "rollup": "^2.73.0",
     "stylelint": "^13.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,11 +797,6 @@ chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-ci-info@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
-  integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
-
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -1821,13 +1816,6 @@ is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
-
-is-ci@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
-  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
-  dependencies:
-    ci-info "^3.2.0"
 
 is-color-stop@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Ticket
[Yarn Issue Comment](https://github.com/yarnpkg/yarn/issues/7212#issuecomment-493720324), which Anthony found in [this slack discussion](https://teamsharesinc.slack.com/archives/C03E14P9W12/p1654091994394509).

## Description
Just removes the `prepare` script from `package.json` (and documents the one setup command you'll have to run manually now in the README).
