### PR TITLE
Update ts-card styling and breakpoints

### DIFF
--- a/scss/_teamshares.scss
+++ b/scss/_teamshares.scss
@@ -716,10 +716,11 @@ ul a {
 // Dashboard components
 
 .ts-card {
-  border: 1px solid $gray-300;
-  border-radius: 0.5rem;
-  min-width: 4rem;
-  overflow: hidden;
+  @apply rounded-lg;
+
+  box-shadow:
+    0 0 4px 1px rgba(0, 0, 0, 0.04),
+    0 0 0 1px rgba(0, 0, 0, 0.06);
 }
 
 clipboard-copy {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -139,7 +139,22 @@ module.exports = {
       },
       opacity: {
         '95': '0.95'
-      }
+      },
+      screens: {
+        'container-md': [
+          // Sidebar appears at 768px, so revert to `sm:` styles
+          // between 768px and 868px, after which the main
+          // content area is wide enough again to apply the
+          // `md:` styles.
+          {
+            'min': '641px',
+            'max': '767px'
+          },
+          {
+            'min': '868px'
+          }
+        ],
+      },
     }
   },
   variants: {


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Cap-table-request-page-styling-updates-48d27d22e76a4a708625a65a22674b58)

## Description

* Updates `.ts-card` border styling to match [cash management designs](https://www.figma.com/file/tzmJvSJYLDCqZU8a0N3SVY/Cash-management?node-id=977%3A18610)
* Adds custom breakpoints--see note from Sara:

> We’ll use also this breakpoint in the new responsive My Ownership page (upcoming ticket). This breakpoint adds to the default Tailwind set that we use and allows us to account for the responsive side nav and updates the layout based on how wide the main page container is when the side nav is collapsed.

## Screenshots (if relevant)

### Before

<img width="1314" alt="image" src="https://user-images.githubusercontent.com/97977088/176052932-5e502369-b9c9-4992-81ad-8f2dc094138a.png">


### After

<img width="1314" alt="image" src="https://user-images.githubusercontent.com/97977088/176052888-941bcc32-fa4a-4957-9920-87a94d4b7ec7.png">

**Reminder:** these changes won't be pulled into any downstream apps until you merge _this_ PR, and _then_ merge a PR _on that app_ checking in an updated `yarn.lock` (i.e. after having run `yarn upgrade @teamshares/ui`).
