### PR TITLE
Add custom blue-50 and yellow-50

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,7 @@ module.exports = {
     extend: {
       colors: {
         blue: {
+          50: '#F6FAFD',
           100: "#e1eff9",
           200: "#b7d8f0",
           300: "#84bafa",
@@ -62,6 +63,7 @@ module.exports = {
           900: "#004d49"
         },
         yellow: {
+          50: '#FFFBF0',
           100: "#faf4ea",
           200: "#f2eade",
           300: "#fce491",


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Cap-table-request-page-styling-updates-48d27d22e76a4a708625a65a22674b58)

## Description

Add custom colors to be used as background colors for new `Banner` component (which will be added by https://github.com/teamshares/os-app/pull/153)

**Reminder:** these changes won't be pulled into any downstream apps until you merge _this_ PR, and _then_ merge a PR _on that app_ checking in an updated `yarn.lock` (i.e. after having run `yarn upgrade @teamshares/ui`).
