### PR TITLE
Reorganize JS + add Honeybadger

### DIFF
--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -1,6 +1,6 @@
 /*
-Stimulus 3.0.1
-Copyright © 2021 Basecamp, LLC
+Stimulus 3.1.0
+Copyright © 2022 Basecamp, LLC
  */
 
 function camelize(value) {
@@ -141,7 +141,7 @@ function ValuePropertiesBlessing(constructor) {
         valueDescriptorMap: {
             get() {
                 return valueDefinitionPairs.reduce((result, valueDefinitionPair) => {
-                    const valueDescriptor = parseValueDefinitionPair(valueDefinitionPair);
+                    const valueDescriptor = parseValueDefinitionPair(valueDefinitionPair, this.identifier);
                     const attributeName = this.data.getAttributeNameForKey(valueDescriptor.key);
                     return Object.assign(result, { [attributeName]: valueDescriptor });
                 }, {});
@@ -152,8 +152,8 @@ function ValuePropertiesBlessing(constructor) {
         return Object.assign(properties, propertiesForValueDefinitionPair(valueDefinitionPair));
     }, propertyDescriptorMap);
 }
-function propertiesForValueDefinitionPair(valueDefinitionPair) {
-    const definition = parseValueDefinitionPair(valueDefinitionPair);
+function propertiesForValueDefinitionPair(valueDefinitionPair, controller) {
+    const definition = parseValueDefinitionPair(valueDefinitionPair, controller);
     const { key, name, reader: read, writer: write } = definition;
     return {
         [name]: {
@@ -182,8 +182,12 @@ function propertiesForValueDefinitionPair(valueDefinitionPair) {
         }
     };
 }
-function parseValueDefinitionPair([token, typeDefinition]) {
-    return valueDescriptorForTokenAndTypeDefinition(token, typeDefinition);
+function parseValueDefinitionPair([token, typeDefinition], controller) {
+    return valueDescriptorForTokenAndTypeDefinition({
+        controller,
+        token,
+        typeDefinition,
+    });
 }
 function parseValueTypeConstant(constant) {
     switch (constant) {
@@ -205,24 +209,30 @@ function parseValueTypeDefault(defaultValue) {
     if (Object.prototype.toString.call(defaultValue) === "[object Object]")
         return "object";
 }
-function parseValueTypeObject(typeObject) {
-    const typeFromObject = parseValueTypeConstant(typeObject.type);
-    if (typeFromObject) {
-        const defaultValueType = parseValueTypeDefault(typeObject.default);
-        if (typeFromObject !== defaultValueType) {
-            throw new Error(`Type "${typeFromObject}" must match the type of the default value. Given default value: "${typeObject.default}" as "${defaultValueType}"`);
-        }
-        return typeFromObject;
+function parseValueTypeObject(payload) {
+    const typeFromObject = parseValueTypeConstant(payload.typeObject.type);
+    if (!typeFromObject)
+        return;
+    const defaultValueType = parseValueTypeDefault(payload.typeObject.default);
+    if (typeFromObject !== defaultValueType) {
+        const propertyPath = payload.controller ? `${payload.controller}.${payload.token}` : payload.token;
+        throw new Error(`The specified default value for the Stimulus Value "${propertyPath}" must match the defined type "${typeFromObject}". The provided default value of "${payload.typeObject.default}" is of type "${defaultValueType}".`);
     }
+    return typeFromObject;
 }
-function parseValueTypeDefinition(typeDefinition) {
-    const typeFromObject = parseValueTypeObject(typeDefinition);
-    const typeFromDefaultValue = parseValueTypeDefault(typeDefinition);
-    const typeFromConstant = parseValueTypeConstant(typeDefinition);
+function parseValueTypeDefinition(payload) {
+    const typeFromObject = parseValueTypeObject({
+        controller: payload.controller,
+        token: payload.token,
+        typeObject: payload.typeDefinition
+    });
+    const typeFromDefaultValue = parseValueTypeDefault(payload.typeDefinition);
+    const typeFromConstant = parseValueTypeConstant(payload.typeDefinition);
     const type = typeFromObject || typeFromDefaultValue || typeFromConstant;
     if (type)
         return type;
-    throw new Error(`Unknown value type "${typeDefinition}"`);
+    const propertyPath = payload.controller ? `${payload.controller}.${payload.typeDefinition}` : payload.token;
+    throw new Error(`Unknown value type "${propertyPath}" for "${payload.token}" value`);
 }
 function defaultValueForDefinition(typeDefinition) {
     const constant = parseValueTypeConstant(typeDefinition);
@@ -233,15 +243,15 @@ function defaultValueForDefinition(typeDefinition) {
         return defaultValue;
     return typeDefinition;
 }
-function valueDescriptorForTokenAndTypeDefinition(token, typeDefinition) {
-    const key = `${dasherize(token)}-value`;
-    const type = parseValueTypeDefinition(typeDefinition);
+function valueDescriptorForTokenAndTypeDefinition(payload) {
+    const key = `${dasherize(payload.token)}-value`;
+    const type = parseValueTypeDefinition(payload);
     return {
         type,
         key,
         name: camelize(key),
-        get defaultValue() { return defaultValueForDefinition(typeDefinition); },
-        get hasCustomDefaultValue() { return parseValueTypeDefault(typeDefinition) !== undefined; },
+        get defaultValue() { return defaultValueForDefinition(payload.typeDefinition); },
+        get hasCustomDefaultValue() { return parseValueTypeDefault(payload.typeDefinition) !== undefined; },
         reader: readers[type],
         writer: writers[type] || writers.default
     };
@@ -257,12 +267,12 @@ const readers = {
     array(value) {
         const array = JSON.parse(value);
         if (!Array.isArray(array)) {
-            throw new TypeError("Expected array");
+            throw new TypeError(`expected value of type "array" but instead got value "${value}" of type "${parseValueTypeDefault(array)}"`);
         }
         return array;
     },
     boolean(value) {
-        return !(value == "0" || value == "false");
+        return !(value == "0" || String(value).toLowerCase() == "false");
     },
     number(value) {
         return Number(value);
@@ -270,7 +280,7 @@ const readers = {
     object(value) {
         const object = JSON.parse(value);
         if (object === null || typeof object != "object" || Array.isArray(object)) {
-            throw new TypeError("Expected object");
+            throw new TypeError(`expected value of type "object" but instead got value "${value}" of type "${parseValueTypeDefault(object)}"`);
         }
         return object;
     },
@@ -451,4 +461,24 @@ class _class extends Controller {
 
 _defineProperty(_class, "targets", ["switchable", "clickable"]);
 
-export { input_clipboard_controller as InputClipboardController, input_mask_controller as InputMaskController, _class as SwitchController, _class$1 as ToggleController };
+const Honeybadger = require("@honeybadger-io/js");
+
+const initHoneybadger = (opts = {}) => {
+  if (process.env.RAILS_ENV !== "production" || !process.env.HEROKU_APP_NAME) return;
+  const heroku = process.env.HEROKU_APP_NAME;
+  const appContext = heroku.includes("-production") ? "production" : heroku.includes("-staging") ? "staging" : "review";
+
+  if (!process.env.HONEYBADGER_JS_API_KEY) {
+    console.log(`Honeybadger not configured -- set HONEYBADGER_JS_API_KEY to enable (for ${heroku})`);
+    return;
+  }
+
+  const config = Object.assign({
+    apiKey: process.env.HONEYBADGER_JS_API_KEY,
+    environment: appContext
+  }, opts);
+  Honeybadger.configure(config);
+  window.Honeybadger = Honeybadger;
+};
+
+export { input_clipboard_controller as InputClipboardController, input_mask_controller as InputMaskController, _class as SwitchController, _class$1 as ToggleController, initHoneybadger };

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@teamshares/ui",
   "version": "0.0.1",
   "private": true,
-  "main": "dist/application.js",
-  "module": "dist/application.es.js",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
   "files": [
     "dist/*.js",
     "tailwind.config.js",
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@github/clipboard-copy-element": "^1.1.2",
+    "@honeybadger-io/js": "^4.3.0",
     "@hotwired/stimulus": "^3.1.0",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.2.1",
@@ -35,7 +36,7 @@
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@rollup/plugin-babel": "^5.3.1",
-    "@rollup/plugin-node-resolve": "^14.0.0",
+    "@rollup/plugin-node-resolve": "^13.3.0",
     "eslint": "^8.20.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import { babel } from "@rollup/plugin-babel";
-import { nodeResolve } from '@rollup/plugin-node-resolve';
+import { nodeResolve } from "@rollup/plugin-node-resolve";
 import pkg from "./package.json";
 
 
@@ -15,7 +15,7 @@ const external = ["stimulus"];
 
 export default [
   {
-    input: "src/application.js",
+    input: "src/index.js",
     external,
     plugins,
     output: {
@@ -26,7 +26,7 @@ export default [
     }
   },
   {
-    input: "src/application.js",
+    input: "src/index.js",
     plugins,
     external,
     output: {

--- a/src/_honeybadger.js
+++ b/src/_honeybadger.js
@@ -1,0 +1,21 @@
+const Honeybadger = require("@honeybadger-io/js");
+
+export const initHoneybadger = (opts = {}) => {
+  if (process.env.RAILS_ENV !== "production" || !process.env.HEROKU_APP_NAME) return;
+
+  const heroku = process.env.HEROKU_APP_NAME;
+  const appContext = heroku.includes("-production") ? "production" : (heroku.includes("-staging") ? "staging" : "review");
+
+  if (!process.env.HONEYBADGER_JS_API_KEY) {
+    console.log(`Honeybadger not configured -- set HONEYBADGER_JS_API_KEY to enable (for ${heroku})`);
+    return;
+  }
+
+  const config = Object.assign({
+    apiKey: process.env.HONEYBADGER_JS_API_KEY,
+    environment: appContext
+  }, opts);
+
+  Honeybadger.configure(config);
+  window.Honeybadger = Honeybadger;
+};

--- a/src/application.js
+++ b/src/application.js
@@ -1,6 +1,0 @@
-import InputClipboardController from "./controllers/input_clipboard_controller";
-import InputMaskController from "./controllers/input_mask_controller";
-import ToggleController from "./controllers/toggle_controller";
-import SwitchController from "./controllers/switch_controller";
-
-export { InputClipboardController, InputMaskController, ToggleController, SwitchController };

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,0 +1,6 @@
+import InputClipboardController from "./input_clipboard_controller";
+import InputMaskController from "./input_mask_controller";
+import ToggleController from "./toggle_controller";
+import SwitchController from "./switch_controller";
+
+export { InputClipboardController, InputMaskController, ToggleController, SwitchController };

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export * from "./controllers";
+export * from "./_honeybadger";

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,6 +281,21 @@
   resolved "https://registry.yarnpkg.com/@github/clipboard-copy-element/-/clipboard-copy-element-1.1.2.tgz#7a6e8042749471504d4e7cfcc47097a781db2bdb"
   integrity sha512-L6CMrcA5we0udafvoSuRCE/Ci/3xrLWKYRGup2IlhxF771bQYsQ2EB1of182pI8ZWM4oxgwzu37+igMeoZjN/A==
 
+"@honeybadger-io/core@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@honeybadger-io/core/-/core-4.3.0.tgz#d10b7d6110063d92579f2bddf70caf65b232260b"
+  integrity sha512-bma9gilEJBwGLfcANOpHpK0a7j+Lhjre6Ao0jX/OmACZMWj5sbNYZ3maqiH5b2qX4mlg6/kNPkywERxhAWkuiw==
+  dependencies:
+    stacktrace-parser "^0.1.10"
+
+"@honeybadger-io/js@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@honeybadger-io/js/-/js-4.3.0.tgz#4ea6162ead2125fc1d9e6b4d04b1a6b1094fecab"
+  integrity sha512-q/vrnt/iGfhT1emx155KuzQ+rYMatLXpX8aH53N7qcKCbtg1KMCmuBrcbPMMVbC8NDJ41U31YD9v7PghT7RYBw==
+  dependencies:
+    "@honeybadger-io/core" "^4.3.0"
+    "@types/aws-lambda" "^8.10.89"
+
 "@hotwired/stimulus@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.1.0.tgz#20215251e5afe6e0a3787285181ba1bfc9097df0"
@@ -369,10 +384,10 @@
     "@babel/helper-module-imports" "^7.10.4"
     "@rollup/pluginutils" "^3.1.0"
 
-"@rollup/plugin-node-resolve@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-14.0.0.tgz#373c1a00e7fb3e2a7d2ee109c5b03a5e608f3b8f"
-  integrity sha512-XkWfpgp/zGiFu8LS+JAiQeZN4oYYA4/ViFJiZhwQegTg5ZbzKTvM9YyKXVBNnmZ8Et76WnlVgwRUu1rhKF4ayw==
+"@rollup/plugin-node-resolve@^13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz#da1c5c5ce8316cef96a2f823d111c1e4e498801c"
+  integrity sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
@@ -416,6 +431,11 @@
     lodash.isplainobject "^4.0.6"
     lodash.merge "^4.6.2"
     lodash.uniq "^4.5.0"
+
+"@types/aws-lambda@^8.10.89":
+  version "8.10.104"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.104.tgz#01ec1d55a08bdf1201150d9ecae39ff7cca9ff4a"
+  integrity sha512-HXZJH8aBa06re9NCtFudOr21izYZycgXIVjd8vFBSNSf6Ca4GYD77TfKqwYgcDqv4olqj5KK+Ks7Xi5IXFbNGA==
 
 "@types/estree@0.0.39":
   version "0.0.39"
@@ -2859,6 +2879,13 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
   integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
 
+stacktrace-parser@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
+  integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
+  dependencies:
+    type-fest "^0.7.1"
+
 string-argv@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
@@ -3172,6 +3199,11 @@ type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
+  integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
 type-fest@^0.8.1:
   version "0.8.1"


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Extract-Honeybadger-JS-2381e081de224d21b5882ef837ffd94e)

## Description
* **PRIMARY:** Extracts the HoneybadgerJS setup into the shared repo
* Reconfigure to use `index.js` rather than `application.js`
* Downgrade `plugin-node-resolve` -- 14+ raises config errors when trying to build

## Why?
We're pulling out Honeybadger on the server side into shared-rails-engine ([see here](https://www.notion.so/teamshares/DEPS-TeamsharesRails-CI-Infra-7b2a575a88504e7fa75447f9fbf35502)), so this gives us parity + encourages broader use. Needed _now_ to support removing references to `ENV['SERVER_ENV']` (which are currently being cleaned up on the Ruby side in the before-mentioned ticket).

## Loom
https://www.loom.com/share/cab4d526c070466f8cea5cc9f2dc86c2