### PR TITLE
change opacity to decimals

### DIFF
--- a/scss/_teamshares.scss
+++ b/scss/_teamshares.scss
@@ -1176,7 +1176,7 @@ a.icon-button-view-component {
 
   &:disabled {
     cursor: not-allowed;
-    opacity: 45%;
+    opacity: 0.45;
   }
 
   > .button-icon {
@@ -1202,7 +1202,7 @@ a.icon-button-view-component {
 
   &:disabled {
     cursor: not-allowed;
-    opacity: 45%;
+    opacity: 0.45;
   }
 
   > .button-icon {


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Disabled-state-on-ViewComponent-button-makes-button-disappear-completely-bdd23c1621ad45ba912c52be8f4fa152)

## Description
Change opacity from percentage to decimals
