### PR TITLE
Add shoelace components

### DIFF
--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -1,3 +1,18350 @@
+// node_modules/@lit/reactive-element/css-tag.js
+var t$3 = window.ShadowRoot && (void 0 === window.ShadyCSS || window.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype;
+var e$3 = Symbol();
+var n$2 = /* @__PURE__ */ new Map();
+var s$3 = class {
+  constructor(t3, n5) {
+    if (this._$cssResult$ = true, n5 !== e$3)
+      throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+    this.cssText = t3;
+  }
+  get styleSheet() {
+    let e4 = n$2.get(this.cssText);
+    return t$3 && void 0 === e4 && (n$2.set(this.cssText, e4 = new CSSStyleSheet()), e4.replaceSync(this.cssText)), e4;
+  }
+  toString() {
+    return this.cssText;
+  }
+};
+var o$4 = (t3) => new s$3("string" == typeof t3 ? t3 : t3 + "", e$3);
+var r$2 = (t3, ...n5) => {
+  const o5 = 1 === t3.length ? t3[0] : n5.reduce((e4, n6, s5) => e4 + ((t4) => {
+    if (true === t4._$cssResult$)
+      return t4.cssText;
+    if ("number" == typeof t4)
+      return t4;
+    throw Error("Value passed to 'css' function must be a 'css' function result: " + t4 + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
+  })(n6) + t3[s5 + 1], t3[0]);
+  return new s$3(o5, e$3);
+};
+var i$2 = (e4, n5) => {
+  t$3 ? e4.adoptedStyleSheets = n5.map((t3) => t3 instanceof CSSStyleSheet ? t3 : t3.styleSheet) : n5.forEach((t3) => {
+    const n6 = document.createElement("style"), s5 = window.litNonce;
+    void 0 !== s5 && n6.setAttribute("nonce", s5), n6.textContent = t3.cssText, e4.appendChild(n6);
+  });
+};
+var S$1 = t$3 ? (t3) => t3 : (t3) => t3 instanceof CSSStyleSheet ? ((t4) => {
+  let e4 = "";
+  for (const n5 of t4.cssRules)
+    e4 += n5.cssText;
+  return o$4(e4);
+})(t3) : t3;
+
+// node_modules/@lit/reactive-element/reactive-element.js
+var s2$1;
+var e2$2 = window.trustedTypes;
+var r2$1 = e2$2 ? e2$2.emptyScript : "";
+var h$1 = window.reactiveElementPolyfillSupport;
+var o2$2 = { toAttribute(t3, i3) {
+  switch (i3) {
+    case Boolean:
+      t3 = t3 ? r2$1 : null;
+      break;
+    case Object:
+    case Array:
+      t3 = null == t3 ? t3 : JSON.stringify(t3);
+  }
+  return t3;
+}, fromAttribute(t3, i3) {
+  let s5 = t3;
+  switch (i3) {
+    case Boolean:
+      s5 = null !== t3;
+      break;
+    case Number:
+      s5 = null === t3 ? null : Number(t3);
+      break;
+    case Object:
+    case Array:
+      try {
+        s5 = JSON.parse(t3);
+      } catch (t4) {
+        s5 = null;
+      }
+  }
+  return s5;
+} };
+var n2$3 = (t3, i3) => i3 !== t3 && (i3 == i3 || t3 == t3);
+var l$4 = { attribute: true, type: String, converter: o2$2, reflect: false, hasChanged: n2$3 };
+var a$2 = class extends HTMLElement {
+  constructor() {
+    super(), this._$Et = /* @__PURE__ */ new Map(), this.isUpdatePending = false, this.hasUpdated = false, this._$Ei = null, this.o();
+  }
+  static addInitializer(t3) {
+    var i3;
+    null !== (i3 = this.l) && void 0 !== i3 || (this.l = []), this.l.push(t3);
+  }
+  static get observedAttributes() {
+    this.finalize();
+    const t3 = [];
+    return this.elementProperties.forEach((i3, s5) => {
+      const e4 = this._$Eh(s5, i3);
+      void 0 !== e4 && (this._$Eu.set(e4, s5), t3.push(e4));
+    }), t3;
+  }
+  static createProperty(t3, i3 = l$4) {
+    if (i3.state && (i3.attribute = false), this.finalize(), this.elementProperties.set(t3, i3), !i3.noAccessor && !this.prototype.hasOwnProperty(t3)) {
+      const s5 = "symbol" == typeof t3 ? Symbol() : "__" + t3, e4 = this.getPropertyDescriptor(t3, s5, i3);
+      void 0 !== e4 && Object.defineProperty(this.prototype, t3, e4);
+    }
+  }
+  static getPropertyDescriptor(t3, i3, s5) {
+    return { get() {
+      return this[i3];
+    }, set(e4) {
+      const r4 = this[t3];
+      this[i3] = e4, this.requestUpdate(t3, r4, s5);
+    }, configurable: true, enumerable: true };
+  }
+  static getPropertyOptions(t3) {
+    return this.elementProperties.get(t3) || l$4;
+  }
+  static finalize() {
+    if (this.hasOwnProperty("finalized"))
+      return false;
+    this.finalized = true;
+    const t3 = Object.getPrototypeOf(this);
+    if (t3.finalize(), this.elementProperties = new Map(t3.elementProperties), this._$Eu = /* @__PURE__ */ new Map(), this.hasOwnProperty("properties")) {
+      const t4 = this.properties, i3 = [...Object.getOwnPropertyNames(t4), ...Object.getOwnPropertySymbols(t4)];
+      for (const s5 of i3)
+        this.createProperty(s5, t4[s5]);
+    }
+    return this.elementStyles = this.finalizeStyles(this.styles), true;
+  }
+  static finalizeStyles(i3) {
+    const s5 = [];
+    if (Array.isArray(i3)) {
+      const e4 = new Set(i3.flat(1 / 0).reverse());
+      for (const i4 of e4)
+        s5.unshift(S$1(i4));
+    } else
+      void 0 !== i3 && s5.push(S$1(i3));
+    return s5;
+  }
+  static _$Eh(t3, i3) {
+    const s5 = i3.attribute;
+    return false === s5 ? void 0 : "string" == typeof s5 ? s5 : "string" == typeof t3 ? t3.toLowerCase() : void 0;
+  }
+  o() {
+    var t3;
+    this._$Ep = new Promise((t4) => this.enableUpdating = t4), this._$AL = /* @__PURE__ */ new Map(), this._$Em(), this.requestUpdate(), null === (t3 = this.constructor.l) || void 0 === t3 || t3.forEach((t4) => t4(this));
+  }
+  addController(t3) {
+    var i3, s5;
+    (null !== (i3 = this._$Eg) && void 0 !== i3 ? i3 : this._$Eg = []).push(t3), void 0 !== this.renderRoot && this.isConnected && (null === (s5 = t3.hostConnected) || void 0 === s5 || s5.call(t3));
+  }
+  removeController(t3) {
+    var i3;
+    null === (i3 = this._$Eg) || void 0 === i3 || i3.splice(this._$Eg.indexOf(t3) >>> 0, 1);
+  }
+  _$Em() {
+    this.constructor.elementProperties.forEach((t3, i3) => {
+      this.hasOwnProperty(i3) && (this._$Et.set(i3, this[i3]), delete this[i3]);
+    });
+  }
+  createRenderRoot() {
+    var t3;
+    const s5 = null !== (t3 = this.shadowRoot) && void 0 !== t3 ? t3 : this.attachShadow(this.constructor.shadowRootOptions);
+    return i$2(s5, this.constructor.elementStyles), s5;
+  }
+  connectedCallback() {
+    var t3;
+    void 0 === this.renderRoot && (this.renderRoot = this.createRenderRoot()), this.enableUpdating(true), null === (t3 = this._$Eg) || void 0 === t3 || t3.forEach((t4) => {
+      var i3;
+      return null === (i3 = t4.hostConnected) || void 0 === i3 ? void 0 : i3.call(t4);
+    });
+  }
+  enableUpdating(t3) {
+  }
+  disconnectedCallback() {
+    var t3;
+    null === (t3 = this._$Eg) || void 0 === t3 || t3.forEach((t4) => {
+      var i3;
+      return null === (i3 = t4.hostDisconnected) || void 0 === i3 ? void 0 : i3.call(t4);
+    });
+  }
+  attributeChangedCallback(t3, i3, s5) {
+    this._$AK(t3, s5);
+  }
+  _$ES(t3, i3, s5 = l$4) {
+    var e4, r4;
+    const h3 = this.constructor._$Eh(t3, s5);
+    if (void 0 !== h3 && true === s5.reflect) {
+      const n5 = (null !== (r4 = null === (e4 = s5.converter) || void 0 === e4 ? void 0 : e4.toAttribute) && void 0 !== r4 ? r4 : o2$2.toAttribute)(i3, s5.type);
+      this._$Ei = t3, null == n5 ? this.removeAttribute(h3) : this.setAttribute(h3, n5), this._$Ei = null;
+    }
+  }
+  _$AK(t3, i3) {
+    var s5, e4, r4;
+    const h3 = this.constructor, n5 = h3._$Eu.get(t3);
+    if (void 0 !== n5 && this._$Ei !== n5) {
+      const t4 = h3.getPropertyOptions(n5), l4 = t4.converter, a3 = null !== (r4 = null !== (e4 = null === (s5 = l4) || void 0 === s5 ? void 0 : s5.fromAttribute) && void 0 !== e4 ? e4 : "function" == typeof l4 ? l4 : null) && void 0 !== r4 ? r4 : o2$2.fromAttribute;
+      this._$Ei = n5, this[n5] = a3(i3, t4.type), this._$Ei = null;
+    }
+  }
+  requestUpdate(t3, i3, s5) {
+    let e4 = true;
+    void 0 !== t3 && (((s5 = s5 || this.constructor.getPropertyOptions(t3)).hasChanged || n2$3)(this[t3], i3) ? (this._$AL.has(t3) || this._$AL.set(t3, i3), true === s5.reflect && this._$Ei !== t3 && (void 0 === this._$EC && (this._$EC = /* @__PURE__ */ new Map()), this._$EC.set(t3, s5))) : e4 = false), !this.isUpdatePending && e4 && (this._$Ep = this._$E_());
+  }
+  async _$E_() {
+    this.isUpdatePending = true;
+    try {
+      await this._$Ep;
+    } catch (t4) {
+      Promise.reject(t4);
+    }
+    const t3 = this.scheduleUpdate();
+    return null != t3 && await t3, !this.isUpdatePending;
+  }
+  scheduleUpdate() {
+    return this.performUpdate();
+  }
+  performUpdate() {
+    var t3;
+    if (!this.isUpdatePending)
+      return;
+    this.hasUpdated, this._$Et && (this._$Et.forEach((t4, i4) => this[i4] = t4), this._$Et = void 0);
+    let i3 = false;
+    const s5 = this._$AL;
+    try {
+      i3 = this.shouldUpdate(s5), i3 ? (this.willUpdate(s5), null === (t3 = this._$Eg) || void 0 === t3 || t3.forEach((t4) => {
+        var i4;
+        return null === (i4 = t4.hostUpdate) || void 0 === i4 ? void 0 : i4.call(t4);
+      }), this.update(s5)) : this._$EU();
+    } catch (t4) {
+      throw i3 = false, this._$EU(), t4;
+    }
+    i3 && this._$AE(s5);
+  }
+  willUpdate(t3) {
+  }
+  _$AE(t3) {
+    var i3;
+    null === (i3 = this._$Eg) || void 0 === i3 || i3.forEach((t4) => {
+      var i4;
+      return null === (i4 = t4.hostUpdated) || void 0 === i4 ? void 0 : i4.call(t4);
+    }), this.hasUpdated || (this.hasUpdated = true, this.firstUpdated(t3)), this.updated(t3);
+  }
+  _$EU() {
+    this._$AL = /* @__PURE__ */ new Map(), this.isUpdatePending = false;
+  }
+  get updateComplete() {
+    return this.getUpdateComplete();
+  }
+  getUpdateComplete() {
+    return this._$Ep;
+  }
+  shouldUpdate(t3) {
+    return true;
+  }
+  update(t3) {
+    void 0 !== this._$EC && (this._$EC.forEach((t4, i3) => this._$ES(i3, this[i3], t4)), this._$EC = void 0), this._$EU();
+  }
+  updated(t3) {
+  }
+  firstUpdated(t3) {
+  }
+};
+a$2.finalized = true, a$2.elementProperties = /* @__PURE__ */ new Map(), a$2.elementStyles = [], a$2.shadowRootOptions = { mode: "open" }, null == h$1 || h$1({ ReactiveElement: a$2 }), (null !== (s2$1 = globalThis.reactiveElementVersions) && void 0 !== s2$1 ? s2$1 : globalThis.reactiveElementVersions = []).push("1.3.2");
+
+// node_modules/lit-html/lit-html.js
+var t2;
+var i2$3 = globalThis.trustedTypes;
+var s3 = i2$3 ? i2$3.createPolicy("lit-html", { createHTML: (t3) => t3 }) : void 0;
+var e3$1 = `lit$${(Math.random() + "").slice(9)}$`;
+var o3$1 = "?" + e3$1;
+var n3$1 = `<${o3$1}>`;
+var l2$1 = document;
+var h2$1 = (t3 = "") => l2$1.createComment(t3);
+var r3 = (t3) => null === t3 || "object" != typeof t3 && "function" != typeof t3;
+var d$1 = Array.isArray;
+var u$1 = (t3) => {
+  var i3;
+  return d$1(t3) || "function" == typeof (null === (i3 = t3) || void 0 === i3 ? void 0 : i3[Symbol.iterator]);
+};
+var c$1 = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g;
+var v = /-->/g;
+var a2$1 = />/g;
+var f$2 = />|[ 	\n\r](?:([^\s"'>=/]+)([ 	\n\r]*=[ 	\n\r]*(?:[^ 	\n\r"'`<>=]|("|')|))|$)/g;
+var _ = /'/g;
+var m$1 = /"/g;
+var g$1 = /^(?:script|style|textarea|title)$/i;
+var p$1 = (t3) => (i3, ...s5) => ({ _$litType$: t3, strings: i3, values: s5 });
+var $ = p$1(1);
+var b$1 = Symbol.for("lit-noChange");
+var w = Symbol.for("lit-nothing");
+var T$1 = /* @__PURE__ */ new WeakMap();
+var x$1 = (t3, i3, s5) => {
+  var e4, o5;
+  const n5 = null !== (e4 = null == s5 ? void 0 : s5.renderBefore) && void 0 !== e4 ? e4 : i3;
+  let l4 = n5._$litPart$;
+  if (void 0 === l4) {
+    const t4 = null !== (o5 = null == s5 ? void 0 : s5.renderBefore) && void 0 !== o5 ? o5 : null;
+    n5._$litPart$ = l4 = new N$1(i3.insertBefore(h2$1(), t4), t4, void 0, null != s5 ? s5 : {});
+  }
+  return l4._$AI(t3), l4;
+};
+var A = l2$1.createTreeWalker(l2$1, 129, null, false);
+var C$1 = (t3, i3) => {
+  const o5 = t3.length - 1, l4 = [];
+  let h3, r4 = 2 === i3 ? "<svg>" : "", d2 = c$1;
+  for (let i4 = 0; i4 < o5; i4++) {
+    const s5 = t3[i4];
+    let o6, u3, p2 = -1, $2 = 0;
+    for (; $2 < s5.length && (d2.lastIndex = $2, u3 = d2.exec(s5), null !== u3); )
+      $2 = d2.lastIndex, d2 === c$1 ? "!--" === u3[1] ? d2 = v : void 0 !== u3[1] ? d2 = a2$1 : void 0 !== u3[2] ? (g$1.test(u3[2]) && (h3 = RegExp("</" + u3[2], "g")), d2 = f$2) : void 0 !== u3[3] && (d2 = f$2) : d2 === f$2 ? ">" === u3[0] ? (d2 = null != h3 ? h3 : c$1, p2 = -1) : void 0 === u3[1] ? p2 = -2 : (p2 = d2.lastIndex - u3[2].length, o6 = u3[1], d2 = void 0 === u3[3] ? f$2 : '"' === u3[3] ? m$1 : _) : d2 === m$1 || d2 === _ ? d2 = f$2 : d2 === v || d2 === a2$1 ? d2 = c$1 : (d2 = f$2, h3 = void 0);
+    const y2 = d2 === f$2 && t3[i4 + 1].startsWith("/>") ? " " : "";
+    r4 += d2 === c$1 ? s5 + n3$1 : p2 >= 0 ? (l4.push(o6), s5.slice(0, p2) + "$lit$" + s5.slice(p2) + e3$1 + y2) : s5 + e3$1 + (-2 === p2 ? (l4.push(void 0), i4) : y2);
+  }
+  const u2 = r4 + (t3[o5] || "<?>") + (2 === i3 ? "</svg>" : "");
+  if (!Array.isArray(t3) || !t3.hasOwnProperty("raw"))
+    throw Error("invalid template strings array");
+  return [void 0 !== s3 ? s3.createHTML(u2) : u2, l4];
+};
+var E = class {
+  constructor({ strings: t3, _$litType$: s5 }, n5) {
+    let l4;
+    this.parts = [];
+    let r4 = 0, d2 = 0;
+    const u2 = t3.length - 1, c2 = this.parts, [v2, a3] = C$1(t3, s5);
+    if (this.el = E.createElement(v2, n5), A.currentNode = this.el.content, 2 === s5) {
+      const t4 = this.el.content, i3 = t4.firstChild;
+      i3.remove(), t4.append(...i3.childNodes);
+    }
+    for (; null !== (l4 = A.nextNode()) && c2.length < u2; ) {
+      if (1 === l4.nodeType) {
+        if (l4.hasAttributes()) {
+          const t4 = [];
+          for (const i3 of l4.getAttributeNames())
+            if (i3.endsWith("$lit$") || i3.startsWith(e3$1)) {
+              const s6 = a3[d2++];
+              if (t4.push(i3), void 0 !== s6) {
+                const t5 = l4.getAttribute(s6.toLowerCase() + "$lit$").split(e3$1), i4 = /([.?@])?(.*)/.exec(s6);
+                c2.push({ type: 1, index: r4, name: i4[2], strings: t5, ctor: "." === i4[1] ? M : "?" === i4[1] ? H$2 : "@" === i4[1] ? I : S2 });
+              } else
+                c2.push({ type: 6, index: r4 });
+            }
+          for (const i3 of t4)
+            l4.removeAttribute(i3);
+        }
+        if (g$1.test(l4.tagName)) {
+          const t4 = l4.textContent.split(e3$1), s6 = t4.length - 1;
+          if (s6 > 0) {
+            l4.textContent = i2$3 ? i2$3.emptyScript : "";
+            for (let i3 = 0; i3 < s6; i3++)
+              l4.append(t4[i3], h2$1()), A.nextNode(), c2.push({ type: 2, index: ++r4 });
+            l4.append(t4[s6], h2$1());
+          }
+        }
+      } else if (8 === l4.nodeType)
+        if (l4.data === o3$1)
+          c2.push({ type: 2, index: r4 });
+        else {
+          let t4 = -1;
+          for (; -1 !== (t4 = l4.data.indexOf(e3$1, t4 + 1)); )
+            c2.push({ type: 7, index: r4 }), t4 += e3$1.length - 1;
+        }
+      r4++;
+    }
+  }
+  static createElement(t3, i3) {
+    const s5 = l2$1.createElement("template");
+    return s5.innerHTML = t3, s5;
+  }
+};
+function P(t3, i3, s5 = t3, e4) {
+  var o5, n5, l4, h3;
+  if (i3 === b$1)
+    return i3;
+  let d2 = void 0 !== e4 ? null === (o5 = s5._$Cl) || void 0 === o5 ? void 0 : o5[e4] : s5._$Cu;
+  const u2 = r3(i3) ? void 0 : i3._$litDirective$;
+  return (null == d2 ? void 0 : d2.constructor) !== u2 && (null === (n5 = null == d2 ? void 0 : d2._$AO) || void 0 === n5 || n5.call(d2, false), void 0 === u2 ? d2 = void 0 : (d2 = new u2(t3), d2._$AT(t3, s5, e4)), void 0 !== e4 ? (null !== (l4 = (h3 = s5)._$Cl) && void 0 !== l4 ? l4 : h3._$Cl = [])[e4] = d2 : s5._$Cu = d2), void 0 !== d2 && (i3 = P(t3, d2._$AS(t3, i3.values), d2, e4)), i3;
+}
+var V = class {
+  constructor(t3, i3) {
+    this.v = [], this._$AN = void 0, this._$AD = t3, this._$AM = i3;
+  }
+  get parentNode() {
+    return this._$AM.parentNode;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  p(t3) {
+    var i3;
+    const { el: { content: s5 }, parts: e4 } = this._$AD, o5 = (null !== (i3 = null == t3 ? void 0 : t3.creationScope) && void 0 !== i3 ? i3 : l2$1).importNode(s5, true);
+    A.currentNode = o5;
+    let n5 = A.nextNode(), h3 = 0, r4 = 0, d2 = e4[0];
+    for (; void 0 !== d2; ) {
+      if (h3 === d2.index) {
+        let i4;
+        2 === d2.type ? i4 = new N$1(n5, n5.nextSibling, this, t3) : 1 === d2.type ? i4 = new d2.ctor(n5, d2.name, d2.strings, this, t3) : 6 === d2.type && (i4 = new L$1(n5, this, t3)), this.v.push(i4), d2 = e4[++r4];
+      }
+      h3 !== (null == d2 ? void 0 : d2.index) && (n5 = A.nextNode(), h3++);
+    }
+    return o5;
+  }
+  m(t3) {
+    let i3 = 0;
+    for (const s5 of this.v)
+      void 0 !== s5 && (void 0 !== s5.strings ? (s5._$AI(t3, s5, i3), i3 += s5.strings.length - 2) : s5._$AI(t3[i3])), i3++;
+  }
+};
+var N$1 = class {
+  constructor(t3, i3, s5, e4) {
+    var o5;
+    this.type = 2, this._$AH = w, this._$AN = void 0, this._$AA = t3, this._$AB = i3, this._$AM = s5, this.options = e4, this._$Cg = null === (o5 = null == e4 ? void 0 : e4.isConnected) || void 0 === o5 || o5;
+  }
+  get _$AU() {
+    var t3, i3;
+    return null !== (i3 = null === (t3 = this._$AM) || void 0 === t3 ? void 0 : t3._$AU) && void 0 !== i3 ? i3 : this._$Cg;
+  }
+  get parentNode() {
+    let t3 = this._$AA.parentNode;
+    const i3 = this._$AM;
+    return void 0 !== i3 && 11 === t3.nodeType && (t3 = i3.parentNode), t3;
+  }
+  get startNode() {
+    return this._$AA;
+  }
+  get endNode() {
+    return this._$AB;
+  }
+  _$AI(t3, i3 = this) {
+    t3 = P(this, t3, i3), r3(t3) ? t3 === w || null == t3 || "" === t3 ? (this._$AH !== w && this._$AR(), this._$AH = w) : t3 !== this._$AH && t3 !== b$1 && this.$(t3) : void 0 !== t3._$litType$ ? this.T(t3) : void 0 !== t3.nodeType ? this.k(t3) : u$1(t3) ? this.S(t3) : this.$(t3);
+  }
+  M(t3, i3 = this._$AB) {
+    return this._$AA.parentNode.insertBefore(t3, i3);
+  }
+  k(t3) {
+    this._$AH !== t3 && (this._$AR(), this._$AH = this.M(t3));
+  }
+  $(t3) {
+    this._$AH !== w && r3(this._$AH) ? this._$AA.nextSibling.data = t3 : this.k(l2$1.createTextNode(t3)), this._$AH = t3;
+  }
+  T(t3) {
+    var i3;
+    const { values: s5, _$litType$: e4 } = t3, o5 = "number" == typeof e4 ? this._$AC(t3) : (void 0 === e4.el && (e4.el = E.createElement(e4.h, this.options)), e4);
+    if ((null === (i3 = this._$AH) || void 0 === i3 ? void 0 : i3._$AD) === o5)
+      this._$AH.m(s5);
+    else {
+      const t4 = new V(o5, this), i4 = t4.p(this.options);
+      t4.m(s5), this.k(i4), this._$AH = t4;
+    }
+  }
+  _$AC(t3) {
+    let i3 = T$1.get(t3.strings);
+    return void 0 === i3 && T$1.set(t3.strings, i3 = new E(t3)), i3;
+  }
+  S(t3) {
+    d$1(this._$AH) || (this._$AH = [], this._$AR());
+    const i3 = this._$AH;
+    let s5, e4 = 0;
+    for (const o5 of t3)
+      e4 === i3.length ? i3.push(s5 = new N$1(this.M(h2$1()), this.M(h2$1()), this, this.options)) : s5 = i3[e4], s5._$AI(o5), e4++;
+    e4 < i3.length && (this._$AR(s5 && s5._$AB.nextSibling, e4), i3.length = e4);
+  }
+  _$AR(t3 = this._$AA.nextSibling, i3) {
+    var s5;
+    for (null === (s5 = this._$AP) || void 0 === s5 || s5.call(this, false, true, i3); t3 && t3 !== this._$AB; ) {
+      const i4 = t3.nextSibling;
+      t3.remove(), t3 = i4;
+    }
+  }
+  setConnected(t3) {
+    var i3;
+    void 0 === this._$AM && (this._$Cg = t3, null === (i3 = this._$AP) || void 0 === i3 || i3.call(this, t3));
+  }
+};
+var S2 = class {
+  constructor(t3, i3, s5, e4, o5) {
+    this.type = 1, this._$AH = w, this._$AN = void 0, this.element = t3, this.name = i3, this._$AM = e4, this.options = o5, s5.length > 2 || "" !== s5[0] || "" !== s5[1] ? (this._$AH = Array(s5.length - 1).fill(new String()), this.strings = s5) : this._$AH = w;
+  }
+  get tagName() {
+    return this.element.tagName;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  _$AI(t3, i3 = this, s5, e4) {
+    const o5 = this.strings;
+    let n5 = false;
+    if (void 0 === o5)
+      t3 = P(this, t3, i3, 0), n5 = !r3(t3) || t3 !== this._$AH && t3 !== b$1, n5 && (this._$AH = t3);
+    else {
+      const e5 = t3;
+      let l4, h3;
+      for (t3 = o5[0], l4 = 0; l4 < o5.length - 1; l4++)
+        h3 = P(this, e5[s5 + l4], i3, l4), h3 === b$1 && (h3 = this._$AH[l4]), n5 || (n5 = !r3(h3) || h3 !== this._$AH[l4]), h3 === w ? t3 = w : t3 !== w && (t3 += (null != h3 ? h3 : "") + o5[l4 + 1]), this._$AH[l4] = h3;
+    }
+    n5 && !e4 && this.C(t3);
+  }
+  C(t3) {
+    t3 === w ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, null != t3 ? t3 : "");
+  }
+};
+var M = class extends S2 {
+  constructor() {
+    super(...arguments), this.type = 3;
+  }
+  C(t3) {
+    this.element[this.name] = t3 === w ? void 0 : t3;
+  }
+};
+var k$1 = i2$3 ? i2$3.emptyScript : "";
+var H$2 = class extends S2 {
+  constructor() {
+    super(...arguments), this.type = 4;
+  }
+  C(t3) {
+    t3 && t3 !== w ? this.element.setAttribute(this.name, k$1) : this.element.removeAttribute(this.name);
+  }
+};
+var I = class extends S2 {
+  constructor(t3, i3, s5, e4, o5) {
+    super(t3, i3, s5, e4, o5), this.type = 5;
+  }
+  _$AI(t3, i3 = this) {
+    var s5;
+    if ((t3 = null !== (s5 = P(this, t3, i3, 0)) && void 0 !== s5 ? s5 : w) === b$1)
+      return;
+    const e4 = this._$AH, o5 = t3 === w && e4 !== w || t3.capture !== e4.capture || t3.once !== e4.once || t3.passive !== e4.passive, n5 = t3 !== w && (e4 === w || o5);
+    o5 && this.element.removeEventListener(this.name, this, e4), n5 && this.element.addEventListener(this.name, this, t3), this._$AH = t3;
+  }
+  handleEvent(t3) {
+    var i3, s5;
+    "function" == typeof this._$AH ? this._$AH.call(null !== (s5 = null === (i3 = this.options) || void 0 === i3 ? void 0 : i3.host) && void 0 !== s5 ? s5 : this.element, t3) : this._$AH.handleEvent(t3);
+  }
+};
+var L$1 = class {
+  constructor(t3, i3, s5) {
+    this.element = t3, this.type = 6, this._$AN = void 0, this._$AM = i3, this.options = s5;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  _$AI(t3) {
+    P(this, t3);
+  }
+};
+var z$1 = window.litHtmlPolyfillSupport;
+null == z$1 || z$1(E, N$1), (null !== (t2 = globalThis.litHtmlVersions) && void 0 !== t2 ? t2 : globalThis.litHtmlVersions = []).push("2.2.4");
+
+// node_modules/lit-element/lit-element.js
+var l3;
+var o4;
+var s4 = class extends a$2 {
+  constructor() {
+    super(...arguments), this.renderOptions = { host: this }, this._$Dt = void 0;
+  }
+  createRenderRoot() {
+    var t3, e4;
+    const i3 = super.createRenderRoot();
+    return null !== (t3 = (e4 = this.renderOptions).renderBefore) && void 0 !== t3 || (e4.renderBefore = i3.firstChild), i3;
+  }
+  update(t3) {
+    const i3 = this.render();
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t3), this._$Dt = x$1(i3, this.renderRoot, this.renderOptions);
+  }
+  connectedCallback() {
+    var t3;
+    super.connectedCallback(), null === (t3 = this._$Dt) || void 0 === t3 || t3.setConnected(true);
+  }
+  disconnectedCallback() {
+    var t3;
+    super.disconnectedCallback(), null === (t3 = this._$Dt) || void 0 === t3 || t3.setConnected(false);
+  }
+  render() {
+    return b$1;
+  }
+};
+s4.finalized = true, s4._$litElement$ = true, null === (l3 = globalThis.litElementHydrateSupport) || void 0 === l3 || l3.call(globalThis, { LitElement: s4 });
+var n4 = globalThis.litElementPolyfillSupport;
+null == n4 || n4({ LitElement: s4 });
+(null !== (o4 = globalThis.litElementVersions) && void 0 !== o4 ? o4 : globalThis.litElementVersions = []).push("3.2.0");
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// src/styles/component.styles.ts
+var component_styles_default = r$2`
+  :host {
+    box-sizing: border-box;
+  }
+
+  :host *,
+  :host *::before,
+  :host *::after {
+    box-sizing: inherit;
+  }
+
+  [hidden] {
+    display: none !important;
+  }
+`;
+
+// src/components/tooltip/tooltip.styles.ts
+var tooltip_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --max-width: 20rem;
+    --hide-delay: 0ms;
+    --show-delay: 150ms;
+
+    display: contents;
+  }
+
+  .tooltip {
+    --arrow-size: var(--sl-tooltip-arrow-size);
+    --arrow-color: var(--sl-tooltip-background-color);
+  }
+
+  .tooltip::part(popup) {
+    pointer-events: none;
+    z-index: var(--sl-z-index-tooltip);
+  }
+
+  .tooltip[placement^='top']::part(popup) {
+    transform-origin: bottom;
+  }
+
+  .tooltip[placement^='bottom']::part(popup) {
+    transform-origin: top;
+  }
+
+  .tooltip[placement^='left']::part(popup) {
+    transform-origin: right;
+  }
+
+  .tooltip[placement^='right']::part(popup) {
+    transform-origin: left;
+  }
+
+  .tooltip__body {
+    width: max-content;
+    max-width: var(--max-width);
+    border-radius: var(--sl-tooltip-border-radius);
+    background-color: var(--sl-tooltip-background-color);
+    font-family: var(--sl-tooltip-font-family);
+    font-size: var(--sl-tooltip-font-size);
+    font-weight: var(--sl-tooltip-font-weight);
+    line-height: var(--sl-tooltip-line-height);
+    color: var(--sl-tooltip-color);
+    padding: var(--sl-tooltip-padding);
+    pointer-events: none;
+  }
+`;
+
+// src/internal/event.ts
+function waitForEvent(el, eventName) {
+  return new Promise((resolve) => {
+    function done(event) {
+      if (event.target === el) {
+        el.removeEventListener(eventName, done);
+        resolve();
+      }
+    }
+    el.addEventListener(eventName, done);
+  });
+}
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __defProps = Object.defineProperties;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getOwnPropSymbols = Object.getOwnPropertySymbols;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __propIsEnum = Object.prototype.propertyIsEnumerable;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __spreadValues = (a, b) => {
+  for (var prop in b || (b = {}))
+    if (__hasOwnProp.call(b, prop))
+      __defNormalProp(a, prop, b[prop]);
+  if (__getOwnPropSymbols)
+    for (var prop of __getOwnPropSymbols(b)) {
+      if (__propIsEnum.call(b, prop))
+        __defNormalProp(a, prop, b[prop]);
+    }
+  return a;
+};
+var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
+var __objRest = (source, exclude) => {
+  var target = {};
+  for (var prop in source)
+    if (__hasOwnProp.call(source, prop) && exclude.indexOf(prop) < 0)
+      target[prop] = source[prop];
+  if (source != null && __getOwnPropSymbols)
+    for (var prop of __getOwnPropSymbols(source)) {
+      if (exclude.indexOf(prop) < 0 && __propIsEnum.call(source, prop))
+        target[prop] = source[prop];
+    }
+  return target;
+};
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __decorateClass = (decorators, target, key, kind) => {
+  var result = kind > 1 ? void 0 : kind ? __getOwnPropDesc(target, key) : target;
+  for (var i = decorators.length - 1, decorator; i >= 0; i--)
+    if (decorator = decorators[i])
+      result = (kind ? decorator(target, key, result) : decorator(result)) || result;
+  if (kind && result)
+    __defProp(target, key, result);
+  return result;
+};
+
+// src/internal/animate.ts
+function animateTo(el, keyframes, options) {
+  return new Promise((resolve) => {
+    if ((options == null ? void 0 : options.duration) === Infinity) {
+      throw new Error("Promise-based animations must be finite.");
+    }
+    const animation = el.animate(keyframes, __spreadProps(__spreadValues({}, options), {
+      duration: prefersReducedMotion() ? 0 : options.duration
+    }));
+    animation.addEventListener("cancel", resolve, { once: true });
+    animation.addEventListener("finish", resolve, { once: true });
+  });
+}
+function parseDuration(delay) {
+  delay = delay.toString().toLowerCase();
+  if (delay.indexOf("ms") > -1) {
+    return parseFloat(delay);
+  }
+  if (delay.indexOf("s") > -1) {
+    return parseFloat(delay) * 1e3;
+  }
+  return parseFloat(delay);
+}
+function prefersReducedMotion() {
+  const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+  return query.matches;
+}
+function stopAnimations(el) {
+  return Promise.all(
+    el.getAnimations().map((animation) => {
+      return new Promise((resolve) => {
+        const handleAnimationEvent = requestAnimationFrame(resolve);
+        animation.addEventListener("cancel", () => handleAnimationEvent, { once: true });
+        animation.addEventListener("finish", () => handleAnimationEvent, { once: true });
+        animation.cancel();
+      });
+    })
+  );
+}
+function shimKeyframesHeightAuto(keyframes, calculatedHeight) {
+  return keyframes.map((keyframe) => __spreadProps(__spreadValues({}, keyframe), {
+    height: keyframe.height === "auto" ? `${calculatedHeight}px` : keyframe.height
+  }));
+}
+
+// src/utilities/animation-registry.ts
+var defaultAnimationRegistry = /* @__PURE__ */ new Map();
+var customAnimationRegistry = /* @__PURE__ */ new WeakMap();
+function ensureAnimation(animation) {
+  return animation != null ? animation : { keyframes: [], options: { duration: 0 } };
+}
+function getLogicalAnimation(animation, dir) {
+  if (dir.toLowerCase() === "rtl") {
+    return {
+      keyframes: animation.rtlKeyframes || animation.keyframes,
+      options: animation.options
+    };
+  }
+  return animation;
+}
+function setDefaultAnimation(animationName, animation) {
+  defaultAnimationRegistry.set(animationName, ensureAnimation(animation));
+}
+function getAnimation(el, animationName, options) {
+  const customAnimation = customAnimationRegistry.get(el);
+  if (customAnimation == null ? void 0 : customAnimation[animationName]) {
+    return getLogicalAnimation(customAnimation[animationName], options.dir);
+  }
+  const defaultAnimation = defaultAnimationRegistry.get(animationName);
+  if (defaultAnimation) {
+    return getLogicalAnimation(defaultAnimation, options.dir);
+  }
+  return {
+    keyframes: [],
+    options: { duration: 0 }
+  };
+}
+
+// node_modules/@shoelace-style/localize/dist/index.js
+var connectedElements = /* @__PURE__ */ new Set();
+var documentElementObserver = new MutationObserver(update);
+var translations = /* @__PURE__ */ new Map();
+var documentDirection = document.documentElement.dir || "ltr";
+var documentLanguage = document.documentElement.lang || navigator.language;
+var fallback;
+documentElementObserver.observe(document.documentElement, {
+  attributes: true,
+  attributeFilter: ["dir", "lang"]
+});
+function registerTranslation(...translation2) {
+  translation2.map((t) => {
+    const code = t.$code.toLowerCase();
+    if (translations.has(code)) {
+      translations.set(code, Object.assign(Object.assign({}, translations.get(code)), t));
+    } else {
+      translations.set(code, t);
+    }
+    if (!fallback) {
+      fallback = t;
+    }
+  });
+  update();
+}
+function update() {
+  documentDirection = document.documentElement.dir || "ltr";
+  documentLanguage = document.documentElement.lang || navigator.language;
+  [...connectedElements.keys()].map((el) => {
+    if (typeof el.requestUpdate === "function") {
+      el.requestUpdate();
+    }
+  });
+}
+var LocalizeController = class {
+  constructor(host) {
+    this.host = host;
+    this.host.addController(this);
+  }
+  hostConnected() {
+    connectedElements.add(this.host);
+  }
+  hostDisconnected() {
+    connectedElements.delete(this.host);
+  }
+  dir() {
+    return `${this.host.dir || documentDirection}`.toLowerCase();
+  }
+  lang() {
+    return `${this.host.lang || documentLanguage}`.toLowerCase();
+  }
+  term(key, ...args) {
+    const code = this.lang().toLowerCase().slice(0, 2);
+    const regionCode = this.lang().length > 2 ? this.lang().toLowerCase() : "";
+    const primary = translations.get(regionCode);
+    const secondary = translations.get(code);
+    let term;
+    if (primary && primary[key]) {
+      term = primary[key];
+    } else if (secondary && secondary[key]) {
+      term = secondary[key];
+    } else if (fallback && fallback[key]) {
+      term = fallback[key];
+    } else {
+      console.error(`No translation found for: ${String(key)}`);
+      return key;
+    }
+    if (typeof term === "function") {
+      return term(...args);
+    }
+    return term;
+  }
+  date(dateToFormat, options) {
+    dateToFormat = new Date(dateToFormat);
+    return new Intl.DateTimeFormat(this.lang(), options).format(dateToFormat);
+  }
+  number(numberToFormat, options) {
+    numberToFormat = Number(numberToFormat);
+    return isNaN(numberToFormat) ? "" : new Intl.NumberFormat(this.lang(), options).format(numberToFormat);
+  }
+  relativeTime(value, unit, options) {
+    return new Intl.RelativeTimeFormat(this.lang(), options).format(value, unit);
+  }
+};
+
+// src/utilities/localize.ts
+var LocalizeController2 = class extends LocalizeController {
+};
+
+// src/translations/en.ts
+var translation = {
+  $code: "en",
+  $name: "English",
+  $dir: "ltr",
+  clearEntry: "Clear entry",
+  close: "Close",
+  copy: "Copy",
+  currentValue: "Current value",
+  hidePassword: "Hide password",
+  loading: "Loading",
+  progress: "Progress",
+  remove: "Remove",
+  resize: "Resize",
+  scrollToEnd: "Scroll to end",
+  scrollToStart: "Scroll to start",
+  selectAColorFromTheScreen: "Select a color from the screen",
+  showPassword: "Show password",
+  toggleColorFormat: "Toggle color format"
+};
+registerTranslation(translation);
+
+// node_modules/lit-html/directive.js
+var t$2 = { ATTRIBUTE: 1, CHILD: 2, PROPERTY: 3, BOOLEAN_ATTRIBUTE: 4, EVENT: 5, ELEMENT: 6 };
+var e$2 = (t2) => (...e2) => ({ _$litDirective$: t2, values: e2 });
+var i$1 = class {
+  constructor(t2) {
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  _$AT(t2, e2, i2) {
+    this._$Ct = t2, this._$AM = e2, this._$Ci = i2;
+  }
+  _$AS(t2, e2) {
+    return this.update(t2, e2);
+  }
+  update(t2, e2) {
+    return this.render(...e2);
+  }
+};
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// node_modules/lit-html/directives/class-map.js
+var o$3 = e$2(class extends i$1 {
+  constructor(t2) {
+    var i2;
+    if (super(t2), t2.type !== t$2.ATTRIBUTE || "class" !== t2.name || (null === (i2 = t2.strings) || void 0 === i2 ? void 0 : i2.length) > 2)
+      throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.");
+  }
+  render(t2) {
+    return " " + Object.keys(t2).filter((i2) => t2[i2]).join(" ") + " ";
+  }
+  update(i2, [s]) {
+    var r, o2;
+    if (void 0 === this.et) {
+      this.et = /* @__PURE__ */ new Set(), void 0 !== i2.strings && (this.st = new Set(i2.strings.join(" ").split(/\s/).filter((t2) => "" !== t2)));
+      for (const t2 in s)
+        s[t2] && !(null === (r = this.st) || void 0 === r ? void 0 : r.has(t2)) && this.et.add(t2);
+      return this.render(s);
+    }
+    const e2 = i2.element.classList;
+    this.et.forEach((t2) => {
+      t2 in s || (e2.remove(t2), this.et.delete(t2));
+    });
+    for (const t2 in s) {
+      const i3 = !!s[t2];
+      i3 === this.et.has(t2) || (null === (o2 = this.st) || void 0 === o2 ? void 0 : o2.has(t2)) || (i3 ? (e2.add(t2), this.et.add(t2)) : (e2.remove(t2), this.et.delete(t2)));
+    }
+    return b$1;
+  }
+});
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// src/internal/watch.ts
+function watch(propName, options) {
+  const resolvedOptions = __spreadValues({
+    waitUntilFirstUpdate: false
+  }, options);
+  return (proto, decoratedFnName) => {
+    const { update } = proto;
+    if (propName in proto) {
+      const propNameKey = propName;
+      proto.update = function(changedProps) {
+        if (changedProps.has(propNameKey)) {
+          const oldValue = changedProps.get(propNameKey);
+          const newValue = this[propNameKey];
+          if (oldValue !== newValue) {
+            if (!resolvedOptions.waitUntilFirstUpdate || this.hasUpdated) {
+              this[decoratedFnName](oldValue, newValue);
+            }
+          }
+        }
+        update.call(this, changedProps);
+      };
+    }
+  };
+}
+
+// node_modules/@lit/reactive-element/decorators/custom-element.js
+var n$1 = (n3) => (e4) => "function" == typeof e4 ? ((n4, e5) => (window.customElements.define(n4, e5), e5))(n3, e4) : ((n4, e5) => {
+  const { kind: t2, elements: i3 } = e5;
+  return { kind: t2, elements: i3, finisher(e6) {
+    window.customElements.define(n4, e6);
+  } };
+})(n3, e4);
+
+// node_modules/@lit/reactive-element/decorators/property.js
+var i = (i3, e4) => "method" === e4.kind && e4.descriptor && !("value" in e4.descriptor) ? __spreadProps(__spreadValues({}, e4), { finisher(n3) {
+  n3.createProperty(e4.key, i3);
+} }) : { kind: "field", key: Symbol(), placement: "own", descriptor: {}, originalKey: e4.key, initializer() {
+  "function" == typeof e4.initializer && (this[e4.key] = e4.initializer.call(this));
+}, finisher(n3) {
+  n3.createProperty(e4.key, i3);
+} };
+function e$1(e4) {
+  return (n3, t2) => void 0 !== t2 ? ((i3, e5, n4) => {
+    e5.constructor.createProperty(n4, i3);
+  })(e4, n3, t2) : i(e4, n3);
+}
+
+// node_modules/@lit/reactive-element/decorators/state.js
+function t$1(t2) {
+  return e$1(__spreadProps(__spreadValues({}, t2), { state: true }));
+}
+
+// node_modules/@lit/reactive-element/decorators/base.js
+var o$2 = ({ finisher: e4, descriptor: t2 }) => (o2, n3) => {
+  var r;
+  if (void 0 === n3) {
+    const n4 = null !== (r = o2.originalKey) && void 0 !== r ? r : o2.key, i3 = null != t2 ? { kind: "method", placement: "prototype", key: n4, descriptor: t2(o2.key) } : __spreadProps(__spreadValues({}, o2), { key: n4 });
+    return null != e4 && (i3.finisher = function(t3) {
+      e4(t3, n4);
+    }), i3;
+  }
+  {
+    const r2 = o2.constructor;
+    void 0 !== t2 && Object.defineProperty(o2, n3, t2(n3)), null == e4 || e4(r2, n3);
+  }
+};
+
+// node_modules/@lit/reactive-element/decorators/query.js
+function i2$2(i3, n3) {
+  return o$2({ descriptor: (o2) => {
+    const t2 = { get() {
+      var o3, n4;
+      return null !== (n4 = null === (o3 = this.renderRoot) || void 0 === o3 ? void 0 : o3.querySelector(i3)) && void 0 !== n4 ? n4 : null;
+    }, enumerable: true, configurable: true };
+    if (n3) {
+      const n4 = "symbol" == typeof o2 ? Symbol() : "__" + o2;
+      t2.get = function() {
+        var o3, t3;
+        return void 0 === this[n4] && (this[n4] = null !== (t3 = null === (o3 = this.renderRoot) || void 0 === o3 ? void 0 : o3.querySelector(i3)) && void 0 !== t3 ? t3 : null), this[n4];
+      };
+    }
+    return t2;
+  } });
+}
+
+// node_modules/@lit/reactive-element/decorators/query-async.js
+function e2$1(e4) {
+  return o$2({ descriptor: (r) => ({ async get() {
+    var r2;
+    return await this.updateComplete, null === (r2 = this.renderRoot) || void 0 === r2 ? void 0 : r2.querySelector(e4);
+  }, enumerable: true, configurable: true }) });
+}
+
+// node_modules/@lit/reactive-element/decorators/query-assigned-elements.js
+var n2$2;
+null != (null === (n2$2 = window.HTMLSlotElement) || void 0 === n2$2 ? void 0 : n2$2.prototype.assignedElements) ? (o2, n3) => o2.assignedElements(n3) : (o2, n3) => o2.assignedNodes(n3).filter((o3) => o3.nodeType === Node.ELEMENT_NODE);
+
+// src/internal/shoelace-element.ts
+var ShoelaceElement = class extends s4 {
+  emit(name, options) {
+    const event = new CustomEvent(name, __spreadValues({
+      bubbles: true,
+      cancelable: false,
+      composed: true,
+      detail: {}
+    }, options));
+    this.dispatchEvent(event);
+    return event;
+  }
+};
+__decorateClass([
+  e$1()
+], ShoelaceElement.prototype, "dir", 2);
+__decorateClass([
+  e$1()
+], ShoelaceElement.prototype, "lang", 2);
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// src/components/tooltip/tooltip.ts
+var SlTooltip = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.content = "";
+    this.placement = "top";
+    this.disabled = false;
+    this.distance = 8;
+    this.open = false;
+    this.skidding = 0;
+    this.trigger = "hover focus";
+    this.hoist = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.handleBlur = this.handleBlur.bind(this);
+    this.handleClick = this.handleClick.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleMouseOver = this.handleMouseOver.bind(this);
+    this.handleMouseOut = this.handleMouseOut.bind(this);
+    this.updateComplete.then(() => {
+      this.addEventListener("blur", this.handleBlur, true);
+      this.addEventListener("focus", this.handleFocus, true);
+      this.addEventListener("click", this.handleClick);
+      this.addEventListener("keydown", this.handleKeyDown);
+      this.addEventListener("mouseover", this.handleMouseOver);
+      this.addEventListener("mouseout", this.handleMouseOut);
+    });
+  }
+  firstUpdated() {
+    this.body.hidden = !this.open;
+    if (this.open) {
+      this.popup.active = true;
+      this.popup.reposition();
+    }
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener("blur", this.handleBlur, true);
+    this.removeEventListener("focus", this.handleFocus, true);
+    this.removeEventListener("click", this.handleClick);
+    this.removeEventListener("keydown", this.handleKeyDown);
+    this.removeEventListener("mouseover", this.handleMouseOver);
+    this.removeEventListener("mouseout", this.handleMouseOut);
+  }
+  async show() {
+    if (this.open) {
+      return void 0;
+    }
+    this.open = true;
+    return waitForEvent(this, "sl-after-show");
+  }
+  async hide() {
+    if (!this.open) {
+      return void 0;
+    }
+    this.open = false;
+    return waitForEvent(this, "sl-after-hide");
+  }
+  getTarget() {
+    const target = [...this.children].find(
+      (el) => el.tagName.toLowerCase() !== "style" && el.getAttribute("slot") !== "content"
+    );
+    if (!target) {
+      throw new Error("Invalid tooltip target: no child element was found.");
+    }
+    return target;
+  }
+  handleBlur() {
+    if (this.hasTrigger("focus")) {
+      this.hide();
+    }
+  }
+  handleClick() {
+    if (this.hasTrigger("click")) {
+      if (this.open) {
+        this.hide();
+      } else {
+        this.show();
+      }
+    }
+  }
+  handleFocus() {
+    if (this.hasTrigger("focus")) {
+      this.show();
+    }
+  }
+  handleKeyDown(event) {
+    if (this.open && event.key === "Escape") {
+      event.stopPropagation();
+      this.hide();
+    }
+  }
+  handleMouseOver() {
+    if (this.hasTrigger("hover")) {
+      const delay = parseDuration(getComputedStyle(this).getPropertyValue("--show-delay"));
+      clearTimeout(this.hoverTimeout);
+      this.hoverTimeout = window.setTimeout(() => this.show(), delay);
+    }
+  }
+  handleMouseOut() {
+    if (this.hasTrigger("hover")) {
+      const delay = parseDuration(getComputedStyle(this).getPropertyValue("--hide-delay"));
+      clearTimeout(this.hoverTimeout);
+      this.hoverTimeout = window.setTimeout(() => this.hide(), delay);
+    }
+  }
+  async handleOpenChange() {
+    if (this.open) {
+      if (this.disabled) {
+        return;
+      }
+      this.emit("sl-show");
+      await stopAnimations(this.body);
+      this.body.hidden = false;
+      this.popup.active = true;
+      const { keyframes, options } = getAnimation(this, "tooltip.show", { dir: this.localize.dir() });
+      await animateTo(this.popup.popup, keyframes, options);
+      this.emit("sl-after-show");
+    } else {
+      this.emit("sl-hide");
+      await stopAnimations(this.body);
+      const { keyframes, options } = getAnimation(this, "tooltip.hide", { dir: this.localize.dir() });
+      await animateTo(this.popup.popup, keyframes, options);
+      this.popup.active = false;
+      this.body.hidden = true;
+      this.emit("sl-after-hide");
+    }
+  }
+  async handleOptionsChange() {
+    if (this.hasUpdated) {
+      await this.updateComplete;
+      this.popup.reposition();
+    }
+  }
+  handleDisabledChange() {
+    if (this.disabled && this.open) {
+      this.hide();
+    }
+  }
+  hasTrigger(triggerType) {
+    const triggers = this.trigger.split(" ");
+    return triggers.includes(triggerType);
+  }
+  render() {
+    return $`
+      <sl-popup
+        part="base"
+        exportparts="
+          popup:base__popup,
+          arrow:base__arrow
+        "
+        class=${o$3({
+      tooltip: true,
+      "tooltip--open": this.open
+    })}
+        placement=${this.placement}
+        distance=${this.distance}
+        skidding=${this.skidding}
+        strategy=${this.hoist ? "fixed" : "absolute"}
+        flip
+        shift
+        arrow
+      >
+        <slot slot="anchor" aria-describedby="tooltip"></slot>
+
+        <div part="body" id="tooltip" class="tooltip__body" role="tooltip" aria-hidden=${this.open ? "false" : "true"}>
+          <slot name="content" aria-live=${this.open ? "polite" : "off"}> ${this.content} </slot>
+        </div>
+      </sl-popup>
+    `;
+  }
+};
+SlTooltip.styles = tooltip_styles_default;
+__decorateClass([
+  i2$2("slot:not([name])")
+], SlTooltip.prototype, "defaultSlot", 2);
+__decorateClass([
+  i2$2(".tooltip__body")
+], SlTooltip.prototype, "body", 2);
+__decorateClass([
+  i2$2("sl-popup")
+], SlTooltip.prototype, "popup", 2);
+__decorateClass([
+  e$1()
+], SlTooltip.prototype, "content", 2);
+__decorateClass([
+  e$1()
+], SlTooltip.prototype, "placement", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTooltip.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlTooltip.prototype, "distance", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTooltip.prototype, "open", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlTooltip.prototype, "skidding", 2);
+__decorateClass([
+  e$1()
+], SlTooltip.prototype, "trigger", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlTooltip.prototype, "hoist", 2);
+__decorateClass([
+  watch("open", { waitUntilFirstUpdate: true })
+], SlTooltip.prototype, "handleOpenChange", 1);
+__decorateClass([
+  watch("content"),
+  watch("distance"),
+  watch("hoist"),
+  watch("placement"),
+  watch("skidding")
+], SlTooltip.prototype, "handleOptionsChange", 1);
+__decorateClass([
+  watch("disabled")
+], SlTooltip.prototype, "handleDisabledChange", 1);
+SlTooltip = __decorateClass([
+  n$1("sl-tooltip")
+], SlTooltip);
+setDefaultAnimation("tooltip.show", {
+  keyframes: [
+    { opacity: 0, transform: "scale(0.8)" },
+    { opacity: 1, transform: "scale(1)" }
+  ],
+  options: { duration: 150, easing: "ease" }
+});
+setDefaultAnimation("tooltip.hide", {
+  keyframes: [
+    { opacity: 1, transform: "scale(1)" },
+    { opacity: 0, transform: "scale(0.8)" }
+  ],
+  options: { duration: 150, easing: "ease" }
+});
+
+// src/components/tree/tree.styles.ts
+var tree_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    /*
+     * These are actually used by tree item, but we define them here so they can more easily be set and all tree items
+     * stay consistent.
+     */
+    --indent-guide-color: var(--sl-color-neutral-200);
+    --indent-guide-offset: 0;
+    --indent-guide-style: solid;
+    --indent-guide-width: 0;
+    --indent-size: var(--sl-spacing-large);
+
+    display: block;
+    isolation: isolate;
+
+    /*
+     * Tree item indentation uses the "em" unit to increment its width on each level, so setting the font size to zero
+     * here removes the indentation for all the nodes on the first level.
+     */
+    font-size: 0;
+  }
+`;
+
+// src/components/tree-item/tree-item.styles.ts
+var tree_item_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+    outline: 0;
+    z-index: 0;
+  }
+
+  :host(:focus) {
+    outline: 0;
+  }
+
+  slot:not([name])::slotted(sl-icon) {
+    margin-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .tree-item {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    flex-direction: column;
+    color: var(--sl-color-neutral-700);
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+  }
+
+  .tree-item__checkbox {
+    pointer-events: none;
+  }
+
+  .tree-item__expand-button,
+  .tree-item__checkbox,
+  .tree-item__label {
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+    font-weight: var(--sl-font-weight-normal);
+    line-height: var(--sl-line-height-normal);
+    letter-spacing: var(--sl-letter-spacing-normal);
+  }
+
+  .tree-item__default-toggle-button {
+    transition: var(--sl-transition-medium) transform ease;
+  }
+
+  .tree-item--expanded .tree-item__default-toggle-button {
+    transform: rotate(90deg);
+  }
+
+  .tree-item--expanded.tree-item--rtl .tree-item__default-toggle-button {
+    transform: rotate(-90deg);
+  }
+
+  .tree-item__checkbox::part(base) {
+    display: flex;
+    align-items: center;
+  }
+
+  .tree-item__indentation {
+    display: block;
+    width: 1em;
+    flex-shrink: 0;
+  }
+
+  .tree-item__expand-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: content-box;
+    color: var(--sl-color-neutral-500);
+    padding: var(--sl-spacing-x-small);
+    width: 1rem;
+    height: 1rem;
+    cursor: pointer;
+  }
+
+  .tree-item__expand-button--visible {
+    cursor: pointer;
+  }
+
+  .tree-item__item {
+    display: flex;
+    align-items: center;
+    border-inline-start: solid 3px transparent;
+  }
+
+  .tree-item--disabled .tree-item__item {
+    opacity: 0.5;
+    outline: none;
+    cursor: not-allowed;
+  }
+
+  :host(:focus-visible) .tree-item__item {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+    z-index: 2;
+  }
+
+  :host(:not([aria-disabled='true'])) .tree-item--selected .tree-item__item {
+    background-color: var(--sl-color-neutral-100);
+    border-inline-start-color: var(--sl-color-primary-600);
+  }
+
+  :host(:not([aria-disabled='true'])) .tree-item__expand-button {
+    color: var(--sl-color-neutral-600);
+  }
+
+  .tree-item__label {
+    display: flex;
+    align-items: center;
+    transition: var(--sl-transition-fast) color;
+  }
+
+  .tree-item__children {
+    font-size: calc(1em + var(--indent-size, var(--sl-spacing-medium)));
+  }
+
+  /* Indentation lines */
+  .tree-item__children {
+    position: relative;
+  }
+
+  .tree-item__children::before {
+    content: '';
+    position: absolute;
+    top: var(--indent-guide-offset);
+    bottom: var(--indent-guide-offset);
+    left: calc(1em - (var(--indent-guide-width) / 2) - 1px);
+    border-inline-end: var(--indent-guide-width) var(--indent-guide-style) var(--indent-guide-color);
+    z-index: 1;
+  }
+
+  .tree-item--rtl .tree-item__children::before {
+    left: auto;
+    right: 1em;
+  }
+`;
+
+var r$1 = (o) => void 0 === o.strings;
+var f$1 = {};
+var s$2 = (o, i3 = f$1) => o._$AH = i3;
+
+// node_modules/lit-html/directives/live.js
+var l$3 = e$2(class extends i$1 {
+  constructor(r2) {
+    if (super(r2), r2.type !== t$2.PROPERTY && r2.type !== t$2.ATTRIBUTE && r2.type !== t$2.BOOLEAN_ATTRIBUTE)
+      throw Error("The `live` directive is not allowed on child or event bindings");
+    if (!r$1(r2))
+      throw Error("`live` bindings can only contain a single expression");
+  }
+  render(r2) {
+    return r2;
+  }
+  update(i3, [t2]) {
+    if (t2 === b$1 || t2 === w)
+      return t2;
+    const o = i3.element, l2 = i3.name;
+    if (i3.type === t$2.PROPERTY) {
+      if (t2 === o[l2])
+        return b$1;
+    } else if (i3.type === t$2.BOOLEAN_ATTRIBUTE) {
+      if (!!t2 === o.hasAttribute(l2))
+        return b$1;
+    } else if (i3.type === t$2.ATTRIBUTE && o.getAttribute(l2) === t2 + "")
+      return b$1;
+    return s$2(i3), t2;
+  }
+});
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// node_modules/lit-html/directives/when.js
+function n2$1(n3, o2, r) {
+  return n3 ? o2() : null == r ? void 0 : r();
+}
+
+// src/components/tree-item/tree-item.ts
+function isTreeItem(element) {
+  return element && (element == null ? void 0 : element.getAttribute("role")) === "treeitem";
+}
+var SlTreeItem = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.indeterminate = false;
+    this.isLeaf = false;
+    this.loading = false;
+    this.selectable = false;
+    this.expanded = false;
+    this.selected = false;
+    this.disabled = false;
+    this.lazy = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("role", "treeitem");
+    this.setAttribute("tabindex", "-1");
+    if (this.isNestedItem()) {
+      this.slot = "children";
+    }
+  }
+  firstUpdated() {
+    this.childrenContainer.hidden = !this.expanded;
+    this.childrenContainer.style.height = this.expanded ? "auto" : "0";
+    this.isLeaf = this.getChildrenItems().length === 0;
+    this.handleExpandedChange();
+  }
+  handleLoadingChange() {
+    this.setAttribute("aria-busy", this.loading ? "true" : "false");
+    if (!this.loading) {
+      this.animateExpand();
+    }
+  }
+  handleDisabledChange() {
+    this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+  }
+  handleSelectedChange() {
+    this.setAttribute("aria-selected", this.selected ? "true" : "false");
+  }
+  handleExpandedChange() {
+    if (!this.isLeaf) {
+      this.setAttribute("aria-expanded", this.expanded ? "true" : "false");
+    } else {
+      this.removeAttribute("aria-expanded");
+    }
+  }
+  handleExpandAnimation() {
+    if (this.expandButtonSlot) {
+      this.expandButtonSlot.name = this.expanded ? "collapse-icon" : "expand-icon";
+    }
+    if (this.expanded) {
+      if (this.lazy) {
+        this.loading = true;
+        this.emit("sl-lazy-load");
+      } else {
+        this.animateExpand();
+      }
+    } else {
+      this.animateCollapse();
+    }
+  }
+  handleLazyChange() {
+    this.emit("sl-lazy-change");
+  }
+  async animateExpand() {
+    this.emit("sl-expand");
+    await stopAnimations(this.childrenContainer);
+    this.childrenContainer.hidden = false;
+    const { keyframes, options } = getAnimation(this, "tree-item.expand", { dir: this.localize.dir() });
+    await animateTo(
+      this.childrenContainer,
+      shimKeyframesHeightAuto(keyframes, this.childrenContainer.scrollHeight),
+      options
+    );
+    this.childrenContainer.style.height = "auto";
+    this.emit("sl-after-expand");
+  }
+  async animateCollapse() {
+    this.emit("sl-collapse");
+    await stopAnimations(this.childrenContainer);
+    const { keyframes, options } = getAnimation(this, "tree-item.collapse", { dir: this.localize.dir() });
+    await animateTo(
+      this.childrenContainer,
+      shimKeyframesHeightAuto(keyframes, this.childrenContainer.scrollHeight),
+      options
+    );
+    this.childrenContainer.hidden = true;
+    this.emit("sl-after-collapse");
+  }
+  getChildrenItems({ includeDisabled = true } = {}) {
+    return this.childrenSlot ? [...this.childrenSlot.assignedElements({ flatten: true })].filter(
+      (item) => isTreeItem(item) && (includeDisabled || !item.disabled)
+    ) : [];
+  }
+  isNestedItem() {
+    const parent = this.parentElement;
+    return !!parent && isTreeItem(parent);
+  }
+  handleChildrenSlotChange() {
+    this.loading = false;
+    this.isLeaf = this.getChildrenItems().length === 0;
+  }
+  willUpdate(changedProperties) {
+    if (changedProperties.has("selected") && !changedProperties.has("indeterminate")) {
+      this.indeterminate = false;
+    }
+  }
+  render() {
+    const isRtl = this.localize.dir() === "rtl";
+    const showExpandButton = !this.loading && (!this.isLeaf || this.lazy);
+    return $`
+      <div
+        part="base"
+        class="${o$3({
+      "tree-item": true,
+      "tree-item--expanded": this.expanded,
+      "tree-item--selected": this.selected,
+      "tree-item--disabled": this.disabled,
+      "tree-item--leaf": this.isLeaf,
+      "tree-item--rtl": this.localize.dir() === "rtl"
+    })}"
+      >
+        <div
+          class="tree-item__item"
+          part="
+            item
+            ${this.disabled ? "item--disabled" : ""}
+            ${this.expanded ? "item--expanded" : ""}
+            ${this.indeterminate ? "item--indeterminate" : ""}
+            ${this.selected ? "item--selected" : ""}
+          "
+        >
+          <div class="tree-item__indentation" part="indentation"></div>
+
+          <div
+            part="expand-button"
+            class=${o$3({
+      "tree-item__expand-button": true,
+      "tree-item__expand-button--visible": showExpandButton
+    })}
+            aria-hidden="true"
+          >
+            ${n2$1(this.loading, () => $` <sl-spinner></sl-spinner> `)}
+            ${n2$1(
+      showExpandButton,
+      () => $`
+                <slot class="tree-item__expand-icon-slot" name="expand-icon">
+                  <sl-icon
+                    class="tree-item__default-toggle-button"
+                    library="system"
+                    name=${isRtl ? "chevron-left" : "chevron-right"}
+                  ></sl-icon>
+                </slot>
+              `
+    )}
+          </div>
+
+          ${n2$1(
+      this.selectable,
+      () => $`
+                <sl-checkbox
+                  tabindex="-1"
+                  class="tree-item__checkbox"
+                  ?disabled="${this.disabled}"
+                  ?checked="${l$3(this.selected)}"
+                  ?indeterminate="${this.indeterminate}"
+                >
+                  <div class="tree-item__label" part="label">
+                    <slot></slot>
+                  </div>
+                </sl-checkbox>
+              `,
+      () => $`
+              <div class="tree-item__label" part="label">
+                <slot></slot>
+              </div>
+            `
+    )}
+        </div>
+
+        <div class="tree-item__children" part="children" role="group">
+          <slot name="children" @slotchange="${this.handleChildrenSlotChange}"></slot>
+        </div>
+      </div>
+    `;
+  }
+};
+SlTreeItem.styles = tree_item_styles_default;
+__decorateClass([
+  t$1()
+], SlTreeItem.prototype, "indeterminate", 2);
+__decorateClass([
+  t$1()
+], SlTreeItem.prototype, "isLeaf", 2);
+__decorateClass([
+  t$1()
+], SlTreeItem.prototype, "loading", 2);
+__decorateClass([
+  t$1()
+], SlTreeItem.prototype, "selectable", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTreeItem.prototype, "expanded", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTreeItem.prototype, "selected", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTreeItem.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTreeItem.prototype, "lazy", 2);
+__decorateClass([
+  i2$2("slot:not([name])")
+], SlTreeItem.prototype, "defaultSlot", 2);
+__decorateClass([
+  i2$2("slot[name=children]")
+], SlTreeItem.prototype, "childrenSlot", 2);
+__decorateClass([
+  i2$2(".tree-item__item")
+], SlTreeItem.prototype, "itemElement", 2);
+__decorateClass([
+  i2$2(".tree-item__children")
+], SlTreeItem.prototype, "childrenContainer", 2);
+__decorateClass([
+  i2$2(".tree-item__expand-button slot")
+], SlTreeItem.prototype, "expandButtonSlot", 2);
+__decorateClass([
+  watch("loading", { waitUntilFirstUpdate: true })
+], SlTreeItem.prototype, "handleLoadingChange", 1);
+__decorateClass([
+  watch("disabled")
+], SlTreeItem.prototype, "handleDisabledChange", 1);
+__decorateClass([
+  watch("selected")
+], SlTreeItem.prototype, "handleSelectedChange", 1);
+__decorateClass([
+  watch("expanded", { waitUntilFirstUpdate: true })
+], SlTreeItem.prototype, "handleExpandedChange", 1);
+__decorateClass([
+  watch("expanded", { waitUntilFirstUpdate: true })
+], SlTreeItem.prototype, "handleExpandAnimation", 1);
+__decorateClass([
+  watch("lazy", { waitUntilFirstUpdate: true })
+], SlTreeItem.prototype, "handleLazyChange", 1);
+SlTreeItem = __decorateClass([
+  n$1("sl-tree-item")
+], SlTreeItem);
+setDefaultAnimation("tree-item.expand", {
+  keyframes: [
+    { height: "0", opacity: "0", overflow: "hidden" },
+    { height: "auto", opacity: "1", overflow: "hidden" }
+  ],
+  options: { duration: 250, easing: "cubic-bezier(0.4, 0.0, 0.2, 1)" }
+});
+setDefaultAnimation("tree-item.collapse", {
+  keyframes: [
+    { height: "auto", opacity: "1", overflow: "hidden" },
+    { height: "0", opacity: "0", overflow: "hidden" }
+  ],
+  options: { duration: 200, easing: "cubic-bezier(0.4, 0.0, 0.2, 1)" }
+});
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// src/internal/math.ts
+function clamp(value, min, max) {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
+// src/components/tree/tree.ts
+function syncCheckboxes(changedTreeItem) {
+  function syncAncestors(treeItem) {
+    const parentItem = treeItem.parentElement;
+    if (isTreeItem(parentItem)) {
+      const children = parentItem.getChildrenItems({ includeDisabled: false });
+      const allChecked = !!children.length && children.every((item) => item.selected);
+      const allUnchecked = children.every((item) => !item.selected && !item.indeterminate);
+      parentItem.selected = allChecked;
+      parentItem.indeterminate = !allChecked && !allUnchecked;
+      syncAncestors(parentItem);
+    }
+  }
+  function syncDescendants(treeItem) {
+    for (const childItem of treeItem.getChildrenItems()) {
+      childItem.selected = !childItem.disabled && treeItem.selected;
+      syncDescendants(childItem);
+    }
+  }
+  syncAncestors(changedTreeItem);
+  syncDescendants(changedTreeItem);
+}
+var SlTree = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.selection = "single";
+    this.treeItems = [];
+    this.localize = new LocalizeController2(this);
+    this.initTreeItem = (item) => {
+      item.selectable = this.selection === "multiple";
+      ["expand", "collapse"].filter((status) => !!this.querySelector(`[slot="${status}-icon"]`)).forEach((status) => {
+        const existingIcon = item.querySelector(`[slot="${status}-icon"]`);
+        if (existingIcon === null) {
+          item.append(this.getExpandButtonIcon(status));
+        } else if (existingIcon.hasAttribute("data-default")) {
+          existingIcon.replaceWith(this.getExpandButtonIcon(status));
+        } else ;
+      });
+    };
+    this.handleTreeChanged = (mutations) => {
+      for (const mutation of mutations) {
+        const addedNodes = [...mutation.addedNodes].filter(isTreeItem);
+        const removedNodes = [...mutation.removedNodes].filter(isTreeItem);
+        addedNodes.forEach(this.initTreeItem);
+        if (removedNodes.includes(this.lastFocusedItem)) {
+          this.focusItem(this.getFocusableItems()[0]);
+        }
+      }
+    };
+    this.handleFocusOut = (event) => {
+      const relatedTarget = event.relatedTarget;
+      if (!relatedTarget || !this.contains(relatedTarget)) {
+        this.tabIndex = 0;
+      }
+    };
+    this.handleFocusIn = (event) => {
+      const target = event.target;
+      if (event.target === this) {
+        this.focusItem(this.lastFocusedItem || this.treeItems[0]);
+      }
+      if (isTreeItem(target) && !target.disabled) {
+        if (this.lastFocusedItem) {
+          this.lastFocusedItem.tabIndex = -1;
+        }
+        this.lastFocusedItem = target;
+        this.tabIndex = -1;
+        target.tabIndex = 0;
+      }
+    };
+  }
+  async connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("role", "tree");
+    this.setAttribute("tabindex", "0");
+    this.addEventListener("focusin", this.handleFocusIn);
+    this.addEventListener("focusout", this.handleFocusOut);
+    this.addEventListener("sl-lazy-change", this.updateItems);
+    await this.updateComplete;
+    this.mutationObserver = new MutationObserver(this.handleTreeChanged);
+    this.mutationObserver.observe(this, { childList: true, subtree: true });
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.mutationObserver.disconnect();
+    this.removeEventListener("focusin", this.handleFocusIn);
+    this.removeEventListener("focusout", this.handleFocusOut);
+    this.removeEventListener("sl-lazy-change", this.updateItems);
+  }
+  getExpandButtonIcon(status) {
+    const slot = status === "expand" ? this.expandedIconSlot : this.collapsedIconSlot;
+    const icon = slot.assignedElements({ flatten: true })[0];
+    if (icon) {
+      const clone = icon.cloneNode(true);
+      [clone, ...clone.querySelectorAll("[id]")].forEach((el) => el.removeAttribute("id"));
+      clone.setAttribute("data-default", "");
+      clone.slot = `${status}-icon`;
+      return clone;
+    }
+    return null;
+  }
+  handleSelectionChange() {
+    this.setAttribute("aria-multiselectable", this.selection === "multiple" ? "true" : "false");
+    for (const item of this.treeItems) {
+      item.selectable = this.selection === "multiple";
+    }
+  }
+  syncTreeItems(selectedItem) {
+    if (this.selection === "multiple") {
+      syncCheckboxes(selectedItem);
+    } else {
+      for (const item of this.treeItems) {
+        if (item !== selectedItem) {
+          item.selected = false;
+        }
+      }
+    }
+  }
+  selectItem(selectedItem) {
+    if (this.selection === "multiple") {
+      selectedItem.selected = !selectedItem.selected;
+      if (selectedItem.lazy) {
+        selectedItem.expanded = true;
+      }
+      this.syncTreeItems(selectedItem);
+    } else if (this.selection === "single" || selectedItem.isLeaf) {
+      selectedItem.expanded = !selectedItem.expanded;
+      selectedItem.selected = true;
+      this.syncTreeItems(selectedItem);
+    } else if (this.selection === "leaf") {
+      selectedItem.expanded = !selectedItem.expanded;
+    }
+    this.emit("sl-selection-change", { detail: { selection: this.selectedItems } });
+  }
+  get selectedItems() {
+    const items = [...this.treeItems];
+    const isSelected = (item) => item.selected;
+    return items.filter(isSelected);
+  }
+  getFocusableItems() {
+    const collapsedItems = /* @__PURE__ */ new Set();
+    return [...this.treeItems].filter((item) => {
+      var _a;
+      if (item.disabled)
+        return false;
+      const parent = (_a = item.parentElement) == null ? void 0 : _a.closest("[role=treeitem]");
+      if (parent && (!parent.expanded || parent.loading || collapsedItems.has(parent))) {
+        collapsedItems.add(item);
+      }
+      return !collapsedItems.has(item);
+    });
+  }
+  focusItem(item) {
+    item == null ? void 0 : item.focus();
+  }
+  handleKeyDown(event) {
+    if (!["ArrowDown", "ArrowUp", "ArrowRight", "ArrowLeft", "Home", "End", "Enter", " "].includes(event.key)) {
+      return;
+    }
+    const items = this.getFocusableItems();
+    const isLtr = this.localize.dir() === "ltr";
+    const isRtl = this.localize.dir() === "rtl";
+    if (items.length > 0) {
+      event.preventDefault();
+      const activeItemIndex = items.findIndex((item) => item.matches(":focus"));
+      const activeItem = items[activeItemIndex];
+      const focusItemAt = (index) => {
+        const item = items[clamp(index, 0, items.length - 1)];
+        this.focusItem(item);
+      };
+      const toggleExpand = (expanded) => {
+        activeItem.expanded = expanded;
+      };
+      if (event.key === "ArrowDown") {
+        focusItemAt(activeItemIndex + 1);
+      } else if (event.key === "ArrowUp") {
+        focusItemAt(activeItemIndex - 1);
+      } else if (isLtr && event.key === "ArrowRight" || isRtl && event.key === "ArrowLeft") {
+        if (!activeItem || activeItem.disabled || activeItem.expanded || activeItem.isLeaf && !activeItem.lazy) {
+          focusItemAt(activeItemIndex + 1);
+        } else {
+          toggleExpand(true);
+        }
+      } else if (isLtr && event.key === "ArrowLeft" || isRtl && event.key === "ArrowRight") {
+        if (!activeItem || activeItem.disabled || activeItem.isLeaf || !activeItem.expanded) {
+          focusItemAt(activeItemIndex - 1);
+        } else {
+          toggleExpand(false);
+        }
+      } else if (event.key === "Home") {
+        focusItemAt(0);
+      } else if (event.key === "End") {
+        focusItemAt(items.length - 1);
+      } else if (event.key === "Enter" || event.key === " ") {
+        if (!activeItem.disabled) {
+          this.selectItem(activeItem);
+        }
+      }
+    }
+  }
+  handleClick(event) {
+    const target = event.target;
+    const treeItem = target.closest("sl-tree-item");
+    const isExpandButton = event.composedPath().some((el) => {
+      var _a;
+      return (_a = el == null ? void 0 : el.classList) == null ? void 0 : _a.contains("tree-item__expand-button");
+    });
+    if (!treeItem || treeItem.disabled) {
+      return;
+    }
+    if (this.selection === "multiple" && isExpandButton) {
+      treeItem.expanded = !treeItem.expanded;
+    } else {
+      this.selectItem(treeItem);
+    }
+  }
+  updateItems() {
+    this.treeItems = [...this.querySelectorAll("sl-tree-item")];
+    [...this.treeItems].forEach(this.initTreeItem);
+  }
+  render() {
+    return $`
+      <div part="base" class="tree" @click=${this.handleClick} @keydown=${this.handleKeyDown}>
+        <slot @slotchange=${this.updateItems}></slot>
+        <slot name="expand-icon" hidden aria-hidden="true"> </slot>
+        <slot name="collapse-icon" hidden aria-hidden="true"> </slot>
+      </div>
+    `;
+  }
+};
+SlTree.styles = tree_styles_default;
+__decorateClass([
+  i2$2("slot:not([name])")
+], SlTree.prototype, "defaultSlot", 2);
+__decorateClass([
+  i2$2("slot[name=expand-icon]")
+], SlTree.prototype, "expandedIconSlot", 2);
+__decorateClass([
+  i2$2("slot[name=collapse-icon]")
+], SlTree.prototype, "collapsedIconSlot", 2);
+__decorateClass([
+  e$1()
+], SlTree.prototype, "selection", 2);
+__decorateClass([
+  watch("selection")
+], SlTree.prototype, "handleSelectionChange", 1);
+SlTree = __decorateClass([
+  n$1("sl-tree")
+], SlTree);
+
+// src/components/tab-group/tab-group.styles.ts
+var tab_group_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --indicator-color: var(--sl-color-primary-600);
+    --track-color: var(--sl-color-neutral-200);
+    --track-width: 2px;
+
+    display: block;
+  }
+
+  .tab-group {
+    display: flex;
+    border: solid 1px transparent;
+    border-radius: 0;
+  }
+
+  .tab-group__tabs {
+    display: flex;
+    position: relative;
+  }
+
+  .tab-group__indicator {
+    position: absolute;
+    transition: var(--sl-transition-fast) transform ease, var(--sl-transition-fast) width ease;
+  }
+
+  .tab-group--has-scroll-controls .tab-group__nav-container {
+    position: relative;
+    padding: 0 var(--sl-spacing-x-large);
+  }
+
+  .tab-group__body {
+    overflow: auto;
+  }
+
+  .tab-group__scroll-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: var(--sl-spacing-x-large);
+  }
+
+  .tab-group__scroll-button--start {
+    left: 0;
+  }
+
+  .tab-group__scroll-button--end {
+    right: 0;
+  }
+
+  .tab-group--rtl .tab-group__scroll-button--start {
+    left: auto;
+    right: 0;
+  }
+
+  .tab-group--rtl .tab-group__scroll-button--end {
+    left: 0;
+    right: auto;
+  }
+
+  /*
+   * Top
+   */
+
+  .tab-group--top {
+    flex-direction: column;
+  }
+
+  .tab-group--top .tab-group__nav-container {
+    order: 1;
+  }
+
+  .tab-group--top .tab-group__nav {
+    display: flex;
+    overflow-x: auto;
+
+    /* Hide scrollbar in Firefox */
+    scrollbar-width: none;
+  }
+
+  /* Hide scrollbar in Chrome/Safari */
+  .tab-group--top .tab-group__nav::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .tab-group--top .tab-group__tabs {
+    flex: 1 1 auto;
+    position: relative;
+    flex-direction: row;
+    border-bottom: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--top .tab-group__indicator {
+    bottom: calc(-1 * var(--track-width));
+    border-bottom: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--top .tab-group__body {
+    order: 2;
+  }
+
+  .tab-group--top ::slotted(sl-tab-panel) {
+    --padding: var(--sl-spacing-medium) 0;
+  }
+
+  /*
+   * Bottom
+   */
+
+  .tab-group--bottom {
+    flex-direction: column;
+  }
+
+  .tab-group--bottom .tab-group__nav-container {
+    order: 2;
+  }
+
+  .tab-group--bottom .tab-group__nav {
+    display: flex;
+    overflow-x: auto;
+
+    /* Hide scrollbar in Firefox */
+    scrollbar-width: none;
+  }
+
+  /* Hide scrollbar in Chrome/Safari */
+  .tab-group--bottom .tab-group__nav::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .tab-group--bottom .tab-group__tabs {
+    flex: 1 1 auto;
+    position: relative;
+    flex-direction: row;
+    border-top: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--bottom .tab-group__indicator {
+    top: calc(-1 * var(--track-width));
+    border-top: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--bottom .tab-group__body {
+    order: 1;
+  }
+
+  .tab-group--bottom ::slotted(sl-tab-panel) {
+    --padding: var(--sl-spacing-medium) 0;
+  }
+
+  /*
+   * Start
+   */
+
+  .tab-group--start {
+    flex-direction: row;
+  }
+
+  .tab-group--start .tab-group__nav-container {
+    order: 1;
+  }
+
+  .tab-group--start .tab-group__tabs {
+    flex: 0 0 auto;
+    flex-direction: column;
+    border-inline-end: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--start .tab-group__indicator {
+    right: calc(-1 * var(--track-width));
+    border-right: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--start.tab-group--rtl .tab-group__indicator {
+    right: auto;
+    left: calc(-1 * var(--track-width));
+  }
+
+  .tab-group--start .tab-group__body {
+    flex: 1 1 auto;
+    order: 2;
+  }
+
+  .tab-group--start ::slotted(sl-tab-panel) {
+    --padding: 0 var(--sl-spacing-medium);
+  }
+
+  /*
+   * End
+   */
+
+  .tab-group--end {
+    flex-direction: row;
+  }
+
+  .tab-group--end .tab-group__nav-container {
+    order: 2;
+  }
+
+  .tab-group--end .tab-group__tabs {
+    flex: 0 0 auto;
+    flex-direction: column;
+    border-left: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--end .tab-group__indicator {
+    left: calc(-1 * var(--track-width));
+    border-inline-start: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--end.tab-group--rtl .tab-group__indicator {
+    right: calc(-1 * var(--track-width));
+    left: auto;
+  }
+
+  .tab-group--end .tab-group__body {
+    flex: 1 1 auto;
+    order: 1;
+  }
+
+  .tab-group--end ::slotted(sl-tab-panel) {
+    --padding: 0 var(--sl-spacing-medium);
+  }
+`;
+
+// src/internal/offset.ts
+function getOffset(element, parent) {
+  return {
+    top: Math.round(element.getBoundingClientRect().top - parent.getBoundingClientRect().top),
+    left: Math.round(element.getBoundingClientRect().left - parent.getBoundingClientRect().left)
+  };
+}
+
+// src/internal/scroll.ts
+var locks = /* @__PURE__ */ new Set();
+function lockBodyScrolling(lockingEl) {
+  locks.add(lockingEl);
+  document.body.classList.add("sl-scroll-lock");
+}
+function unlockBodyScrolling(lockingEl) {
+  locks.delete(lockingEl);
+  if (locks.size === 0) {
+    document.body.classList.remove("sl-scroll-lock");
+  }
+}
+function scrollIntoView(element, container, direction = "vertical", behavior = "smooth") {
+  const offset = getOffset(element, container);
+  const offsetTop = offset.top + container.scrollTop;
+  const offsetLeft = offset.left + container.scrollLeft;
+  const minX = container.scrollLeft;
+  const maxX = container.scrollLeft + container.offsetWidth;
+  const minY = container.scrollTop;
+  const maxY = container.scrollTop + container.offsetHeight;
+  if (direction === "horizontal" || direction === "both") {
+    if (offsetLeft < minX) {
+      container.scrollTo({ left: offsetLeft, behavior });
+    } else if (offsetLeft + element.clientWidth > maxX) {
+      container.scrollTo({ left: offsetLeft - container.offsetWidth + element.clientWidth, behavior });
+    }
+  }
+  if (direction === "vertical" || direction === "both") {
+    if (offsetTop < minY) {
+      container.scrollTo({ top: offsetTop, behavior });
+    } else if (offsetTop + element.clientHeight > maxY) {
+      container.scrollTo({ top: offsetTop - container.offsetHeight + element.clientHeight, behavior });
+    }
+  }
+}
+
+// src/components/tab-group/tab-group.ts
+var SlTabGroup = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.tabs = [];
+    this.panels = [];
+    this.hasScrollControls = false;
+    this.placement = "top";
+    this.activation = "auto";
+    this.noScrollControls = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.resizeObserver = new ResizeObserver(() => {
+      this.preventIndicatorTransition();
+      this.repositionIndicator();
+      this.updateScrollControls();
+    });
+    this.mutationObserver = new MutationObserver((mutations) => {
+      if (mutations.some((m) => !["aria-labelledby", "aria-controls"].includes(m.attributeName))) {
+        setTimeout(() => this.setAriaLabels());
+      }
+      if (mutations.some((m) => m.attributeName === "disabled")) {
+        this.syncTabsAndPanels();
+      }
+    });
+    this.updateComplete.then(() => {
+      this.syncTabsAndPanels();
+      this.mutationObserver.observe(this, { attributes: true, childList: true, subtree: true });
+      this.resizeObserver.observe(this.nav);
+      const intersectionObserver = new IntersectionObserver((entries, observer) => {
+        var _a;
+        if (entries[0].intersectionRatio > 0) {
+          this.setAriaLabels();
+          this.setActiveTab((_a = this.getActiveTab()) != null ? _a : this.tabs[0], { emitEvents: false });
+          observer.unobserve(entries[0].target);
+        }
+      });
+      intersectionObserver.observe(this.tabGroup);
+    });
+  }
+  disconnectedCallback() {
+    this.mutationObserver.disconnect();
+    this.resizeObserver.unobserve(this.nav);
+  }
+  show(panel) {
+    const tab = this.tabs.find((el) => el.panel === panel);
+    if (tab) {
+      this.setActiveTab(tab, { scrollBehavior: "smooth" });
+    }
+  }
+  getAllTabs(options = { includeDisabled: true }) {
+    const slot = this.shadowRoot.querySelector('slot[name="nav"]');
+    return [...slot.assignedElements()].filter((el) => {
+      return options.includeDisabled ? el.tagName.toLowerCase() === "sl-tab" : el.tagName.toLowerCase() === "sl-tab" && !el.disabled;
+    });
+  }
+  getAllPanels() {
+    const slot = this.body.querySelector("slot");
+    return [...slot.assignedElements()].filter((el) => el.tagName.toLowerCase() === "sl-tab-panel");
+  }
+  getActiveTab() {
+    return this.tabs.find((el) => el.active);
+  }
+  handleClick(event) {
+    const target = event.target;
+    const tab = target.closest("sl-tab");
+    const tabGroup = tab == null ? void 0 : tab.closest("sl-tab-group");
+    if (tabGroup !== this) {
+      return;
+    }
+    if (tab !== null) {
+      this.setActiveTab(tab, { scrollBehavior: "smooth" });
+    }
+  }
+  handleKeyDown(event) {
+    const target = event.target;
+    const tab = target.closest("sl-tab");
+    const tabGroup = tab == null ? void 0 : tab.closest("sl-tab-group");
+    if (tabGroup !== this) {
+      return;
+    }
+    if (["Enter", " "].includes(event.key)) {
+      if (tab !== null) {
+        this.setActiveTab(tab, { scrollBehavior: "smooth" });
+        event.preventDefault();
+      }
+    }
+    if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"].includes(event.key)) {
+      const activeEl = this.tabs.find((t2) => t2.matches(":focus"));
+      const isRtl = this.localize.dir() === "rtl";
+      if ((activeEl == null ? void 0 : activeEl.tagName.toLowerCase()) === "sl-tab") {
+        let index = this.tabs.indexOf(activeEl);
+        if (event.key === "Home") {
+          index = 0;
+        } else if (event.key === "End") {
+          index = this.tabs.length - 1;
+        } else if (["top", "bottom"].includes(this.placement) && event.key === (isRtl ? "ArrowRight" : "ArrowLeft") || ["start", "end"].includes(this.placement) && event.key === "ArrowUp") {
+          index--;
+        } else if (["top", "bottom"].includes(this.placement) && event.key === (isRtl ? "ArrowLeft" : "ArrowRight") || ["start", "end"].includes(this.placement) && event.key === "ArrowDown") {
+          index++;
+        }
+        if (index < 0) {
+          index = this.tabs.length - 1;
+        }
+        if (index > this.tabs.length - 1) {
+          index = 0;
+        }
+        this.tabs[index].focus({ preventScroll: true });
+        if (this.activation === "auto") {
+          this.setActiveTab(this.tabs[index], { scrollBehavior: "smooth" });
+        }
+        if (["top", "bottom"].includes(this.placement)) {
+          scrollIntoView(this.tabs[index], this.nav, "horizontal");
+        }
+        event.preventDefault();
+      }
+    }
+  }
+  handleScrollToStart() {
+    this.nav.scroll({
+      left: this.localize.dir() === "rtl" ? this.nav.scrollLeft + this.nav.clientWidth : this.nav.scrollLeft - this.nav.clientWidth,
+      behavior: "smooth"
+    });
+  }
+  handleScrollToEnd() {
+    this.nav.scroll({
+      left: this.localize.dir() === "rtl" ? this.nav.scrollLeft - this.nav.clientWidth : this.nav.scrollLeft + this.nav.clientWidth,
+      behavior: "smooth"
+    });
+  }
+  updateScrollControls() {
+    if (this.noScrollControls) {
+      this.hasScrollControls = false;
+    } else {
+      this.hasScrollControls = ["top", "bottom"].includes(this.placement) && this.nav.scrollWidth > this.nav.clientWidth;
+    }
+  }
+  setActiveTab(tab, options) {
+    options = __spreadValues({
+      emitEvents: true,
+      scrollBehavior: "auto"
+    }, options);
+    if (tab !== this.activeTab && !tab.disabled) {
+      const previousTab = this.activeTab;
+      this.activeTab = tab;
+      this.tabs.map((el) => el.active = el === this.activeTab);
+      this.panels.map((el) => {
+        var _a;
+        return el.active = el.name === ((_a = this.activeTab) == null ? void 0 : _a.panel);
+      });
+      this.syncIndicator();
+      if (["top", "bottom"].includes(this.placement)) {
+        scrollIntoView(this.activeTab, this.nav, "horizontal", options.scrollBehavior);
+      }
+      if (options.emitEvents) {
+        if (previousTab) {
+          this.emit("sl-tab-hide", { detail: { name: previousTab.panel } });
+        }
+        this.emit("sl-tab-show", { detail: { name: this.activeTab.panel } });
+      }
+    }
+  }
+  setAriaLabels() {
+    this.tabs.forEach((tab) => {
+      const panel = this.panels.find((el) => el.name === tab.panel);
+      if (panel) {
+        tab.setAttribute("aria-controls", panel.getAttribute("id"));
+        panel.setAttribute("aria-labelledby", tab.getAttribute("id"));
+      }
+    });
+  }
+  syncIndicator() {
+    const tab = this.getActiveTab();
+    if (tab) {
+      this.indicator.style.display = "block";
+      this.repositionIndicator();
+    } else {
+      this.indicator.style.display = "none";
+    }
+  }
+  repositionIndicator() {
+    const currentTab = this.getActiveTab();
+    if (!currentTab) {
+      return;
+    }
+    const width = currentTab.clientWidth;
+    const height = currentTab.clientHeight;
+    const isRtl = this.localize.dir() === "rtl";
+    const allTabs = this.getAllTabs();
+    const precedingTabs = allTabs.slice(0, allTabs.indexOf(currentTab));
+    const offset = precedingTabs.reduce(
+      (previous, current) => ({
+        left: previous.left + current.clientWidth,
+        top: previous.top + current.clientHeight
+      }),
+      { left: 0, top: 0 }
+    );
+    switch (this.placement) {
+      case "top":
+      case "bottom":
+        this.indicator.style.width = `${width}px`;
+        this.indicator.style.height = "auto";
+        this.indicator.style.transform = isRtl ? `translateX(${-1 * offset.left}px)` : `translateX(${offset.left}px)`;
+        break;
+      case "start":
+      case "end":
+        this.indicator.style.width = "auto";
+        this.indicator.style.height = `${height}px`;
+        this.indicator.style.transform = `translateY(${offset.top}px)`;
+        break;
+    }
+  }
+  preventIndicatorTransition() {
+    const transitionValue = this.indicator.style.transition;
+    this.indicator.style.transition = "none";
+    requestAnimationFrame(() => {
+      this.indicator.style.transition = transitionValue;
+    });
+  }
+  syncTabsAndPanels() {
+    this.tabs = this.getAllTabs({ includeDisabled: false });
+    this.panels = this.getAllPanels();
+    this.syncIndicator();
+  }
+  render() {
+    const isRtl = this.localize.dir() === "rtl";
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      "tab-group": true,
+      "tab-group--top": this.placement === "top",
+      "tab-group--bottom": this.placement === "bottom",
+      "tab-group--start": this.placement === "start",
+      "tab-group--end": this.placement === "end",
+      "tab-group--rtl": this.localize.dir() === "rtl",
+      "tab-group--has-scroll-controls": this.hasScrollControls
+    })}
+        @click=${this.handleClick}
+        @keydown=${this.handleKeyDown}
+      >
+        <div class="tab-group__nav-container" part="nav">
+          ${this.hasScrollControls ? $`
+                <sl-icon-button
+                  part="scroll-button scroll-button--start"
+                  exportparts="base:scroll-button__base"
+                  class="tab-group__scroll-button tab-group__scroll-button--start"
+                  name=${isRtl ? "chevron-right" : "chevron-left"}
+                  library="system"
+                  label=${this.localize.term("scrollToStart")}
+                  @click=${this.handleScrollToStart}
+                ></sl-icon-button>
+              ` : ""}
+
+          <div class="tab-group__nav">
+            <div part="tabs" class="tab-group__tabs" role="tablist">
+              <div part="active-tab-indicator" class="tab-group__indicator"></div>
+              <slot name="nav" @slotchange=${this.syncTabsAndPanels}></slot>
+            </div>
+          </div>
+
+          ${this.hasScrollControls ? $`
+                <sl-icon-button
+                  part="scroll-button scroll-button--end"
+                  exportparts="base:scroll-button__base"
+                  class="tab-group__scroll-button tab-group__scroll-button--end"
+                  name=${isRtl ? "chevron-left" : "chevron-right"}
+                  library="system"
+                  label=${this.localize.term("scrollToEnd")}
+                  @click=${this.handleScrollToEnd}
+                ></sl-icon-button>
+              ` : ""}
+        </div>
+
+        <div part="body" class="tab-group__body">
+          <slot @slotchange=${this.syncTabsAndPanels}></slot>
+        </div>
+      </div>
+    `;
+  }
+};
+SlTabGroup.styles = tab_group_styles_default;
+__decorateClass([
+  i2$2(".tab-group")
+], SlTabGroup.prototype, "tabGroup", 2);
+__decorateClass([
+  i2$2(".tab-group__body")
+], SlTabGroup.prototype, "body", 2);
+__decorateClass([
+  i2$2(".tab-group__nav")
+], SlTabGroup.prototype, "nav", 2);
+__decorateClass([
+  i2$2(".tab-group__indicator")
+], SlTabGroup.prototype, "indicator", 2);
+__decorateClass([
+  t$1()
+], SlTabGroup.prototype, "hasScrollControls", 2);
+__decorateClass([
+  e$1()
+], SlTabGroup.prototype, "placement", 2);
+__decorateClass([
+  e$1()
+], SlTabGroup.prototype, "activation", 2);
+__decorateClass([
+  e$1({ attribute: "no-scroll-controls", type: Boolean })
+], SlTabGroup.prototype, "noScrollControls", 2);
+__decorateClass([
+  watch("noScrollControls", { waitUntilFirstUpdate: true })
+], SlTabGroup.prototype, "updateScrollControls", 1);
+__decorateClass([
+  watch("placement", { waitUntilFirstUpdate: true })
+], SlTabGroup.prototype, "syncIndicator", 1);
+SlTabGroup = __decorateClass([
+  n$1("sl-tab-group")
+], SlTabGroup);
+
+// src/components/tab-panel/tab-panel.styles.ts
+var tab_panel_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --padding: 0;
+
+    display: block;
+  }
+
+  .tab-panel {
+    border: solid 1px transparent;
+    padding: var(--padding);
+  }
+
+  .tab-panel:not(.tab-panel--active) {
+    display: none;
+  }
+`;
+
+// src/internal/auto-increment.ts
+var id = 0;
+function autoIncrement() {
+  return ++id;
+}
+
+// src/components/tab-panel/tab-panel.ts
+var SlTabPanel = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.attrId = autoIncrement();
+    this.componentId = `sl-tab-panel-${this.attrId}`;
+    this.name = "";
+    this.active = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.id = this.id.length > 0 ? this.id : this.componentId;
+    this.setAttribute("role", "tabpanel");
+  }
+  handleActiveChange() {
+    this.setAttribute("aria-hidden", this.active ? "false" : "true");
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      "tab-panel": true,
+      "tab-panel--active": this.active
+    })}
+      >
+        <slot></slot>
+      </div>
+    `;
+  }
+};
+SlTabPanel.styles = tab_panel_styles_default;
+__decorateClass([
+  e$1({ reflect: true })
+], SlTabPanel.prototype, "name", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTabPanel.prototype, "active", 2);
+__decorateClass([
+  watch("active")
+], SlTabPanel.prototype, "handleActiveChange", 1);
+SlTabPanel = __decorateClass([
+  n$1("sl-tab-panel")
+], SlTabPanel);
+
+// src/styles/form-control.styles.ts
+var form_control_styles_default = r$2`
+  .form-control .form-control__label {
+    display: none;
+  }
+
+  .form-control .form-control__help-text {
+    display: none;
+  }
+
+  /* Label */
+  .form-control--has-label .form-control__label {
+    display: inline-block;
+    color: var(--sl-input-label-color);
+    margin-bottom: var(--sl-spacing-3x-small);
+  }
+
+  .form-control--has-label.form-control--small .form-control__label {
+    font-size: var(--sl-input-label-font-size-small);
+  }
+
+  .form-control--has-label.form-control--medium .form-control__label {
+    font-size: var(--sl-input-label-font-size-medium);
+  }
+
+  .form-control--has-label.form-control--large .form-control_label {
+    font-size: var(--sl-input-label-font-size-large);
+  }
+
+  :host([required]) .form-control--has-label .form-control__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+
+  /* Help text */
+  .form-control--has-help-text .form-control__help-text {
+    display: block;
+    color: var(--sl-input-help-text-color);
+  }
+
+  .form-control--has-help-text .form-control__help-text ::slotted(*) {
+    margin-top: var(--sl-spacing-3x-small);
+  }
+
+  .form-control--has-help-text.form-control--small .form-control__help-text {
+    font-size: var(--sl-input-help-text-font-size-small);
+  }
+
+  .form-control--has-help-text.form-control--medium .form-control__help-text {
+    font-size: var(--sl-input-help-text-font-size-medium);
+  }
+
+  .form-control--has-help-text.form-control--large .form-control__help-text {
+    font-size: var(--sl-input-help-text-font-size-large);
+  }
+`;
+
+// src/components/textarea/textarea.styles.ts
+var textarea_styles_default = r$2`
+  ${component_styles_default}
+  ${form_control_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .textarea {
+    display: flex;
+    align-items: center;
+    position: relative;
+    width: 100%;
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-input-font-weight);
+    line-height: var(--sl-line-height-normal);
+    letter-spacing: var(--sl-input-letter-spacing);
+    vertical-align: middle;
+    transition: var(--sl-transition-fast) color, var(--sl-transition-fast) border, var(--sl-transition-fast) box-shadow,
+      var(--sl-transition-fast) background-color;
+    cursor: text;
+  }
+
+  /* Standard textareas */
+  .textarea--standard {
+    background-color: var(--sl-input-background-color);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+  }
+
+  .textarea--standard:hover:not(.textarea--disabled) {
+    background-color: var(--sl-input-background-color-hover);
+    border-color: var(--sl-input-border-color-hover);
+  }
+  .textarea--standard:hover:not(.textarea--disabled) .textarea__control {
+    color: var(--sl-input-color-hover);
+  }
+
+  .textarea--standard.textarea--focused:not(.textarea--disabled) {
+    background-color: var(--sl-input-background-color-focus);
+    border-color: var(--sl-input-border-color-focus);
+    color: var(--sl-input-color-focus);
+    box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-input-focus-ring-color);
+  }
+
+  .textarea--standard.textarea--focused:not(.textarea--disabled) .textarea__control {
+    color: var(--sl-input-color-focus);
+  }
+
+  .textarea--standard.textarea--disabled {
+    background-color: var(--sl-input-background-color-disabled);
+    border-color: var(--sl-input-border-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .textarea--standard.textarea--disabled .textarea__control {
+    color: var(--sl-input-color-disabled);
+  }
+
+  .textarea--standard.textarea--disabled .textarea__control::placeholder {
+    color: var(--sl-input-placeholder-color-disabled);
+  }
+
+  /* Filled textareas */
+  .textarea--filled {
+    border: none;
+    background-color: var(--sl-input-filled-background-color);
+    color: var(--sl-input-color);
+  }
+
+  .textarea--filled:hover:not(.textarea--disabled) {
+    background-color: var(--sl-input-filled-background-color-hover);
+  }
+
+  .textarea--filled.textarea--focused:not(.textarea--disabled) {
+    background-color: var(--sl-input-filled-background-color-focus);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .textarea--filled.textarea--disabled {
+    background-color: var(--sl-input-filled-background-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .textarea__control {
+    flex: 1 1 auto;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: 1.4;
+    color: var(--sl-input-color);
+    border: none;
+    background: none;
+    box-shadow: none;
+    cursor: inherit;
+    -webkit-appearance: none;
+  }
+
+  .textarea__control::-webkit-search-decoration,
+  .textarea__control::-webkit-search-cancel-button,
+  .textarea__control::-webkit-search-results-button,
+  .textarea__control::-webkit-search-results-decoration {
+    -webkit-appearance: none;
+  }
+
+  .textarea__control::placeholder {
+    color: var(--sl-input-placeholder-color);
+    user-select: none;
+  }
+
+  .textarea__control:focus {
+    outline: none;
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .textarea--small {
+    border-radius: var(--sl-input-border-radius-small);
+    font-size: var(--sl-input-font-size-small);
+  }
+
+  .textarea--small .textarea__control {
+    padding: 0.5em var(--sl-input-spacing-small);
+  }
+
+  .textarea--medium {
+    border-radius: var(--sl-input-border-radius-medium);
+    font-size: var(--sl-input-font-size-medium);
+  }
+
+  .textarea--medium .textarea__control {
+    padding: 0.5em var(--sl-input-spacing-medium);
+  }
+
+  .textarea--large {
+    border-radius: var(--sl-input-border-radius-large);
+    font-size: var(--sl-input-font-size-large);
+  }
+
+  .textarea--large .textarea__control {
+    padding: 0.5em var(--sl-input-spacing-large);
+  }
+
+  /*
+   * Resize types
+   */
+
+  .textarea--resize-none .textarea__control {
+    resize: none;
+  }
+
+  .textarea--resize-vertical .textarea__control {
+    resize: vertical;
+  }
+
+  .textarea--resize-auto .textarea__control {
+    height: auto;
+    resize: none;
+  }
+`;
+
+// src/internal/default-value.ts
+var defaultValue = (propertyName = "value") => (proto, key) => {
+  const ctor = proto.constructor;
+  const attributeChangedCallback = ctor.prototype.attributeChangedCallback;
+  ctor.prototype.attributeChangedCallback = function(name, old, value) {
+    var _a;
+    const options = ctor.getPropertyOptions(propertyName);
+    const attributeName = typeof options.attribute === "string" ? options.attribute : propertyName;
+    if (name === attributeName) {
+      const converter = options.converter || o2$2;
+      const fromAttribute = typeof converter === "function" ? converter : (_a = converter == null ? void 0 : converter.fromAttribute) != null ? _a : o2$2.fromAttribute;
+      const newValue = fromAttribute(value, options.type);
+      if (this[propertyName] !== newValue) {
+        this[key] = newValue;
+      }
+    }
+    attributeChangedCallback.call(this, name, old, value);
+  };
+};
+
+// src/internal/formdata-event-polyfill.ts
+var FormDataEventPolyfill = class extends Event {
+  constructor(formData) {
+    super("formdata");
+    this.formData = formData;
+  }
+};
+var FormDataPolyfill = class extends FormData {
+  constructor(form) {
+    var __super = (...args) => {
+      super(...args);
+    };
+    if (form) {
+      __super(form);
+      this.form = form;
+      form.dispatchEvent(new FormDataEventPolyfill(this));
+    } else {
+      __super();
+    }
+  }
+  append(name, value) {
+    if (!this.form) {
+      return super.append(name, value);
+    }
+    let input = this.form.elements[name];
+    if (!input) {
+      input = document.createElement("input");
+      input.type = "hidden";
+      input.name = name;
+      this.form.appendChild(input);
+    }
+    if (this.has(name)) {
+      const entries = this.getAll(name);
+      const index = entries.indexOf(input.value);
+      if (index !== -1) {
+        entries.splice(index, 1);
+      }
+      entries.push(value);
+      this.set(name, entries);
+    } else {
+      super.append(name, value);
+    }
+    input.value = value;
+  }
+};
+function supportsFormDataEvent() {
+  const form = document.createElement("form");
+  let isSupported = false;
+  document.body.append(form);
+  form.addEventListener("submit", (event) => {
+    new FormData(event.target);
+    event.preventDefault();
+  });
+  form.addEventListener("formdata", () => isSupported = true);
+  form.dispatchEvent(new Event("submit", { cancelable: true }));
+  form.remove();
+  return isSupported;
+}
+function polyfillFormData() {
+  if (!window.FormData || supportsFormDataEvent()) {
+    return;
+  }
+  window.FormData = FormDataPolyfill;
+  window.addEventListener("submit", (event) => {
+    if (!event.defaultPrevented) {
+      new FormData(event.target);
+    }
+  });
+}
+if (document.readyState === "complete") {
+  polyfillFormData();
+} else {
+  window.addEventListener("DOMContentLoaded", () => polyfillFormData());
+}
+
+// src/internal/form.ts
+var reportValidityOverloads = /* @__PURE__ */ new WeakMap();
+var FormSubmitController = class {
+  constructor(host, options) {
+    (this.host = host).addController(this);
+    this.options = __spreadValues({
+      form: (input) => input.closest("form"),
+      name: (input) => input.name,
+      value: (input) => input.value,
+      defaultValue: (input) => input.defaultValue,
+      disabled: (input) => input.disabled,
+      reportValidity: (input) => {
+        return typeof input.reportValidity === "function" ? input.reportValidity() : true;
+      },
+      setValue: (input, value) => {
+        input.value = value;
+      }
+    }, options);
+    this.handleFormData = this.handleFormData.bind(this);
+    this.handleFormSubmit = this.handleFormSubmit.bind(this);
+    this.handleFormReset = this.handleFormReset.bind(this);
+    this.reportFormValidity = this.reportFormValidity.bind(this);
+  }
+  hostConnected() {
+    this.form = this.options.form(this.host);
+    if (this.form) {
+      this.form.addEventListener("formdata", this.handleFormData);
+      this.form.addEventListener("submit", this.handleFormSubmit);
+      this.form.addEventListener("reset", this.handleFormReset);
+      if (!reportValidityOverloads.has(this.form)) {
+        reportValidityOverloads.set(this.form, this.form.reportValidity);
+        this.form.reportValidity = () => this.reportFormValidity();
+      }
+    }
+  }
+  hostDisconnected() {
+    if (this.form) {
+      this.form.removeEventListener("formdata", this.handleFormData);
+      this.form.removeEventListener("submit", this.handleFormSubmit);
+      this.form.removeEventListener("reset", this.handleFormReset);
+      if (reportValidityOverloads.has(this.form)) {
+        this.form.reportValidity = reportValidityOverloads.get(this.form);
+        reportValidityOverloads.delete(this.form);
+      }
+      this.form = void 0;
+    }
+  }
+  handleFormData(event) {
+    const disabled = this.options.disabled(this.host);
+    const name = this.options.name(this.host);
+    const value = this.options.value(this.host);
+    if (!disabled && typeof name === "string" && typeof value !== "undefined") {
+      if (Array.isArray(value)) {
+        value.forEach((val) => {
+          event.formData.append(name, val.toString());
+        });
+      } else {
+        event.formData.append(name, value.toString());
+      }
+    }
+  }
+  handleFormSubmit(event) {
+    const disabled = this.options.disabled(this.host);
+    const reportValidity = this.options.reportValidity;
+    if (this.form && !this.form.noValidate && !disabled && !reportValidity(this.host)) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
+  handleFormReset() {
+    this.options.setValue(this.host, this.options.defaultValue(this.host));
+  }
+  reportFormValidity() {
+    if (this.form && !this.form.noValidate) {
+      const elements = this.form.querySelectorAll("*");
+      for (const element of elements) {
+        if (typeof element.reportValidity === "function") {
+          if (!element.reportValidity()) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+  doAction(type, invoker) {
+    if (this.form) {
+      const button = document.createElement("button");
+      button.type = type;
+      button.style.position = "absolute";
+      button.style.width = "0";
+      button.style.height = "0";
+      button.style.clipPath = "inset(50%)";
+      button.style.overflow = "hidden";
+      button.style.whiteSpace = "nowrap";
+      if (invoker) {
+        ["formaction", "formmethod", "formnovalidate", "formtarget"].forEach((attr) => {
+          if (invoker.hasAttribute(attr)) {
+            button.setAttribute(attr, invoker.getAttribute(attr));
+          }
+        });
+      }
+      this.form.append(button);
+      button.click();
+      button.remove();
+    }
+  }
+  reset(invoker) {
+    this.doAction("reset", invoker);
+  }
+  submit(invoker) {
+    this.doAction("submit", invoker);
+  }
+};
+
+// src/internal/slot.ts
+var HasSlotController = class {
+  constructor(host, ...slotNames) {
+    this.slotNames = [];
+    (this.host = host).addController(this);
+    this.slotNames = slotNames;
+    this.handleSlotChange = this.handleSlotChange.bind(this);
+  }
+  hasDefaultSlot() {
+    return [...this.host.childNodes].some((node) => {
+      if (node.nodeType === node.TEXT_NODE && node.textContent.trim() !== "") {
+        return true;
+      }
+      if (node.nodeType === node.ELEMENT_NODE) {
+        const el = node;
+        const tagName = el.tagName.toLowerCase();
+        if (tagName === "sl-visually-hidden") {
+          return false;
+        }
+        if (!el.hasAttribute("slot")) {
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+  hasNamedSlot(name) {
+    return this.host.querySelector(`:scope > [slot="${name}"]`) !== null;
+  }
+  test(slotName) {
+    return slotName === "[default]" ? this.hasDefaultSlot() : this.hasNamedSlot(slotName);
+  }
+  hostConnected() {
+    this.host.shadowRoot.addEventListener("slotchange", this.handleSlotChange);
+  }
+  hostDisconnected() {
+    this.host.shadowRoot.removeEventListener("slotchange", this.handleSlotChange);
+  }
+  handleSlotChange(event) {
+    const slot = event.target;
+    if (this.slotNames.includes("[default]") && !slot.name || slot.name && this.slotNames.includes(slot.name)) {
+      this.host.requestUpdate();
+    }
+  }
+};
+function getTextContent(slot) {
+  if (!slot) {
+    return "";
+  }
+  const nodes = slot.assignedNodes({ flatten: true });
+  let text = "";
+  [...nodes].forEach((node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      text += node.textContent;
+    }
+  });
+  return text;
+}
+
+// node_modules/lit-html/directives/if-defined.js
+var l$2 = (l2) => null != l2 ? l2 : w;
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// src/components/textarea/textarea.ts
+var SlTextarea = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.formSubmitController = new FormSubmitController(this);
+    this.hasSlotController = new HasSlotController(this, "help-text", "label");
+    this.hasFocus = false;
+    this.size = "medium";
+    this.value = "";
+    this.filled = false;
+    this.label = "";
+    this.helpText = "";
+    this.rows = 4;
+    this.resize = "vertical";
+    this.disabled = false;
+    this.readonly = false;
+    this.required = false;
+    this.invalid = false;
+    this.defaultValue = "";
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.resizeObserver = new ResizeObserver(() => this.setTextareaHeight());
+    this.updateComplete.then(() => {
+      this.setTextareaHeight();
+      this.resizeObserver.observe(this.input);
+    });
+  }
+  firstUpdated() {
+    this.invalid = !this.input.checkValidity();
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.resizeObserver.unobserve(this.input);
+  }
+  focus(options) {
+    this.input.focus(options);
+  }
+  blur() {
+    this.input.blur();
+  }
+  select() {
+    this.input.select();
+  }
+  scrollPosition(position) {
+    if (position) {
+      if (typeof position.top === "number")
+        this.input.scrollTop = position.top;
+      if (typeof position.left === "number")
+        this.input.scrollLeft = position.left;
+      return void 0;
+    }
+    return {
+      top: this.input.scrollTop,
+      left: this.input.scrollTop
+    };
+  }
+  setSelectionRange(selectionStart, selectionEnd, selectionDirection = "none") {
+    this.input.setSelectionRange(selectionStart, selectionEnd, selectionDirection);
+  }
+  setRangeText(replacement, start, end, selectMode = "preserve") {
+    this.input.setRangeText(replacement, start, end, selectMode);
+    if (this.value !== this.input.value) {
+      this.value = this.input.value;
+      this.emit("sl-input");
+    }
+    if (this.value !== this.input.value) {
+      this.value = this.input.value;
+      this.setTextareaHeight();
+      this.emit("sl-input");
+      this.emit("sl-change");
+    }
+  }
+  reportValidity() {
+    return this.input.reportValidity();
+  }
+  setCustomValidity(message) {
+    this.input.setCustomValidity(message);
+    this.invalid = !this.input.checkValidity();
+  }
+  handleBlur() {
+    this.hasFocus = false;
+    this.emit("sl-blur");
+  }
+  handleChange() {
+    this.value = this.input.value;
+    this.setTextareaHeight();
+    this.emit("sl-change");
+  }
+  handleDisabledChange() {
+    this.input.disabled = this.disabled;
+    this.invalid = !this.input.checkValidity();
+  }
+  handleFocus() {
+    this.hasFocus = true;
+    this.emit("sl-focus");
+  }
+  handleInput() {
+    this.value = this.input.value;
+    this.emit("sl-input");
+  }
+  handleRowsChange() {
+    this.setTextareaHeight();
+  }
+  handleValueChange() {
+    this.invalid = !this.input.checkValidity();
+    this.updateComplete.then(() => this.setTextareaHeight());
+  }
+  setTextareaHeight() {
+    if (this.resize === "auto") {
+      this.input.style.height = "auto";
+      this.input.style.height = `${this.input.scrollHeight}px`;
+    } else {
+      this.input.style.height = void 0;
+    }
+  }
+  render() {
+    const hasLabelSlot = this.hasSlotController.test("label");
+    const hasHelpTextSlot = this.hasSlotController.test("help-text");
+    const hasLabel = this.label ? true : !!hasLabelSlot;
+    const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
+    return $`
+      <div
+        part="form-control"
+        class=${o$3({
+      "form-control": true,
+      "form-control--small": this.size === "small",
+      "form-control--medium": this.size === "medium",
+      "form-control--large": this.size === "large",
+      "form-control--has-label": hasLabel,
+      "form-control--has-help-text": hasHelpText
+    })}
+      >
+        <label
+          part="form-control-label"
+          class="form-control__label"
+          for="input"
+          aria-hidden=${hasLabel ? "false" : "true"}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <div
+            part="base"
+            class=${o$3({
+      textarea: true,
+      "textarea--small": this.size === "small",
+      "textarea--medium": this.size === "medium",
+      "textarea--large": this.size === "large",
+      "textarea--standard": !this.filled,
+      "textarea--filled": this.filled,
+      "textarea--disabled": this.disabled,
+      "textarea--focused": this.hasFocus,
+      "textarea--empty": !this.value,
+      "textarea--invalid": this.invalid,
+      "textarea--resize-none": this.resize === "none",
+      "textarea--resize-vertical": this.resize === "vertical",
+      "textarea--resize-auto": this.resize === "auto"
+    })}
+          >
+            <textarea
+              part="textarea"
+              id="input"
+              class="textarea__control"
+              name=${l$2(this.name)}
+              .value=${l$3(this.value)}
+              ?disabled=${this.disabled}
+              ?readonly=${this.readonly}
+              ?required=${this.required}
+              placeholder=${l$2(this.placeholder)}
+              rows=${l$2(this.rows)}
+              minlength=${l$2(this.minlength)}
+              maxlength=${l$2(this.maxlength)}
+              autocapitalize=${l$2(this.autocapitalize)}
+              autocorrect=${l$2(this.autocorrect)}
+              ?autofocus=${this.autofocus}
+              spellcheck=${l$2(this.spellcheck)}
+              enterkeyhint=${l$2(this.enterkeyhint)}
+              inputmode=${l$2(this.inputmode)}
+              aria-describedby="help-text"
+              @change=${this.handleChange}
+              @input=${this.handleInput}
+              @focus=${this.handleFocus}
+              @blur=${this.handleBlur}
+            ></textarea>
+          </div>
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${hasHelpText ? "false" : "true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `;
+  }
+};
+SlTextarea.styles = textarea_styles_default;
+__decorateClass([
+  i2$2(".textarea__control")
+], SlTextarea.prototype, "input", 2);
+__decorateClass([
+  t$1()
+], SlTextarea.prototype, "hasFocus", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlTextarea.prototype, "size", 2);
+__decorateClass([
+  e$1()
+], SlTextarea.prototype, "name", 2);
+__decorateClass([
+  e$1()
+], SlTextarea.prototype, "value", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTextarea.prototype, "filled", 2);
+__decorateClass([
+  e$1()
+], SlTextarea.prototype, "label", 2);
+__decorateClass([
+  e$1({ attribute: "help-text" })
+], SlTextarea.prototype, "helpText", 2);
+__decorateClass([
+  e$1()
+], SlTextarea.prototype, "placeholder", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlTextarea.prototype, "rows", 2);
+__decorateClass([
+  e$1()
+], SlTextarea.prototype, "resize", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTextarea.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTextarea.prototype, "readonly", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlTextarea.prototype, "minlength", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlTextarea.prototype, "maxlength", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTextarea.prototype, "required", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTextarea.prototype, "invalid", 2);
+__decorateClass([
+  e$1()
+], SlTextarea.prototype, "autocapitalize", 2);
+__decorateClass([
+  e$1()
+], SlTextarea.prototype, "autocorrect", 2);
+__decorateClass([
+  e$1()
+], SlTextarea.prototype, "autocomplete", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlTextarea.prototype, "autofocus", 2);
+__decorateClass([
+  e$1()
+], SlTextarea.prototype, "enterkeyhint", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlTextarea.prototype, "spellcheck", 2);
+__decorateClass([
+  e$1()
+], SlTextarea.prototype, "inputmode", 2);
+__decorateClass([
+  defaultValue()
+], SlTextarea.prototype, "defaultValue", 2);
+__decorateClass([
+  watch("disabled", { waitUntilFirstUpdate: true })
+], SlTextarea.prototype, "handleDisabledChange", 1);
+__decorateClass([
+  watch("rows", { waitUntilFirstUpdate: true })
+], SlTextarea.prototype, "handleRowsChange", 1);
+__decorateClass([
+  watch("value", { waitUntilFirstUpdate: true })
+], SlTextarea.prototype, "handleValueChange", 1);
+SlTextarea = __decorateClass([
+  n$1("sl-textarea")
+], SlTextarea);
+
+// src/components/split-panel/split-panel.styles.ts
+var split_panel_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --divider-width: 4px;
+    --divider-hit-area: 12px;
+    --min: 0%;
+    --max: 100%;
+
+    display: grid;
+  }
+
+  .start,
+  .end {
+    overflow: hidden;
+  }
+
+  .divider {
+    flex: 0 0 var(--divider-width);
+    display: flex;
+    position: relative;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--sl-color-neutral-200);
+    color: var(--sl-color-neutral-900);
+    z-index: 1;
+  }
+
+  .divider:focus {
+    outline: none;
+  }
+
+  :host(:not([disabled])) .divider:focus-visible {
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  :host([disabled]) .divider {
+    cursor: not-allowed;
+  }
+
+  /* Horizontal */
+  :host(:not([vertical], [disabled])) .divider {
+    cursor: col-resize;
+  }
+
+  :host(:not([vertical])) .divider::after {
+    display: flex;
+    content: '';
+    position: absolute;
+    height: 100%;
+    left: calc(var(--divider-hit-area) / -2 + var(--divider-width) / 2);
+    width: var(--divider-hit-area);
+  }
+
+  /* Vertical */
+  :host([vertical]) {
+    flex-direction: column;
+  }
+
+  :host([vertical]:not([disabled])) .divider {
+    cursor: row-resize;
+  }
+
+  :host([vertical]) .divider::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    top: calc(var(--divider-hit-area) / -2 + var(--divider-width) / 2);
+    height: var(--divider-hit-area);
+  }
+`;
+
+// src/internal/drag.ts
+function drag(container, options) {
+  var _a;
+  function move(pointerEvent) {
+    const dims = container.getBoundingClientRect();
+    const defaultView = container.ownerDocument.defaultView;
+    const offsetX = dims.left + defaultView.pageXOffset;
+    const offsetY = dims.top + defaultView.pageYOffset;
+    const x = pointerEvent.pageX - offsetX;
+    const y = pointerEvent.pageY - offsetY;
+    if (options == null ? void 0 : options.onMove) {
+      options.onMove(x, y);
+    }
+  }
+  function stop() {
+    document.removeEventListener("pointermove", move);
+    document.removeEventListener("pointerup", stop);
+    if (options == null ? void 0 : options.onStop) {
+      options.onStop();
+    }
+  }
+  document.addEventListener("pointermove", move, { passive: true });
+  document.addEventListener("pointerup", stop);
+  if (((_a = options == null ? void 0 : options.initialEvent) == null ? void 0 : _a.type) === "pointermove") {
+    move(options.initialEvent);
+  }
+}
+
+// src/components/split-panel/split-panel.ts
+var SlSplitPanel = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.position = 50;
+    this.vertical = false;
+    this.disabled = false;
+    this.snapThreshold = 12;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.resizeObserver = new ResizeObserver((entries) => this.handleResize(entries));
+    this.updateComplete.then(() => this.resizeObserver.observe(this));
+    this.detectSize();
+    this.cachedPositionInPixels = this.percentageToPixels(this.position);
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.resizeObserver.unobserve(this);
+  }
+  detectSize() {
+    const { width, height } = this.getBoundingClientRect();
+    this.size = this.vertical ? height : width;
+  }
+  percentageToPixels(value) {
+    return this.size * (value / 100);
+  }
+  pixelsToPercentage(value) {
+    return value / this.size * 100;
+  }
+  handleDrag(event) {
+    const isRtl = this.localize.dir() === "rtl";
+    if (this.disabled) {
+      return;
+    }
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+    drag(this, {
+      onMove: (x, y) => {
+        let newPositionInPixels = this.vertical ? y : x;
+        if (this.primary === "end") {
+          newPositionInPixels = this.size - newPositionInPixels;
+        }
+        if (this.snap) {
+          const snaps = this.snap.split(" ");
+          snaps.forEach((value) => {
+            let snapPoint;
+            if (value.endsWith("%")) {
+              snapPoint = this.size * (parseFloat(value) / 100);
+            } else {
+              snapPoint = parseFloat(value);
+            }
+            if (isRtl && !this.vertical) {
+              snapPoint = this.size - snapPoint;
+            }
+            if (newPositionInPixels >= snapPoint - this.snapThreshold && newPositionInPixels <= snapPoint + this.snapThreshold) {
+              newPositionInPixels = snapPoint;
+            }
+          });
+        }
+        this.position = clamp(this.pixelsToPercentage(newPositionInPixels), 0, 100);
+      },
+      initialEvent: event
+    });
+  }
+  handleKeyDown(event) {
+    if (this.disabled) {
+      return;
+    }
+    if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"].includes(event.key)) {
+      let newPosition = this.position;
+      const incr = (event.shiftKey ? 10 : 1) * (this.primary === "end" ? -1 : 1);
+      event.preventDefault();
+      if (event.key === "ArrowLeft" && !this.vertical || event.key === "ArrowUp" && this.vertical) {
+        newPosition -= incr;
+      }
+      if (event.key === "ArrowRight" && !this.vertical || event.key === "ArrowDown" && this.vertical) {
+        newPosition += incr;
+      }
+      if (event.key === "Home") {
+        newPosition = this.primary === "end" ? 100 : 0;
+      }
+      if (event.key === "End") {
+        newPosition = this.primary === "end" ? 0 : 100;
+      }
+      this.position = clamp(newPosition, 0, 100);
+    }
+  }
+  handlePositionChange() {
+    this.cachedPositionInPixels = this.percentageToPixels(this.position);
+    this.positionInPixels = this.percentageToPixels(this.position);
+    this.emit("sl-reposition");
+  }
+  handlePositionInPixelsChange() {
+    this.position = this.pixelsToPercentage(this.positionInPixels);
+  }
+  handleVerticalChange() {
+    this.detectSize();
+  }
+  handleResize(entries) {
+    const { width, height } = entries[0].contentRect;
+    this.size = this.vertical ? height : width;
+    if (this.primary) {
+      this.position = this.pixelsToPercentage(this.cachedPositionInPixels);
+    }
+  }
+  render() {
+    const gridTemplate = this.vertical ? "gridTemplateRows" : "gridTemplateColumns";
+    const gridTemplateAlt = this.vertical ? "gridTemplateColumns" : "gridTemplateRows";
+    const isRtl = this.localize.dir() === "rtl";
+    const primary = `
+      clamp(
+        0%,
+        clamp(
+          var(--min),
+          ${this.position}% - var(--divider-width) / 2,
+          var(--max)
+        ),
+        calc(100% - var(--divider-width))
+      )
+    `;
+    const secondary = "auto";
+    if (this.primary === "end") {
+      if (isRtl && !this.vertical) {
+        this.style[gridTemplate] = `${primary} var(--divider-width) ${secondary}`;
+      } else {
+        this.style[gridTemplate] = `${secondary} var(--divider-width) ${primary}`;
+      }
+    } else {
+      if (isRtl && !this.vertical) {
+        this.style[gridTemplate] = `${secondary} var(--divider-width) ${primary}`;
+      } else {
+        this.style[gridTemplate] = `${primary} var(--divider-width) ${secondary}`;
+      }
+    }
+    this.style[gridTemplateAlt] = "";
+    return $`
+      <div part="panel start" class="start">
+        <slot name="start"></slot>
+      </div>
+
+      <div
+        part="divider"
+        class="divider"
+        tabindex=${l$2(this.disabled ? void 0 : "0")}
+        role="separator"
+        aria-label=${this.localize.term("resize")}
+        @keydown=${this.handleKeyDown}
+        @mousedown=${this.handleDrag}
+        @touchstart=${this.handleDrag}
+      >
+        <slot name="handle"></slot>
+      </div>
+
+      <div part="panel end" class="end">
+        <slot name="end"></slot>
+      </div>
+    `;
+  }
+};
+SlSplitPanel.styles = split_panel_styles_default;
+__decorateClass([
+  i2$2(".divider")
+], SlSplitPanel.prototype, "divider", 2);
+__decorateClass([
+  e$1({ type: Number, reflect: true })
+], SlSplitPanel.prototype, "position", 2);
+__decorateClass([
+  e$1({ attribute: "position-in-pixels", type: Number })
+], SlSplitPanel.prototype, "positionInPixels", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSplitPanel.prototype, "vertical", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSplitPanel.prototype, "disabled", 2);
+__decorateClass([
+  e$1()
+], SlSplitPanel.prototype, "primary", 2);
+__decorateClass([
+  e$1()
+], SlSplitPanel.prototype, "snap", 2);
+__decorateClass([
+  e$1({ type: Number, attribute: "snap-threshold" })
+], SlSplitPanel.prototype, "snapThreshold", 2);
+__decorateClass([
+  watch("position")
+], SlSplitPanel.prototype, "handlePositionChange", 1);
+__decorateClass([
+  watch("positionInPixels")
+], SlSplitPanel.prototype, "handlePositionInPixelsChange", 1);
+__decorateClass([
+  watch("vertical")
+], SlSplitPanel.prototype, "handleVerticalChange", 1);
+SlSplitPanel = __decorateClass([
+  n$1("sl-split-panel")
+], SlSplitPanel);
+
+// src/components/switch/switch.styles.ts
+var switch_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --height: var(--sl-toggle-size);
+    --thumb-size: calc(var(--sl-toggle-size) + 4px);
+    --width: calc(var(--height) * 2);
+
+    display: inline-block;
+  }
+
+  .switch {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--sl-input-font-family);
+    font-size: var(--sl-input-font-size-medium);
+    font-weight: var(--sl-input-font-weight);
+    color: var(--sl-input-color);
+    vertical-align: middle;
+    cursor: pointer;
+  }
+
+  .switch__control {
+    flex: 0 0 auto;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--width);
+    height: var(--height);
+    background-color: var(--sl-color-neutral-400);
+    border: solid var(--sl-input-border-width) var(--sl-color-neutral-400);
+    border-radius: var(--height);
+    transition: var(--sl-transition-fast) border-color, var(--sl-transition-fast) background-color;
+  }
+
+  .switch__control .switch__thumb {
+    width: var(--thumb-size);
+    height: var(--thumb-size);
+    background-color: var(--sl-color-neutral-0);
+    border-radius: 50%;
+    border: solid var(--sl-input-border-width) var(--sl-color-neutral-400);
+    transform: translateX(calc((var(--width) - var(--height)) / -2));
+    transition: var(--sl-transition-fast) transform ease, var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) border-color, var(--sl-transition-fast) box-shadow;
+  }
+
+  .switch__input {
+    position: absolute;
+    opacity: 0;
+    padding: 0;
+    margin: 0;
+    pointer-events: none;
+  }
+
+  /* Hover */
+  .switch:not(.switch--checked):not(.switch--disabled) .switch__control:hover {
+    background-color: var(--sl-color-neutral-400);
+    border-color: var(--sl-color-neutral-400);
+  }
+
+  .switch:not(.switch--checked):not(.switch--disabled) .switch__control:hover .switch__thumb {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-neutral-400);
+  }
+
+  /* Focus */
+  .switch:not(.switch--checked):not(.switch--disabled) .switch__input:focus-visible ~ .switch__control {
+    background-color: var(--sl-color-neutral-400);
+    border-color: var(--sl-color-neutral-400);
+  }
+
+  .switch:not(.switch--checked):not(.switch--disabled) .switch__input:focus-visible ~ .switch__control .switch__thumb {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-primary-600);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Checked */
+  .switch--checked .switch__control {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+  }
+
+  .switch--checked .switch__control .switch__thumb {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-primary-600);
+    transform: translateX(calc((var(--width) - var(--height)) / 2));
+  }
+
+  /* Checked + hover */
+  .switch.switch--checked:not(.switch--disabled) .switch__control:hover {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+  }
+
+  .switch.switch--checked:not(.switch--disabled) .switch__control:hover .switch__thumb {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-primary-600);
+  }
+
+  /* Checked + focus */
+  .switch.switch--checked:not(.switch--disabled) .switch__input:focus-visible ~ .switch__control {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+  }
+
+  .switch.switch--checked:not(.switch--disabled) .switch__input:focus-visible ~ .switch__control .switch__thumb {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-primary-600);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Disabled */
+  .switch--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .switch__label {
+    line-height: var(--height);
+    margin-inline-start: 0.5em;
+    user-select: none;
+  }
+
+  :host([required]) .switch__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+`;
+
+// src/components/switch/switch.ts
+var SlSwitch = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.formSubmitController = new FormSubmitController(this, {
+      value: (control) => control.checked ? control.value : void 0,
+      defaultValue: (control) => control.defaultChecked,
+      setValue: (control, checked) => control.checked = checked
+    });
+    this.hasFocus = false;
+    this.disabled = false;
+    this.required = false;
+    this.checked = false;
+    this.invalid = false;
+    this.defaultChecked = false;
+  }
+  firstUpdated() {
+    this.invalid = !this.input.checkValidity();
+  }
+  click() {
+    this.input.click();
+  }
+  focus(options) {
+    this.input.focus(options);
+  }
+  blur() {
+    this.input.blur();
+  }
+  reportValidity() {
+    return this.input.reportValidity();
+  }
+  setCustomValidity(message) {
+    this.input.setCustomValidity(message);
+    this.invalid = !this.input.checkValidity();
+  }
+  handleBlur() {
+    this.hasFocus = false;
+    this.emit("sl-blur");
+  }
+  handleCheckedChange() {
+    this.input.checked = this.checked;
+    this.invalid = !this.input.checkValidity();
+  }
+  handleClick() {
+    this.checked = !this.checked;
+    this.emit("sl-change");
+  }
+  handleDisabledChange() {
+    this.input.disabled = this.disabled;
+    this.invalid = !this.input.checkValidity();
+  }
+  handleFocus() {
+    this.hasFocus = true;
+    this.emit("sl-focus");
+  }
+  handleKeyDown(event) {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      this.checked = false;
+      this.emit("sl-change");
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      this.checked = true;
+      this.emit("sl-change");
+    }
+  }
+  render() {
+    return $`
+      <label
+        part="base"
+        class=${o$3({
+      switch: true,
+      "switch--checked": this.checked,
+      "switch--disabled": this.disabled,
+      "switch--focused": this.hasFocus
+    })}
+      >
+        <input
+          class="switch__input"
+          type="checkbox"
+          name=${l$2(this.name)}
+          value=${l$2(this.value)}
+          .checked=${l$3(this.checked)}
+          .disabled=${this.disabled}
+          .required=${this.required}
+          role="switch"
+          aria-checked=${this.checked ? "true" : "false"}
+          @click=${this.handleClick}
+          @blur=${this.handleBlur}
+          @focus=${this.handleFocus}
+          @keydown=${this.handleKeyDown}
+        />
+
+        <span part="control" class="switch__control">
+          <span part="thumb" class="switch__thumb"></span>
+        </span>
+
+        <span part="label" class="switch__label">
+          <slot></slot>
+        </span>
+      </label>
+    `;
+  }
+};
+SlSwitch.styles = switch_styles_default;
+__decorateClass([
+  i2$2('input[type="checkbox"]')
+], SlSwitch.prototype, "input", 2);
+__decorateClass([
+  t$1()
+], SlSwitch.prototype, "hasFocus", 2);
+__decorateClass([
+  e$1()
+], SlSwitch.prototype, "name", 2);
+__decorateClass([
+  e$1()
+], SlSwitch.prototype, "value", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSwitch.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSwitch.prototype, "required", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSwitch.prototype, "checked", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSwitch.prototype, "invalid", 2);
+__decorateClass([
+  defaultValue("checked")
+], SlSwitch.prototype, "defaultChecked", 2);
+__decorateClass([
+  watch("checked", { waitUntilFirstUpdate: true })
+], SlSwitch.prototype, "handleCheckedChange", 1);
+__decorateClass([
+  watch("disabled", { waitUntilFirstUpdate: true })
+], SlSwitch.prototype, "handleDisabledChange", 1);
+SlSwitch = __decorateClass([
+  n$1("sl-switch")
+], SlSwitch);
+
+// src/components/tab/tab.styles.ts
+var tab_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .tab {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-small);
+    font-weight: var(--sl-font-weight-semibold);
+    border-radius: var(--sl-border-radius-medium);
+    color: var(--sl-color-neutral-600);
+    padding: var(--sl-spacing-medium) var(--sl-spacing-large);
+    white-space: nowrap;
+    user-select: none;
+    cursor: pointer;
+    transition: var(--transition-speed) box-shadow, var(--transition-speed) color;
+  }
+
+  .tab:hover:not(.tab--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  .tab:focus {
+    outline: none;
+  }
+
+  .tab:focus-visible:not(.tab--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  .tab:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: calc(-1 * var(--sl-focus-ring-width) - var(--sl-focus-ring-offset));
+  }
+
+  .tab.tab--active:not(.tab--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  .tab.tab--closable {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .tab.tab--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .tab__close-button {
+    font-size: var(--sl-font-size-large);
+    margin-inline-start: var(--sl-spacing-2x-small);
+  }
+
+  .tab__close-button::part(base) {
+    padding: var(--sl-spacing-3x-small);
+  }
+`;
+
+// src/components/tab/tab.ts
+var SlTab = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.attrId = autoIncrement();
+    this.componentId = `sl-tab-${this.attrId}`;
+    this.panel = "";
+    this.active = false;
+    this.closable = false;
+    this.disabled = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("role", "tab");
+  }
+  focus(options) {
+    this.tab.focus(options);
+  }
+  blur() {
+    this.tab.blur();
+  }
+  handleCloseClick() {
+    this.emit("sl-close");
+  }
+  handleActiveChange() {
+    this.setAttribute("aria-selected", this.active ? "true" : "false");
+  }
+  handleDisabledChange() {
+    this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+  }
+  render() {
+    this.id = this.id.length > 0 ? this.id : this.componentId;
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      tab: true,
+      "tab--active": this.active,
+      "tab--closable": this.closable,
+      "tab--disabled": this.disabled
+    })}
+        tabindex=${this.disabled ? "-1" : "0"}
+      >
+        <slot></slot>
+        ${this.closable ? $`
+              <sl-icon-button
+                part="close-button"
+                exportparts="base:close-button__base"
+                name="x"
+                library="system"
+                label=${this.localize.term("close")}
+                class="tab__close-button"
+                @click=${this.handleCloseClick}
+                tabindex="-1"
+              ></sl-icon-button>
+            ` : ""}
+      </div>
+    `;
+  }
+};
+SlTab.styles = tab_styles_default;
+__decorateClass([
+  i2$2(".tab")
+], SlTab.prototype, "tab", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlTab.prototype, "panel", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTab.prototype, "active", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlTab.prototype, "closable", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTab.prototype, "disabled", 2);
+__decorateClass([
+  watch("active")
+], SlTab.prototype, "handleActiveChange", 1);
+__decorateClass([
+  watch("disabled")
+], SlTab.prototype, "handleDisabledChange", 1);
+SlTab = __decorateClass([
+  n$1("sl-tab")
+], SlTab);
+
+// src/components/resize-observer/resize-observer.styles.ts
+var resize_observer_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: contents;
+  }
+`;
+
+// src/components/resize-observer/resize-observer.ts
+var SlResizeObserver = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.observedElements = [];
+    this.disabled = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.resizeObserver = new ResizeObserver((entries) => {
+      this.emit("sl-resize", { detail: { entries } });
+    });
+    if (!this.disabled) {
+      this.startObserver();
+    }
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.stopObserver();
+  }
+  handleSlotChange() {
+    if (!this.disabled) {
+      this.startObserver();
+    }
+  }
+  startObserver() {
+    const slot = this.shadowRoot.querySelector("slot");
+    if (slot !== null) {
+      const elements = slot.assignedElements({ flatten: true });
+      this.observedElements.forEach((el) => this.resizeObserver.unobserve(el));
+      this.observedElements = [];
+      elements.forEach((el) => {
+        this.resizeObserver.observe(el);
+        this.observedElements.push(el);
+      });
+    }
+  }
+  stopObserver() {
+    this.resizeObserver.disconnect();
+  }
+  handleDisabledChange() {
+    if (this.disabled) {
+      this.stopObserver();
+    } else {
+      this.startObserver();
+    }
+  }
+  render() {
+    return $` <slot @slotchange=${this.handleSlotChange}></slot> `;
+  }
+};
+SlResizeObserver.styles = resize_observer_styles_default;
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlResizeObserver.prototype, "disabled", 2);
+__decorateClass([
+  watch("disabled", { waitUntilFirstUpdate: true })
+], SlResizeObserver.prototype, "handleDisabledChange", 1);
+SlResizeObserver = __decorateClass([
+  n$1("sl-resize-observer")
+], SlResizeObserver);
+
+// src/components/relative-time/relative-time.ts
+var availableUnits = [
+  { max: 276e4, value: 6e4, unit: "minute" },
+  { max: 72e6, value: 36e5, unit: "hour" },
+  { max: 5184e5, value: 864e5, unit: "day" },
+  { max: 24192e5, value: 6048e5, unit: "week" },
+  { max: 28512e6, value: 2592e6, unit: "month" },
+  { max: Infinity, value: 31536e6, unit: "year" }
+];
+var SlRelativeTime = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.isoTime = "";
+    this.relativeTime = "";
+    this.titleTime = "";
+    this.format = "long";
+    this.numeric = "auto";
+    this.sync = false;
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearTimeout(this.updateTimeout);
+  }
+  render() {
+    const now = new Date();
+    const then = new Date(this.date);
+    if (isNaN(then.getMilliseconds())) {
+      this.relativeTime = "";
+      this.isoTime = "";
+      return "";
+    }
+    const diff = then.getTime() - now.getTime();
+    const { unit, value } = availableUnits.find((singleUnit) => Math.abs(diff) < singleUnit.max);
+    this.isoTime = then.toISOString();
+    this.titleTime = this.localize.date(then, {
+      month: "long",
+      year: "numeric",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      timeZoneName: "short"
+    });
+    this.relativeTime = this.localize.relativeTime(Math.round(diff / value), unit, {
+      numeric: this.numeric,
+      style: this.format
+    });
+    clearTimeout(this.updateTimeout);
+    if (this.sync) {
+      let nextInterval;
+      if (unit === "minute") {
+        nextInterval = getTimeUntilNextUnit("second");
+      } else if (unit === "hour") {
+        nextInterval = getTimeUntilNextUnit("minute");
+      } else if (unit === "day") {
+        nextInterval = getTimeUntilNextUnit("hour");
+      } else {
+        nextInterval = getTimeUntilNextUnit("day");
+      }
+      this.updateTimeout = window.setTimeout(() => this.requestUpdate(), nextInterval);
+    }
+    return $` <time datetime=${this.isoTime} title=${this.titleTime}>${this.relativeTime}</time> `;
+  }
+};
+__decorateClass([
+  t$1()
+], SlRelativeTime.prototype, "isoTime", 2);
+__decorateClass([
+  t$1()
+], SlRelativeTime.prototype, "relativeTime", 2);
+__decorateClass([
+  t$1()
+], SlRelativeTime.prototype, "titleTime", 2);
+__decorateClass([
+  e$1()
+], SlRelativeTime.prototype, "date", 2);
+__decorateClass([
+  e$1()
+], SlRelativeTime.prototype, "format", 2);
+__decorateClass([
+  e$1()
+], SlRelativeTime.prototype, "numeric", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlRelativeTime.prototype, "sync", 2);
+SlRelativeTime = __decorateClass([
+  n$1("sl-relative-time")
+], SlRelativeTime);
+function getTimeUntilNextUnit(unit) {
+  const units = { second: 1e3, minute: 6e4, hour: 36e5, day: 864e5 };
+  const value = units[unit];
+  return value - Date.now() % value;
+}
+
+// src/components/select/select.styles.ts
+var select_styles_default = r$2`
+  ${component_styles_default}
+  ${form_control_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .select {
+    display: block;
+  }
+
+  .select::part(panel) {
+    overflow: hidden;
+  }
+
+  .select__control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: start;
+    position: relative;
+    width: 100%;
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-input-font-weight);
+    letter-spacing: var(--sl-input-letter-spacing);
+    vertical-align: middle;
+    overflow: hidden;
+    transition: var(--sl-transition-fast) color, var(--sl-transition-fast) border, var(--sl-transition-fast) box-shadow;
+    cursor: pointer;
+  }
+
+  .select::part(panel) {
+    border-radius: var(--sl-border-radius-medium);
+  }
+
+  /* Standard selects */
+  .select--standard .select__control {
+    background-color: var(--sl-input-background-color);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+    color: var(--sl-input-color);
+  }
+
+  .select--standard:not(.select--disabled) .select__control:hover {
+    background-color: var(--sl-input-background-color-hover);
+    border-color: var(--sl-input-border-color-hover);
+    color: var(--sl-input-color-hover);
+  }
+
+  .select--standard.select--focused:not(.select--disabled) .select__control {
+    background-color: var(--sl-input-background-color-focus);
+    border-color: var(--sl-input-border-color-focus);
+    color: var(--sl-input-color-focus);
+    box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-input-focus-ring-color);
+    outline: none;
+  }
+
+  .select--standard.select--disabled .select__control {
+    background-color: var(--sl-input-background-color-disabled);
+    border-color: var(--sl-input-border-color-disabled);
+    color: var(--sl-input-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+    outline: none;
+  }
+
+  /* Filled selects */
+  .select--filled .select__control {
+    border: none;
+    background-color: var(--sl-input-filled-background-color);
+    color: var(--sl-input-color);
+  }
+
+  .select--filled:hover:not(.select--disabled) .select__control {
+    background-color: var(--sl-input-filled-background-color-hover);
+  }
+
+  .select--filled.select--focused:not(.select--disabled) .select__control {
+    background-color: var(--sl-input-filled-background-color-focus);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .select--filled.select--disabled .select__control {
+    background-color: var(--sl-input-filled-background-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .select--disabled .select__tags,
+  .select--disabled .select__clear {
+    pointer-events: none;
+  }
+
+  .select__prefix {
+    display: inline-flex;
+    align-items: center;
+    color: var(--sl-input-placeholder-color);
+  }
+
+  .select__label {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    user-select: none;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+
+    /* Hide scrollbar in Firefox */
+    scrollbar-width: none;
+  }
+
+  /* Hide scrollbar in Chrome/Safari */
+  .select__label::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .select__clear {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    width: 1.25em;
+    font-size: inherit;
+    color: var(--sl-input-icon-color);
+    border: none;
+    background: none;
+    padding: 0;
+    transition: var(--sl-transition-fast) color;
+    cursor: pointer;
+  }
+
+  .select__clear:hover {
+    color: var(--sl-input-icon-color-hover);
+  }
+
+  .select__suffix {
+    display: inline-flex;
+    align-items: center;
+    color: var(--sl-input-placeholder-color);
+  }
+
+  .select__icon {
+    flex: 0 0 auto;
+    display: inline-flex;
+    transition: var(--sl-transition-medium) transform ease;
+  }
+
+  .select--open .select__icon {
+    transform: rotate(-180deg);
+  }
+
+  /* Placeholder */
+  .select--placeholder-visible .select__label {
+    color: var(--sl-input-placeholder-color);
+  }
+
+  .select--disabled.select--placeholder-visible .select__label {
+    color: var(--sl-input-placeholder-color-disabled);
+  }
+
+  /* Tags */
+  .select__tags {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: left;
+    margin-inline-start: var(--sl-spacing-2x-small);
+  }
+
+  /* Hidden input (for form control validation to show) */
+  .select__hidden-select {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  /* Small */
+  .select--small .select__control {
+    border-radius: var(--sl-input-border-radius-small);
+    font-size: var(--sl-input-font-size-small);
+    min-height: var(--sl-input-height-small);
+  }
+
+  .select--small .select__prefix ::slotted(*) {
+    margin-inline-start: var(--sl-input-spacing-small);
+  }
+
+  .select--small .select__label {
+    margin: 0 var(--sl-input-spacing-small);
+  }
+
+  .select--small .select__clear {
+    margin-inline-end: var(--sl-input-spacing-small);
+  }
+
+  .select--small .select__suffix ::slotted(*) {
+    margin-inline-end: var(--sl-input-spacing-small);
+  }
+
+  .select--small .select__icon {
+    margin-inline-end: var(--sl-input-spacing-small);
+  }
+
+  .select--small .select__tags {
+    padding-bottom: 2px;
+  }
+
+  .select--small .select__tags sl-tag {
+    padding-top: 2px;
+  }
+
+  .select--small .select__tags sl-tag:not(:last-of-type) {
+    margin-inline-end: var(--sl-spacing-2x-small);
+  }
+
+  .select--small.select--has-tags .select__label {
+    margin-inline-start: 0;
+  }
+
+  /* Medium */
+  .select--medium .select__control {
+    border-radius: var(--sl-input-border-radius-medium);
+    font-size: var(--sl-input-font-size-medium);
+    min-height: var(--sl-input-height-medium);
+  }
+
+  .select--medium .select__prefix ::slotted(*) {
+    margin-inline-start: var(--sl-input-spacing-medium);
+  }
+
+  .select--medium .select__label {
+    margin: 0 var(--sl-input-spacing-medium);
+  }
+
+  .select--medium .select__clear {
+    margin-inline-end: var(--sl-input-spacing-medium);
+  }
+
+  .select--medium .select__suffix ::slotted(*) {
+    margin-inline-end: var(--sl-input-spacing-medium);
+  }
+
+  .select--medium .select__icon {
+    margin-inline-end: var(--sl-input-spacing-medium);
+  }
+
+  .select--medium .select__tags {
+    padding-bottom: 3px;
+  }
+
+  .select--medium .select__tags sl-tag {
+    padding-top: 3px;
+  }
+
+  .select--medium .select__tags sl-tag:not(:last-of-type) {
+    margin-inline-end: var(--sl-spacing-2x-small);
+  }
+
+  .select--medium.select--has-tags .select__label {
+    margin-inline-start: 0;
+  }
+
+  /* Large */
+  .select--large .select__control {
+    border-radius: var(--sl-input-border-radius-large);
+    font-size: var(--sl-input-font-size-large);
+    min-height: var(--sl-input-height-large);
+  }
+
+  .select--large .select__prefix ::slotted(*) {
+    margin-inline-start: var(--sl-input-spacing-large);
+  }
+
+  .select--large .select__label {
+    margin: 0 var(--sl-input-spacing-large);
+  }
+
+  .select--large .select__clear {
+    margin-inline-end: var(--sl-input-spacing-large);
+  }
+
+  .select--large .select__suffix ::slotted(*) {
+    margin-inline-end: var(--sl-input-spacing-large);
+  }
+
+  .select--large .select__icon {
+    margin-inline-end: var(--sl-input-spacing-large);
+  }
+
+  .select--large .select__tags {
+    padding-bottom: 4px;
+  }
+  .select--large .select__tags sl-tag {
+    padding-top: 4px;
+  }
+
+  .select--large .select__tags sl-tag:not(:last-of-type) {
+    margin-inline-end: var(--sl-spacing-2x-small);
+  }
+
+  .select--large.select--has-tags .select__label {
+    margin-inline-start: 0;
+  }
+
+  /*
+   * Pill modifier
+   */
+  .select--pill.select--small .select__control {
+    border-radius: var(--sl-input-height-small);
+  }
+
+  .select--pill.select--medium .select__control {
+    border-radius: var(--sl-input-height-medium);
+  }
+
+  .select--pill.select--large .select__control {
+    border-radius: var(--sl-input-height-large);
+  }
+`;
+
+// src/components/select/select.ts
+var SlSelect = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.formSubmitController = new FormSubmitController(this);
+    this.hasSlotController = new HasSlotController(this, "help-text", "label");
+    this.localize = new LocalizeController2(this);
+    this.menuItems = [];
+    this.hasFocus = false;
+    this.isOpen = false;
+    this.displayLabel = "";
+    this.displayTags = [];
+    this.multiple = false;
+    this.maxTagsVisible = 3;
+    this.disabled = false;
+    this.name = "";
+    this.placeholder = "";
+    this.size = "medium";
+    this.hoist = false;
+    this.value = "";
+    this.filled = false;
+    this.pill = false;
+    this.label = "";
+    this.placement = "bottom";
+    this.helpText = "";
+    this.required = false;
+    this.clearable = false;
+    this.invalid = false;
+    this.defaultValue = "";
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.resizeObserver = new ResizeObserver(() => this.resizeMenu());
+    this.updateComplete.then(() => {
+      this.resizeObserver.observe(this);
+      this.syncItemsFromValue();
+    });
+  }
+  firstUpdated() {
+    this.invalid = !this.input.checkValidity();
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.resizeObserver.unobserve(this);
+  }
+  reportValidity() {
+    return this.input.reportValidity();
+  }
+  setCustomValidity(message) {
+    this.input.setCustomValidity(message);
+    this.invalid = !this.input.checkValidity();
+  }
+  getValueAsArray() {
+    if (this.multiple && this.value === "") {
+      return [];
+    }
+    return Array.isArray(this.value) ? this.value : [this.value];
+  }
+  focus(options) {
+    this.control.focus(options);
+  }
+  blur() {
+    this.control.blur();
+  }
+  handleBlur() {
+    if (!this.isOpen) {
+      this.hasFocus = false;
+      this.emit("sl-blur");
+    }
+  }
+  handleClearClick(event) {
+    event.stopPropagation();
+    this.value = this.multiple ? [] : "";
+    this.emit("sl-clear");
+    this.syncItemsFromValue();
+  }
+  handleDisabledChange() {
+    if (this.disabled && this.isOpen) {
+      this.dropdown.hide();
+    }
+    this.input.disabled = this.disabled;
+    this.invalid = !this.input.checkValidity();
+  }
+  handleFocus() {
+    if (!this.hasFocus) {
+      this.hasFocus = true;
+      this.emit("sl-focus");
+    }
+  }
+  handleKeyDown(event) {
+    const target = event.target;
+    const firstItem = this.menuItems[0];
+    const lastItem = this.menuItems[this.menuItems.length - 1];
+    if (target.tagName.toLowerCase() === "sl-tag") {
+      return;
+    }
+    if (event.key === "Tab") {
+      if (this.isOpen) {
+        this.dropdown.hide();
+      }
+      return;
+    }
+    if (["ArrowDown", "ArrowUp"].includes(event.key)) {
+      event.preventDefault();
+      if (!this.isOpen) {
+        this.dropdown.show();
+      }
+      if (event.key === "ArrowDown") {
+        this.menu.setCurrentItem(firstItem);
+        firstItem.focus();
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        this.menu.setCurrentItem(lastItem);
+        lastItem.focus();
+        return;
+      }
+    }
+    if (event.ctrlKey || event.metaKey) {
+      return;
+    }
+    if (!this.isOpen && event.key.length === 1) {
+      event.stopPropagation();
+      event.preventDefault();
+      this.dropdown.show();
+      this.menu.typeToSelect(event);
+    }
+  }
+  handleLabelClick() {
+    this.focus();
+  }
+  handleMenuSelect(event) {
+    const item = event.detail.item;
+    if (this.multiple) {
+      this.value = this.value.includes(item.value) ? this.value.filter((v) => v !== item.value) : [...this.value, item.value];
+    } else {
+      this.value = item.value;
+    }
+    this.syncItemsFromValue();
+  }
+  handleMenuShow() {
+    this.resizeMenu();
+    this.isOpen = true;
+  }
+  handleMenuHide() {
+    this.isOpen = false;
+    this.control.focus();
+  }
+  handleMenuItemLabelChange() {
+    if (!this.multiple) {
+      const checkedItem = this.menuItems.find((item) => item.value === this.value);
+      this.displayLabel = checkedItem ? checkedItem.getTextLabel() : "";
+    }
+  }
+  handleMultipleChange() {
+    var _a;
+    const value = this.getValueAsArray();
+    this.value = this.multiple ? value : (_a = value[0]) != null ? _a : "";
+    this.syncItemsFromValue();
+  }
+  async handleMenuSlotChange() {
+    this.menuItems = [...this.querySelectorAll("sl-menu-item")];
+    const values = [];
+    this.menuItems.forEach((item) => {
+      if (values.includes(item.value)) {
+        console.error(`Duplicate value found in <sl-select> menu item: '${item.value}'`, item);
+      }
+      values.push(item.value);
+    });
+    await Promise.all(this.menuItems.map((item) => item.render));
+    this.syncItemsFromValue();
+  }
+  handleTagInteraction(event) {
+    const path = event.composedPath();
+    const clearButton = path.find((el) => {
+      if (el instanceof HTMLElement) {
+        const element = el;
+        return element.classList.contains("tag__remove");
+      }
+      return false;
+    });
+    if (clearButton) {
+      event.stopPropagation();
+    }
+  }
+  async handleValueChange() {
+    this.syncItemsFromValue();
+    await this.updateComplete;
+    this.invalid = !this.input.checkValidity();
+    this.emit("sl-change");
+  }
+  resizeMenu() {
+    this.menu.style.width = `${this.control.clientWidth}px`;
+    requestAnimationFrame(() => this.dropdown.reposition());
+  }
+  syncItemsFromValue() {
+    const value = this.getValueAsArray();
+    this.menuItems.forEach((item) => item.checked = value.includes(item.value));
+    if (this.multiple) {
+      const checkedItems = this.menuItems.filter((item) => value.includes(item.value));
+      this.displayLabel = checkedItems.length > 0 ? checkedItems[0].getTextLabel() : "";
+      this.displayTags = checkedItems.map((item) => {
+        return $`
+          <sl-tag
+            part="tag"
+            exportparts="
+              base:tag__base,
+              content:tag__content,
+              remove-button:tag__remove-button
+            "
+            variant="neutral"
+            size=${this.size}
+            ?pill=${this.pill}
+            removable
+            @click=${this.handleTagInteraction}
+            @keydown=${this.handleTagInteraction}
+            @sl-remove=${(event) => {
+          event.stopPropagation();
+          if (!this.disabled) {
+            item.checked = false;
+            this.syncValueFromItems();
+          }
+        }}
+          >
+            ${item.getTextLabel()}
+          </sl-tag>
+        `;
+      });
+      if (this.maxTagsVisible > 0 && this.displayTags.length > this.maxTagsVisible) {
+        const total = this.displayTags.length;
+        this.displayLabel = "";
+        this.displayTags = this.displayTags.slice(0, this.maxTagsVisible);
+        this.displayTags.push($`
+          <sl-tag
+            part="tag"
+            exportparts="
+              base:tag__base,
+              content:tag__content,
+              remove-button:tag__remove-button
+            "
+            variant="neutral"
+            size=${this.size}
+          >
+            +${total - this.maxTagsVisible}
+          </sl-tag>
+        `);
+      }
+    } else {
+      const checkedItem = this.menuItems.find((item) => item.value === value[0]);
+      this.displayLabel = checkedItem ? checkedItem.getTextLabel() : "";
+      this.displayTags = [];
+    }
+  }
+  syncValueFromItems() {
+    const checkedItems = this.menuItems.filter((item) => item.checked);
+    const checkedValues = checkedItems.map((item) => item.value);
+    if (this.multiple) {
+      this.value = this.value.filter((val) => checkedValues.includes(val));
+    } else {
+      this.value = checkedValues.length > 0 ? checkedValues[0] : "";
+    }
+  }
+  render() {
+    const hasLabelSlot = this.hasSlotController.test("label");
+    const hasHelpTextSlot = this.hasSlotController.test("help-text");
+    const hasSelection = this.multiple ? this.value.length > 0 : this.value !== "";
+    const hasLabel = this.label ? true : !!hasLabelSlot;
+    const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
+    const hasClearIcon = this.clearable && !this.disabled && hasSelection;
+    return $`
+      <div
+        part="form-control"
+        class=${o$3({
+      "form-control": true,
+      "form-control--small": this.size === "small",
+      "form-control--medium": this.size === "medium",
+      "form-control--large": this.size === "large",
+      "form-control--has-label": hasLabel,
+      "form-control--has-help-text": hasHelpText
+    })}
+      >
+        <label
+          part="form-control-label"
+          class="form-control__label"
+          for="input"
+          aria-hidden=${hasLabel ? "false" : "true"}
+          @click=${this.handleLabelClick}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <sl-dropdown
+            part="base"
+            .hoist=${this.hoist}
+            .placement=${this.placement}
+            .stayOpenOnSelect=${this.multiple}
+            .containingElement=${this}
+            ?disabled=${this.disabled}
+            class=${o$3({
+      select: true,
+      "select--open": this.isOpen,
+      "select--empty": !this.value,
+      "select--focused": this.hasFocus,
+      "select--clearable": this.clearable,
+      "select--disabled": this.disabled,
+      "select--multiple": this.multiple,
+      "select--standard": !this.filled,
+      "select--filled": this.filled,
+      "select--has-tags": this.multiple && this.displayTags.length > 0,
+      "select--placeholder-visible": this.displayLabel === "",
+      "select--small": this.size === "small",
+      "select--medium": this.size === "medium",
+      "select--large": this.size === "large",
+      "select--pill": this.pill,
+      "select--invalid": this.invalid
+    })}
+            @sl-show=${this.handleMenuShow}
+            @sl-hide=${this.handleMenuHide}
+          >
+            <div
+              part="control"
+              slot="trigger"
+              id="input"
+              class="select__control"
+              role="combobox"
+              aria-describedby="help-text"
+              aria-haspopup="true"
+              aria-disabled=${this.disabled ? "true" : "false"}
+              aria-expanded=${this.isOpen ? "true" : "false"}
+              aria-controls="menu"
+              tabindex=${this.disabled ? "-1" : "0"}
+              @blur=${this.handleBlur}
+              @focus=${this.handleFocus}
+              @keydown=${this.handleKeyDown}
+            >
+              <span part="prefix" class="select__prefix">
+                <slot name="prefix"></slot>
+              </span>
+
+              <div part="display-label" class="select__label">
+                ${this.displayTags.length > 0 ? $` <span part="tags" class="select__tags"> ${this.displayTags} </span> ` : this.displayLabel.length > 0 ? this.displayLabel : this.placeholder}
+              </div>
+
+              ${hasClearIcon ? $`
+                    <button
+                      part="clear-button"
+                      class="select__clear"
+                      @click=${this.handleClearClick}
+                      aria-label=${this.localize.term("clearEntry")}
+                      tabindex="-1"
+                    >
+                      <slot name="clear-icon">
+                        <sl-icon name="x-circle-fill" library="system"></sl-icon>
+                      </slot>
+                    </button>
+                  ` : ""}
+
+              <span part="suffix" class="select__suffix">
+                <slot name="suffix"></slot>
+              </span>
+
+              <span part="icon" class="select__icon" aria-hidden="true">
+                <sl-icon name="chevron-down" library="system"></sl-icon>
+              </span>
+
+              <!-- The hidden input tricks the browser's built-in validation so it works as expected. We use an input
+              instead of a select because, otherwise, iOS will show a list of options during validation. The focus
+              handler is used to move focus to the primary control when it's marked invalid.  -->
+              <input
+                class="select__hidden-select"
+                aria-hidden="true"
+                ?required=${this.required}
+                .value=${hasSelection ? "1" : ""}
+                tabindex="-1"
+                @focus=${() => this.control.focus()}
+              />
+            </div>
+
+            <sl-menu part="menu" id="menu" class="select__menu" @sl-select=${this.handleMenuSelect}>
+              <slot @slotchange=${this.handleMenuSlotChange} @sl-label-change=${this.handleMenuItemLabelChange}></slot>
+            </sl-menu>
+          </sl-dropdown>
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${hasHelpText ? "false" : "true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `;
+  }
+};
+SlSelect.styles = select_styles_default;
+__decorateClass([
+  i2$2(".select")
+], SlSelect.prototype, "dropdown", 2);
+__decorateClass([
+  i2$2(".select__control")
+], SlSelect.prototype, "control", 2);
+__decorateClass([
+  i2$2(".select__hidden-select")
+], SlSelect.prototype, "input", 2);
+__decorateClass([
+  i2$2(".select__menu")
+], SlSelect.prototype, "menu", 2);
+__decorateClass([
+  t$1()
+], SlSelect.prototype, "hasFocus", 2);
+__decorateClass([
+  t$1()
+], SlSelect.prototype, "isOpen", 2);
+__decorateClass([
+  t$1()
+], SlSelect.prototype, "displayLabel", 2);
+__decorateClass([
+  t$1()
+], SlSelect.prototype, "displayTags", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSelect.prototype, "multiple", 2);
+__decorateClass([
+  e$1({ attribute: "max-tags-visible", type: Number })
+], SlSelect.prototype, "maxTagsVisible", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSelect.prototype, "disabled", 2);
+__decorateClass([
+  e$1()
+], SlSelect.prototype, "name", 2);
+__decorateClass([
+  e$1()
+], SlSelect.prototype, "placeholder", 2);
+__decorateClass([
+  e$1()
+], SlSelect.prototype, "size", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlSelect.prototype, "hoist", 2);
+__decorateClass([
+  e$1()
+], SlSelect.prototype, "value", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSelect.prototype, "filled", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSelect.prototype, "pill", 2);
+__decorateClass([
+  e$1()
+], SlSelect.prototype, "label", 2);
+__decorateClass([
+  e$1()
+], SlSelect.prototype, "placement", 2);
+__decorateClass([
+  e$1({ attribute: "help-text" })
+], SlSelect.prototype, "helpText", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSelect.prototype, "required", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlSelect.prototype, "clearable", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlSelect.prototype, "invalid", 2);
+__decorateClass([
+  defaultValue()
+], SlSelect.prototype, "defaultValue", 2);
+__decorateClass([
+  watch("disabled", { waitUntilFirstUpdate: true })
+], SlSelect.prototype, "handleDisabledChange", 1);
+__decorateClass([
+  watch("multiple")
+], SlSelect.prototype, "handleMultipleChange", 1);
+__decorateClass([
+  watch("value", { waitUntilFirstUpdate: true })
+], SlSelect.prototype, "handleValueChange", 1);
+SlSelect = __decorateClass([
+  n$1("sl-select")
+], SlSelect);
+
+// src/components/tag/tag.styles.ts
+var tag_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .tag {
+    display: flex;
+    align-items: center;
+    border: solid 1px;
+    line-height: 1;
+    white-space: nowrap;
+    user-select: none;
+    cursor: default;
+  }
+
+  .tag__remove::part(base) {
+    color: inherit;
+    padding: 0;
+  }
+
+  /*
+   * Variant modifiers
+   */
+
+  .tag--primary {
+    background-color: var(--sl-color-primary-50);
+    border-color: var(--sl-color-primary-200);
+    color: var(--sl-color-primary-800);
+  }
+
+  .tag--success {
+    background-color: var(--sl-color-success-50);
+    border-color: var(--sl-color-success-200);
+    color: var(--sl-color-success-800);
+  }
+
+  .tag--neutral {
+    background-color: var(--sl-color-neutral-50);
+    border-color: var(--sl-color-neutral-200);
+    color: var(--sl-color-neutral-800);
+  }
+
+  .tag--warning {
+    background-color: var(--sl-color-warning-50);
+    border-color: var(--sl-color-warning-200);
+    color: var(--sl-color-warning-800);
+  }
+
+  .tag--danger {
+    background-color: var(--sl-color-danger-50);
+    border-color: var(--sl-color-danger-200);
+    color: var(--sl-color-danger-800);
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .tag--small {
+    font-size: var(--sl-button-font-size-small);
+    height: calc(var(--sl-input-height-small) * 0.8);
+    line-height: calc(var(--sl-input-height-small) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-small);
+    padding: 0 var(--sl-spacing-x-small);
+  }
+
+  .tag--small .tag__remove {
+    margin-inline-start: var(--sl-spacing-2x-small);
+    margin-right: calc(-1 * var(--sl-spacing-3x-small));
+  }
+
+  .tag--medium {
+    font-size: var(--sl-button-font-size-medium);
+    height: calc(var(--sl-input-height-medium) * 0.8);
+    line-height: calc(var(--sl-input-height-medium) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-medium);
+    padding: 0 var(--sl-spacing-small);
+  }
+
+  .tag--large {
+    font-size: var(--sl-button-font-size-large);
+    height: calc(var(--sl-input-height-large) * 0.8);
+    line-height: calc(var(--sl-input-height-large) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-large);
+    padding: 0 var(--sl-spacing-medium);
+  }
+
+  .tag__remove {
+    font-size: 1.4em;
+    margin-inline-start: var(--sl-spacing-2x-small);
+    margin-inline-end: calc(-1 * var(--sl-spacing-x-small));
+  }
+
+  /*
+   * Pill modifier
+   */
+
+  .tag--pill {
+    border-radius: var(--sl-border-radius-pill);
+  }
+`;
+
+// src/components/tag/tag.ts
+var SlTag = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.variant = "neutral";
+    this.size = "medium";
+    this.pill = false;
+    this.removable = false;
+  }
+  handleRemoveClick() {
+    this.emit("sl-remove");
+  }
+  render() {
+    return $`
+      <span
+        part="base"
+        class=${o$3({
+      tag: true,
+      "tag--primary": this.variant === "primary",
+      "tag--success": this.variant === "success",
+      "tag--neutral": this.variant === "neutral",
+      "tag--warning": this.variant === "warning",
+      "tag--danger": this.variant === "danger",
+      "tag--text": this.variant === "text",
+      "tag--small": this.size === "small",
+      "tag--medium": this.size === "medium",
+      "tag--large": this.size === "large",
+      "tag--pill": this.pill,
+      "tag--removable": this.removable
+    })}
+      >
+        <span part="content" class="tag__content">
+          <slot></slot>
+        </span>
+
+        ${this.removable ? $`
+              <sl-icon-button
+                part="remove-button"
+                exportparts="base:remove-button__base"
+                name="x"
+                library="system"
+                label=${this.localize.term("remove")}
+                class="tag__remove"
+                @click=${this.handleRemoveClick}
+              ></sl-icon-button>
+            ` : ""}
+      </span>
+    `;
+  }
+};
+SlTag.styles = tag_styles_default;
+__decorateClass([
+  e$1({ reflect: true })
+], SlTag.prototype, "variant", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlTag.prototype, "size", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlTag.prototype, "pill", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlTag.prototype, "removable", 2);
+SlTag = __decorateClass([
+  n$1("sl-tag")
+], SlTag);
+
+// src/components/skeleton/skeleton.styles.ts
+var skeleton_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --border-radius: var(--sl-border-radius-pill);
+    --color: var(--sl-color-neutral-200);
+    --sheen-color: var(--sl-color-neutral-300);
+
+    display: block;
+    position: relative;
+  }
+
+  .skeleton {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    min-height: 1rem;
+  }
+
+  .skeleton__indicator {
+    flex: 1 1 auto;
+    background: var(--color);
+    border-radius: var(--border-radius);
+  }
+
+  .skeleton--sheen .skeleton__indicator {
+    background: linear-gradient(270deg, var(--sheen-color), var(--color), var(--color), var(--sheen-color));
+    background-size: 400% 100%;
+    background-size: 400% 100%;
+    animation: sheen 8s ease-in-out infinite;
+  }
+
+  .skeleton--pulse .skeleton__indicator {
+    animation: pulse 2s ease-in-out 0.5s infinite;
+  }
+
+  @keyframes sheen {
+    0% {
+      background-position: 200% 0;
+    }
+    to {
+      background-position: -200% 0;
+    }
+  }
+
+  @keyframes pulse {
+    0% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.4;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+`;
+
+// src/components/skeleton/skeleton.ts
+var SlSkeleton = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.effect = "none";
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      skeleton: true,
+      "skeleton--pulse": this.effect === "pulse",
+      "skeleton--sheen": this.effect === "sheen"
+    })}
+        aria-busy="true"
+        aria-live="polite"
+      >
+        <div part="indicator" class="skeleton__indicator"></div>
+      </div>
+    `;
+  }
+};
+SlSkeleton.styles = skeleton_styles_default;
+__decorateClass([
+  e$1()
+], SlSkeleton.prototype, "effect", 2);
+SlSkeleton = __decorateClass([
+  n$1("sl-skeleton")
+], SlSkeleton);
+
+// src/components/button/button.styles.ts
+var button_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+    position: relative;
+    width: auto;
+    cursor: pointer;
+  }
+
+  .button {
+    display: inline-flex;
+    align-items: stretch;
+    justify-content: center;
+    width: 100%;
+    border-style: solid;
+    border-width: var(--sl-input-border-width);
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-font-weight-semibold);
+    text-decoration: none;
+    user-select: none;
+    white-space: nowrap;
+    vertical-align: middle;
+    padding: 0;
+    transition: var(--sl-transition-x-fast) background-color, var(--sl-transition-x-fast) color,
+      var(--sl-transition-x-fast) border, var(--sl-transition-x-fast) box-shadow;
+    cursor: inherit;
+  }
+
+  .button::-moz-focus-inner {
+    border: 0;
+  }
+
+  .button:focus {
+    outline: none;
+  }
+
+  .button:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .button--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* When disabled, prevent mouse events from bubbling up */
+  .button--disabled * {
+    pointer-events: none;
+  }
+
+  .button__prefix,
+  .button__suffix {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    pointer-events: none;
+  }
+
+  .button__label ::slotted(sl-icon) {
+    vertical-align: -2px;
+  }
+
+  /*
+   * Standard buttons
+   */
+
+  /* Default */
+  .button--standard.button--default {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-neutral-300);
+    color: var(--sl-color-neutral-700);
+  }
+
+  .button--standard.button--default:hover:not(.button--disabled) {
+    background-color: var(--sl-color-primary-50);
+    border-color: var(--sl-color-primary-300);
+    color: var(--sl-color-primary-700);
+  }
+
+  .button--standard.button--default:active:not(.button--disabled) {
+    background-color: var(--sl-color-primary-100);
+    border-color: var(--sl-color-primary-400);
+    color: var(--sl-color-primary-700);
+  }
+
+  /* Primary */
+  .button--standard.button--primary {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--primary:hover:not(.button--disabled) {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--primary:active:not(.button--disabled) {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Success */
+  .button--standard.button--success {
+    background-color: var(--sl-color-success-600);
+    border-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--success:hover:not(.button--disabled) {
+    background-color: var(--sl-color-success-500);
+    border-color: var(--sl-color-success-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--success:active:not(.button--disabled) {
+    background-color: var(--sl-color-success-600);
+    border-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Neutral */
+  .button--standard.button--neutral {
+    background-color: var(--sl-color-neutral-600);
+    border-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--neutral:hover:not(.button--disabled) {
+    background-color: var(--sl-color-neutral-500);
+    border-color: var(--sl-color-neutral-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--neutral:active:not(.button--disabled) {
+    background-color: var(--sl-color-neutral-600);
+    border-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Warning */
+  .button--standard.button--warning {
+    background-color: var(--sl-color-warning-600);
+    border-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+  .button--standard.button--warning:hover:not(.button--disabled) {
+    background-color: var(--sl-color-warning-500);
+    border-color: var(--sl-color-warning-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--warning:active:not(.button--disabled) {
+    background-color: var(--sl-color-warning-600);
+    border-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Danger */
+  .button--standard.button--danger {
+    background-color: var(--sl-color-danger-600);
+    border-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--danger:hover:not(.button--disabled) {
+    background-color: var(--sl-color-danger-500);
+    border-color: var(--sl-color-danger-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--danger:active:not(.button--disabled) {
+    background-color: var(--sl-color-danger-600);
+    border-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /*
+   * Outline buttons
+   */
+
+  .button--outline {
+    background: none;
+    border: solid 1px;
+  }
+
+  /* Default */
+  .button--outline.button--default {
+    border-color: var(--sl-color-neutral-300);
+    color: var(--sl-color-neutral-700);
+  }
+
+  .button--outline.button--default:hover:not(.button--disabled),
+  .button--outline.button--default.button--checked:not(.button--disabled) {
+    border-color: var(--sl-color-primary-600);
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--default:active:not(.button--disabled) {
+    border-color: var(--sl-color-primary-700);
+    background-color: var(--sl-color-primary-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Primary */
+  .button--outline.button--primary {
+    border-color: var(--sl-color-primary-600);
+    color: var(--sl-color-primary-600);
+  }
+
+  .button--outline.button--primary:hover:not(.button--disabled),
+  .button--outline.button--primary.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--primary:active:not(.button--disabled) {
+    border-color: var(--sl-color-primary-700);
+    background-color: var(--sl-color-primary-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Success */
+  .button--outline.button--success {
+    border-color: var(--sl-color-success-600);
+    color: var(--sl-color-success-600);
+  }
+
+  .button--outline.button--success:hover:not(.button--disabled),
+  .button--outline.button--success.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--success:active:not(.button--disabled) {
+    border-color: var(--sl-color-success-700);
+    background-color: var(--sl-color-success-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Neutral */
+  .button--outline.button--neutral {
+    border-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-600);
+  }
+
+  .button--outline.button--neutral:hover:not(.button--disabled),
+  .button--outline.button--neutral.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--neutral:active:not(.button--disabled) {
+    border-color: var(--sl-color-neutral-700);
+    background-color: var(--sl-color-neutral-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Warning */
+  .button--outline.button--warning {
+    border-color: var(--sl-color-warning-600);
+    color: var(--sl-color-warning-600);
+  }
+
+  .button--outline.button--warning:hover:not(.button--disabled),
+  .button--outline.button--warning.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--warning:active:not(.button--disabled) {
+    border-color: var(--sl-color-warning-700);
+    background-color: var(--sl-color-warning-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Danger */
+  .button--outline.button--danger {
+    border-color: var(--sl-color-danger-600);
+    color: var(--sl-color-danger-600);
+  }
+
+  .button--outline.button--danger:hover:not(.button--disabled),
+  .button--outline.button--danger.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--danger:active:not(.button--disabled) {
+    border-color: var(--sl-color-danger-700);
+    background-color: var(--sl-color-danger-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /*
+   * Text buttons
+   */
+
+  .button--text {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-600);
+  }
+
+  .button--text:hover:not(.button--disabled) {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-500);
+  }
+
+  .button--text:focus-visible:not(.button--disabled) {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-500);
+  }
+
+  .button--text:active:not(.button--disabled) {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-700);
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .button--small {
+    font-size: var(--sl-button-font-size-small);
+    height: var(--sl-input-height-small);
+    line-height: calc(var(--sl-input-height-small) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-small);
+  }
+
+  .button--medium {
+    font-size: var(--sl-button-font-size-medium);
+    height: var(--sl-input-height-medium);
+    line-height: calc(var(--sl-input-height-medium) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-medium);
+  }
+
+  .button--large {
+    font-size: var(--sl-button-font-size-large);
+    height: var(--sl-input-height-large);
+    line-height: calc(var(--sl-input-height-large) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-large);
+  }
+
+  /*
+   * Pill modifier
+   */
+
+  .button--pill.button--small {
+    border-radius: var(--sl-input-height-small);
+  }
+
+  .button--pill.button--medium {
+    border-radius: var(--sl-input-height-medium);
+  }
+
+  .button--pill.button--large {
+    border-radius: var(--sl-input-height-large);
+  }
+
+  /*
+   * Circle modifier
+   */
+
+  .button--circle {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .button--circle.button--small {
+    width: var(--sl-input-height-small);
+    border-radius: 50%;
+  }
+
+  .button--circle.button--medium {
+    width: var(--sl-input-height-medium);
+    border-radius: 50%;
+  }
+
+  .button--circle.button--large {
+    width: var(--sl-input-height-large);
+    border-radius: 50%;
+  }
+
+  .button--circle .button__prefix,
+  .button--circle .button__suffix,
+  .button--circle .button__caret {
+    display: none;
+  }
+
+  /*
+   * Caret modifier
+   */
+
+  .button--caret .button__suffix {
+    display: none;
+  }
+
+  .button--caret .button__caret {
+    display: flex;
+    align-items: center;
+  }
+
+  .button--caret .button__caret svg {
+    width: 1em;
+    height: 1em;
+  }
+
+  /*
+   * Loading modifier
+   */
+
+  .button--loading {
+    position: relative;
+    cursor: wait;
+  }
+
+  .button--loading .button__prefix,
+  .button--loading .button__label,
+  .button--loading .button__suffix,
+  .button--loading .button__caret {
+    visibility: hidden;
+  }
+
+  .button--loading sl-spinner {
+    --indicator-color: currentColor;
+    position: absolute;
+    font-size: 1em;
+    height: 1em;
+    width: 1em;
+    top: calc(50% - 0.5em);
+    left: calc(50% - 0.5em);
+  }
+
+  /*
+   * Badges
+   */
+
+  .button ::slotted(sl-badge) {
+    position: absolute;
+    top: 0;
+    right: 0;
+    transform: translateY(-50%) translateX(50%);
+    pointer-events: none;
+  }
+
+  .button--rtl ::slotted(sl-badge) {
+    right: auto;
+    left: 0;
+    transform: translateY(-50%) translateX(-50%);
+  }
+
+  /*
+   * Button spacing
+   */
+
+  .button--has-label.button--small .button__label {
+    padding: 0 var(--sl-spacing-small);
+  }
+
+  .button--has-label.button--medium .button__label {
+    padding: 0 var(--sl-spacing-medium);
+  }
+
+  .button--has-label.button--large .button__label {
+    padding: 0 var(--sl-spacing-large);
+  }
+
+  .button--has-prefix.button--small {
+    padding-inline-start: var(--sl-spacing-x-small);
+  }
+
+  .button--has-prefix.button--small .button__label {
+    padding-inline-start: var(--sl-spacing-x-small);
+  }
+
+  .button--has-prefix.button--medium {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-prefix.button--medium .button__label {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-prefix.button--large {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-prefix.button--large .button__label {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--small,
+  .button--caret.button--small {
+    padding-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .button--has-suffix.button--small .button__label,
+  .button--caret.button--small .button__label {
+    padding-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .button--has-suffix.button--medium,
+  .button--caret.button--medium {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--medium .button__label,
+  .button--caret.button--medium .button__label {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--large,
+  .button--caret.button--large {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--large .button__label,
+  .button--caret.button--large .button__label {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  /*
+   * Button groups support a variety of button types (e.g. buttons with tooltips, buttons as dropdown triggers, etc.).
+   * This means buttons aren't always direct descendants of the button group, thus we can't target them with the
+   * ::slotted selector. To work around this, the button group component does some magic to add these special classes to
+   * buttons and we style them here instead.
+   */
+
+  :host(.sl-button-group__button--first:not(.sl-button-group__button--last)) .button {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+
+  :host(.sl-button-group__button--inner) .button {
+    border-radius: 0;
+  }
+
+  :host(.sl-button-group__button--last:not(.sl-button-group__button--first)) .button {
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+  }
+
+  /* All except the first */
+  :host(.sl-button-group__button:not(.sl-button-group__button--first)) {
+    margin-inline-start: calc(-1 * var(--sl-input-border-width));
+  }
+
+  /* Add a visual separator between solid buttons */
+  :host(.sl-button-group__button:not(.sl-button-group__button--focus, .sl-button-group__button--first, .sl-button-group__button--radio, [variant='default']):not(:hover, :active, :focus))
+    .button:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    inset-inline-start: 0;
+    bottom: 0;
+    border-left: solid 1px rgb(128 128 128 / 33%);
+    mix-blend-mode: multiply;
+  }
+
+  /* Bump hovered, focused, and checked buttons up so their focus ring isn't clipped */
+  :host(.sl-button-group__button--hover) {
+    z-index: 1;
+  }
+
+  :host(.sl-button-group__button--focus),
+  :host(.sl-button-group__button[checked]) {
+    z-index: 2;
+  }
+`;
+
+// src/components/radio-button/radio-button.styles.ts
+var radio_button_styles_default = r$2`
+  ${button_styles_default}
+
+  label {
+    display: inline-block;
+    position: relative;
+  }
+  /* We use a hidden input so constraint validation errors work, since they don't appear to show when used with buttons.
+    We can't actually hide it, though, otherwise the messages will be suppressed by the browser. */
+  .hidden-input {
+    all: unset;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    outline: dotted 1px red;
+    opacity: 0;
+    z-index: -1;
+  }
+`;
+
+// node_modules/lit-html/static.js
+var o$1 = Symbol.for("");
+var e = (t) => {
+  var r, e2;
+  if ((null === (r = t) || void 0 === r ? void 0 : r.r) === o$1)
+    return null === (e2 = t) || void 0 === e2 ? void 0 : e2._$litStatic$;
+};
+var l$1 = (t, ...r) => ({ _$litStatic$: r.reduce((r2, o2, e2) => r2 + ((t2) => {
+  if (void 0 !== t2._$litStatic$)
+    return t2._$litStatic$;
+  throw Error(`Value passed to 'literal' function must be a 'literal' result: ${t2}. Use 'unsafeStatic' to pass non-literal values, but
+            take care to ensure page security.`);
+})(o2) + t[e2 + 1], t[0]), r: o$1 });
+var a$1 = /* @__PURE__ */ new Map();
+var s$1 = (t) => (r, ...o2) => {
+  const i = o2.length;
+  let l2, s2;
+  const n2 = [], u2 = [];
+  let c, v = 0, $2 = false;
+  for (; v < i; ) {
+    for (c = r[v]; v < i && void 0 !== (s2 = o2[v], l2 = e(s2)); )
+      c += l2 + r[++v], $2 = true;
+    u2.push(s2), n2.push(c), v++;
+  }
+  if (v === i && n2.push(r[i]), $2) {
+    const t2 = n2.join("$$lit$$");
+    void 0 === (r = a$1.get(t2)) && (n2.raw = n2, a$1.set(t2, r = n2)), o2 = u2;
+  }
+  return t(r, ...o2);
+};
+var n = s$1($);
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// src/components/radio-button/radio-button.ts
+var SlRadioButton = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.hasSlotController = new HasSlotController(this, "[default]", "prefix", "suffix");
+    this.hasFocus = false;
+    this.checked = false;
+    this.disabled = false;
+    this.size = "medium";
+    this.pill = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("role", "presentation");
+  }
+  handleDisabledChange() {
+    this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+  }
+  handleBlur() {
+    this.hasFocus = false;
+    this.emit("sl-blur");
+  }
+  handleClick(e2) {
+    if (this.disabled) {
+      e2.preventDefault();
+      e2.stopPropagation();
+      return;
+    }
+    this.checked = true;
+  }
+  handleFocus() {
+    this.hasFocus = true;
+    this.emit("sl-focus");
+  }
+  render() {
+    return n`
+      <div part="base" role="presentation">
+        <button
+          part="button"
+          role="radio"
+          aria-checked="${this.checked}"
+          class=${o$3({
+      button: true,
+      "button--default": true,
+      "button--small": this.size === "small",
+      "button--medium": this.size === "medium",
+      "button--large": this.size === "large",
+      "button--checked": this.checked,
+      "button--disabled": this.disabled,
+      "button--focused": this.hasFocus,
+      "button--outline": true,
+      "button--pill": this.pill,
+      "button--has-label": this.hasSlotController.test("[default]"),
+      "button--has-prefix": this.hasSlotController.test("prefix"),
+      "button--has-suffix": this.hasSlotController.test("suffix")
+    })}
+          aria-disabled=${this.disabled}
+          type="button"
+          value=${l$2(this.value)}
+          tabindex="${this.checked ? "0" : "-1"}"
+          @blur=${this.handleBlur}
+          @focus=${this.handleFocus}
+          @click=${this.handleClick}
+        >
+          <span part="prefix" class="button__prefix">
+            <slot name="prefix"></slot>
+          </span>
+          <span part="label" class="button__label">
+            <slot></slot>
+          </span>
+          <span part="suffix" class="button__suffix">
+            <slot name="suffix"></slot>
+          </span>
+        </button>
+      </div>
+    `;
+  }
+};
+SlRadioButton.styles = radio_button_styles_default;
+__decorateClass([
+  i2$2(".button")
+], SlRadioButton.prototype, "input", 2);
+__decorateClass([
+  i2$2(".hidden-input")
+], SlRadioButton.prototype, "hiddenInput", 2);
+__decorateClass([
+  t$1()
+], SlRadioButton.prototype, "hasFocus", 2);
+__decorateClass([
+  t$1()
+], SlRadioButton.prototype, "checked", 2);
+__decorateClass([
+  e$1()
+], SlRadioButton.prototype, "value", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlRadioButton.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlRadioButton.prototype, "size", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlRadioButton.prototype, "pill", 2);
+__decorateClass([
+  watch("disabled", { waitUntilFirstUpdate: true })
+], SlRadioButton.prototype, "handleDisabledChange", 1);
+SlRadioButton = __decorateClass([
+  n$1("sl-radio-button")
+], SlRadioButton);
+
+// src/components/radio-group/radio-group.styles.ts
+var radio_group_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .radio-group {
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+    border-radius: var(--sl-border-radius-medium);
+    padding: var(--sl-spacing-large);
+    padding-top: var(--sl-spacing-x-small);
+  }
+
+  .radio-group .radio-group__label {
+    font-family: var(--sl-input-font-family);
+    font-size: var(--sl-input-font-size-medium);
+    font-weight: var(--sl-input-font-weight);
+    color: var(--sl-input-color);
+    padding: 0 var(--sl-spacing-2x-small);
+  }
+
+  ::slotted(sl-radio:not(:last-of-type)) {
+    margin-bottom: var(--sl-spacing-2x-small);
+  }
+
+  .radio-group:not(.radio-group--has-fieldset) {
+    border: none;
+    padding: 0;
+    margin: 0;
+    min-width: 0;
+  }
+
+  .radio-group:not(.radio-group--has-fieldset) .radio-group__label {
+    position: absolute;
+    width: 0;
+    height: 0;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .radio-group--required .radio-group__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+`;
+
+// src/components/radio-group/radio-group.ts
+var SlRadioGroup = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.formSubmitController = new FormSubmitController(this, {
+      defaultValue: (control) => control.defaultValue
+    });
+    this.hasButtonGroup = false;
+    this.errorMessage = "";
+    this.customErrorMessage = "";
+    this.defaultValue = "";
+    this.label = "";
+    this.value = "";
+    this.name = "option";
+    this.invalid = false;
+    this.fieldset = false;
+    this.required = false;
+  }
+  handleValueChange() {
+    if (this.hasUpdated) {
+      this.emit("sl-change");
+      this.updateCheckedRadio();
+    }
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.defaultValue = this.value;
+  }
+  setCustomValidity(message = "") {
+    this.customErrorMessage = message;
+    this.errorMessage = message;
+    if (!message) {
+      this.invalid = false;
+    } else {
+      this.invalid = true;
+      this.input.setCustomValidity(message);
+    }
+  }
+  get validity() {
+    const hasMissingData = !(this.value && this.required || !this.required);
+    const hasCustomError = this.customErrorMessage !== "";
+    return {
+      badInput: false,
+      customError: hasCustomError,
+      patternMismatch: false,
+      rangeOverflow: false,
+      rangeUnderflow: false,
+      stepMismatch: false,
+      tooLong: false,
+      tooShort: false,
+      typeMismatch: false,
+      valid: hasMissingData || hasCustomError ? false : true,
+      valueMissing: !hasMissingData
+    };
+  }
+  reportValidity() {
+    const validity = this.validity;
+    this.errorMessage = this.customErrorMessage || validity.valid ? "" : this.input.validationMessage;
+    this.invalid = !validity.valid;
+    if (!validity.valid) {
+      this.showNativeErrorMessage();
+    }
+    return !this.invalid;
+  }
+  getAllRadios() {
+    return [...this.querySelectorAll("sl-radio, sl-radio-button")];
+  }
+  handleRadioClick(event) {
+    const target = event.target;
+    if (target.disabled) {
+      return;
+    }
+    this.value = target.value;
+    const radios = this.getAllRadios();
+    radios.forEach((radio) => radio.checked = radio === target);
+  }
+  handleKeyDown(event) {
+    var _a;
+    if (!["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", " "].includes(event.key)) {
+      return;
+    }
+    const radios = this.getAllRadios().filter((radio) => !radio.disabled);
+    const checkedRadio = (_a = radios.find((radio) => radio.checked)) != null ? _a : radios[0];
+    const incr = event.key === " " ? 0 : ["ArrowUp", "ArrowLeft"].includes(event.key) ? -1 : 1;
+    let index = radios.indexOf(checkedRadio) + incr;
+    if (index < 0) {
+      index = radios.length - 1;
+    }
+    if (index > radios.length - 1) {
+      index = 0;
+    }
+    this.getAllRadios().forEach((radio) => {
+      radio.checked = false;
+      if (!this.hasButtonGroup) {
+        radio.tabIndex = -1;
+      }
+    });
+    this.value = radios[index].value;
+    radios[index].checked = true;
+    if (!this.hasButtonGroup) {
+      radios[index].tabIndex = 0;
+      radios[index].focus();
+    } else {
+      radios[index].shadowRoot.querySelector("button").focus();
+    }
+    event.preventDefault();
+  }
+  handleSlotChange() {
+    var _a;
+    const radios = this.getAllRadios();
+    radios.forEach((radio) => radio.checked = radio.value === this.value);
+    this.hasButtonGroup = radios.some((radio) => radio.tagName.toLowerCase() === "sl-radio-button");
+    if (!radios.some((radio) => radio.checked)) {
+      if (this.hasButtonGroup) {
+        const buttonRadio = radios[0].shadowRoot.querySelector("button");
+        buttonRadio.tabIndex = 0;
+      } else {
+        radios[0].tabIndex = 0;
+      }
+    }
+    if (this.hasButtonGroup) {
+      const buttonGroup = (_a = this.shadowRoot) == null ? void 0 : _a.querySelector("sl-button-group");
+      if (buttonGroup) {
+        buttonGroup.disableRole = true;
+      }
+    }
+  }
+  showNativeErrorMessage() {
+    this.input.hidden = false;
+    this.input.reportValidity();
+    setTimeout(() => this.input.hidden = true, 1e4);
+  }
+  updateCheckedRadio() {
+    const radios = this.getAllRadios();
+    radios.forEach((radio) => radio.checked = radio.value === this.value);
+  }
+  render() {
+    const defaultSlot = $`
+      <slot
+        @click=${this.handleRadioClick}
+        @keydown=${this.handleKeyDown}
+        @slotchange=${this.handleSlotChange}
+        role="presentation"
+      ></slot>
+    `;
+    return $`
+      <fieldset
+        part="base"
+        role="radiogroup"
+        aria-errormessage="radio-error-message"
+        aria-invalid="${this.invalid}"
+        class=${o$3({
+      "radio-group": true,
+      "radio-group--has-fieldset": this.fieldset,
+      "radio-group--required": this.required
+    })}
+      >
+        <legend part="label" class="radio-group__label">
+          <slot name="label">${this.label}</slot>
+        </legend>
+        <div class="visually-hidden">
+          <div id="radio-error-message" aria-live="assertive">${this.errorMessage}</div>
+          <label class="radio-group__validation visually-hidden">
+            <input type="text" class="radio-group__validation-input" ?required=${this.required} tabindex="-1" hidden />
+          </label>
+        </div>
+        ${this.hasButtonGroup ? $`
+              <sl-button-group part="button-group" exportparts="base:button-group__base">
+                ${defaultSlot}
+              </sl-button-group>
+            ` : defaultSlot}
+      </fieldset>
+    `;
+  }
+};
+SlRadioGroup.styles = radio_group_styles_default;
+__decorateClass([
+  i2$2("slot:not([name])")
+], SlRadioGroup.prototype, "defaultSlot", 2);
+__decorateClass([
+  i2$2(".radio-group__validation-input")
+], SlRadioGroup.prototype, "input", 2);
+__decorateClass([
+  t$1()
+], SlRadioGroup.prototype, "hasButtonGroup", 2);
+__decorateClass([
+  t$1()
+], SlRadioGroup.prototype, "errorMessage", 2);
+__decorateClass([
+  t$1()
+], SlRadioGroup.prototype, "customErrorMessage", 2);
+__decorateClass([
+  t$1()
+], SlRadioGroup.prototype, "defaultValue", 2);
+__decorateClass([
+  e$1()
+], SlRadioGroup.prototype, "label", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlRadioGroup.prototype, "value", 2);
+__decorateClass([
+  e$1()
+], SlRadioGroup.prototype, "name", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlRadioGroup.prototype, "invalid", 2);
+__decorateClass([
+  e$1({ type: Boolean, attribute: "fieldset", reflect: true })
+], SlRadioGroup.prototype, "fieldset", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlRadioGroup.prototype, "required", 2);
+__decorateClass([
+  watch("value")
+], SlRadioGroup.prototype, "handleValueChange", 1);
+SlRadioGroup = __decorateClass([
+  n$1("sl-radio-group")
+], SlRadioGroup);
+
+// src/components/range/range.styles.ts
+var range_styles_default = r$2`
+  ${component_styles_default}
+  ${form_control_styles_default}
+
+  :host {
+    --thumb-size: 20px;
+    --tooltip-offset: 10px;
+    --track-color-active: var(--sl-color-neutral-200);
+    --track-color-inactive: var(--sl-color-neutral-200);
+    --track-active-offset: 0%;
+    --track-height: 6px;
+
+    display: block;
+  }
+
+  .range {
+    position: relative;
+  }
+
+  .range__control {
+    --percent: 0%;
+    -webkit-appearance: none;
+    border-radius: 3px;
+    width: 100%;
+    height: var(--track-height);
+    background: transparent;
+    line-height: var(--sl-input-height-medium);
+    vertical-align: middle;
+    margin: 0;
+
+    background-image: linear-gradient(
+      to right,
+      var(--track-color-inactive) 0%,
+      var(--track-color-inactive) min(var(--percent), var(--track-active-offset)),
+      var(--track-color-active) min(var(--percent), var(--track-active-offset)),
+      var(--track-color-active) max(var(--percent), var(--track-active-offset)),
+      var(--track-color-inactive) max(var(--percent), var(--track-active-offset)),
+      var(--track-color-inactive) 100%
+    );
+  }
+
+  .range--rtl .range__control {
+    background-image: linear-gradient(
+      to left,
+      var(--track-color-inactive) 0%,
+      var(--track-color-inactive) min(var(--percent), var(--track-active-offset)),
+      var(--track-color-active) min(var(--percent), var(--track-active-offset)),
+      var(--track-color-active) max(var(--percent), var(--track-active-offset)),
+      var(--track-color-inactive) max(var(--percent), var(--track-active-offset)),
+      var(--track-color-inactive) 100%
+    );
+  }
+
+  /* Webkit */
+  .range__control::-webkit-slider-runnable-track {
+    width: 100%;
+    height: var(--track-height);
+    border-radius: 3px;
+    border: none;
+  }
+
+  .range__control::-webkit-slider-thumb {
+    border: none;
+    width: var(--thumb-size);
+    height: var(--thumb-size);
+    border-radius: 50%;
+    background-color: var(--sl-color-primary-600);
+    border: solid var(--sl-input-border-width) var(--sl-color-primary-600);
+    -webkit-appearance: none;
+    margin-top: calc(var(--thumb-size) / -2 + var(--track-height) / 2);
+    transition: var(--sl-transition-fast) border-color, var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) color, var(--sl-transition-fast) box-shadow, var(--sl-transition-fast) transform;
+    cursor: pointer;
+  }
+
+  .range__control:enabled::-webkit-slider-thumb:hover {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+  }
+
+  .range__control:enabled:focus-visible::-webkit-slider-thumb {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .range__control:enabled::-webkit-slider-thumb:active {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+    cursor: grabbing;
+  }
+
+  /* Firefox */
+  .range__control::-moz-focus-outer {
+    border: 0;
+  }
+
+  .range__control::-moz-range-progress {
+    background-color: var(--track-color-active);
+    border-radius: 3px;
+    height: var(--track-height);
+  }
+
+  .range__control::-moz-range-track {
+    width: 100%;
+    height: var(--track-height);
+    background-color: var(--track-color-inactive);
+    border-radius: 3px;
+    border: none;
+  }
+
+  .range__control::-moz-range-thumb {
+    border: none;
+    height: var(--thumb-size);
+    width: var(--thumb-size);
+    border-radius: 50%;
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+    transition: var(--sl-transition-fast) border-color, var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) color, var(--sl-transition-fast) box-shadow, var(--sl-transition-fast) transform;
+    cursor: pointer;
+  }
+
+  .range__control:enabled::-moz-range-thumb:hover {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+  }
+
+  .range__control:enabled:focus-visible::-moz-range-thumb {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .range__control:enabled::-moz-range-thumb:active {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+    cursor: grabbing;
+  }
+
+  /* States */
+  .range__control:focus-visible {
+    outline: none;
+  }
+
+  .range__control:disabled {
+    opacity: 0.5;
+  }
+
+  .range__control:disabled::-webkit-slider-thumb {
+    cursor: not-allowed;
+  }
+
+  .range__control:disabled::-moz-range-thumb {
+    cursor: not-allowed;
+  }
+
+  /* Tooltip output */
+  .range__tooltip {
+    position: absolute;
+    z-index: var(--sl-z-index-tooltip);
+    left: 0;
+    border-radius: var(--sl-tooltip-border-radius);
+    background-color: var(--sl-tooltip-background-color);
+    font-family: var(--sl-tooltip-font-family);
+    font-size: var(--sl-tooltip-font-size);
+    font-weight: var(--sl-tooltip-font-weight);
+    line-height: var(--sl-tooltip-line-height);
+    color: var(--sl-tooltip-color);
+    opacity: 0;
+    padding: var(--sl-tooltip-padding);
+    transition: var(--sl-transition-fast) opacity;
+    pointer-events: none;
+  }
+
+  .range__tooltip:after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    left: 50%;
+    transform: translateX(calc(-1 * var(--sl-tooltip-arrow-size)));
+  }
+
+  .range--tooltip-visible .range__tooltip {
+    opacity: 1;
+  }
+
+  /* Tooltip on top */
+  .range--tooltip-top .range__tooltip {
+    top: calc(-1 * var(--thumb-size) - var(--tooltip-offset));
+  }
+
+  .range--tooltip-top .range__tooltip:after {
+    border-top: var(--sl-tooltip-arrow-size) solid var(--sl-tooltip-background-color);
+    border-left: var(--sl-tooltip-arrow-size) solid transparent;
+    border-right: var(--sl-tooltip-arrow-size) solid transparent;
+    top: 100%;
+  }
+
+  /* Tooltip on bottom */
+  .range--tooltip-bottom .range__tooltip {
+    bottom: calc(-1 * var(--thumb-size) - var(--tooltip-offset));
+  }
+
+  .range--tooltip-bottom .range__tooltip:after {
+    border-bottom: var(--sl-tooltip-arrow-size) solid var(--sl-tooltip-background-color);
+    border-left: var(--sl-tooltip-arrow-size) solid transparent;
+    border-right: var(--sl-tooltip-arrow-size) solid transparent;
+    bottom: 100%;
+  }
+`;
+
+// src/components/range/range.ts
+var SlRange = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.formSubmitController = new FormSubmitController(this);
+    this.hasSlotController = new HasSlotController(this, "help-text", "label");
+    this.localize = new LocalizeController2(this);
+    this.hasFocus = false;
+    this.hasTooltip = false;
+    this.name = "";
+    this.value = 0;
+    this.label = "";
+    this.helpText = "";
+    this.disabled = false;
+    this.invalid = false;
+    this.min = 0;
+    this.max = 100;
+    this.step = 1;
+    this.tooltip = "top";
+    this.tooltipFormatter = (value) => value.toString();
+    this.defaultValue = 0;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.resizeObserver = new ResizeObserver(() => this.syncRange());
+    if (this.value < this.min) {
+      this.value = this.min;
+    }
+    if (this.value > this.max) {
+      this.value = this.max;
+    }
+    this.updateComplete.then(() => {
+      this.syncRange();
+      this.resizeObserver.observe(this.input);
+    });
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.resizeObserver.unobserve(this.input);
+  }
+  focus(options) {
+    this.input.focus(options);
+  }
+  blur() {
+    this.input.blur();
+  }
+  setCustomValidity(message) {
+    this.input.setCustomValidity(message);
+    this.invalid = !this.input.checkValidity();
+  }
+  handleInput() {
+    this.value = parseFloat(this.input.value);
+    this.emit("sl-change");
+    this.syncRange();
+  }
+  handleBlur() {
+    this.hasFocus = false;
+    this.hasTooltip = false;
+    this.emit("sl-blur");
+  }
+  handleValueChange() {
+    this.invalid = !this.input.checkValidity();
+    this.input.value = this.value.toString();
+    this.value = parseFloat(this.input.value);
+    this.syncRange();
+  }
+  handleDisabledChange() {
+    this.input.disabled = this.disabled;
+    this.invalid = !this.input.checkValidity();
+  }
+  handleFocus() {
+    this.hasFocus = true;
+    this.hasTooltip = true;
+    this.emit("sl-focus");
+  }
+  handleThumbDragStart() {
+    this.hasTooltip = true;
+  }
+  handleThumbDragEnd() {
+    this.hasTooltip = false;
+  }
+  syncRange() {
+    const percent = Math.max(0, (this.value - this.min) / (this.max - this.min));
+    this.syncProgress(percent);
+    if (this.tooltip !== "none") {
+      this.syncTooltip(percent);
+    }
+  }
+  syncProgress(percent) {
+    this.input.style.setProperty("--percent", `${percent * 100}%`);
+  }
+  syncTooltip(percent) {
+    if (this.output !== null) {
+      const inputWidth = this.input.offsetWidth;
+      const tooltipWidth = this.output.offsetWidth;
+      const thumbSize = getComputedStyle(this.input).getPropertyValue("--thumb-size");
+      const isRtl = this.localize.dir() === "rtl";
+      const percentAsWidth = inputWidth * percent;
+      if (isRtl) {
+        const x = `${inputWidth - percentAsWidth}px + ${percent} * ${thumbSize}`;
+        this.output.style.transform = `translateX(calc((${x} - ${tooltipWidth / 2}px - ${thumbSize} / 2)))`;
+      } else {
+        const x = `${percentAsWidth}px - ${percent} * ${thumbSize}`;
+        this.output.style.transform = `translateX(calc(${x} - ${tooltipWidth / 2}px + ${thumbSize} / 2))`;
+      }
+    }
+  }
+  render() {
+    const hasLabelSlot = this.hasSlotController.test("label");
+    const hasHelpTextSlot = this.hasSlotController.test("help-text");
+    const hasLabel = this.label ? true : !!hasLabelSlot;
+    const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
+    return $`
+      <div
+        part="form-control"
+        class=${o$3({
+      "form-control": true,
+      "form-control--medium": true,
+      "form-control--has-label": hasLabel,
+      "form-control--has-help-text": hasHelpText
+    })}
+      >
+        <label
+          part="form-control-label"
+          class="form-control__label"
+          for="input"
+          aria-hidden=${hasLabel ? "false" : "true"}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <div
+            part="base"
+            class=${o$3({
+      range: true,
+      "range--disabled": this.disabled,
+      "range--focused": this.hasFocus,
+      "range--rtl": this.localize.dir() === "rtl",
+      "range--tooltip-visible": this.hasTooltip,
+      "range--tooltip-top": this.tooltip === "top",
+      "range--tooltip-bottom": this.tooltip === "bottom"
+    })}
+            @mousedown=${this.handleThumbDragStart}
+            @mouseup=${this.handleThumbDragEnd}
+            @touchstart=${this.handleThumbDragStart}
+            @touchend=${this.handleThumbDragEnd}
+          >
+            <input
+              part="input"
+              id="input"
+              type="range"
+              class="range__control"
+              name=${l$2(this.name)}
+              ?disabled=${this.disabled}
+              min=${l$2(this.min)}
+              max=${l$2(this.max)}
+              step=${l$2(this.step)}
+              .value=${l$3(this.value.toString())}
+              aria-describedby="help-text"
+              @input=${this.handleInput}
+              @focus=${this.handleFocus}
+              @blur=${this.handleBlur}
+            />
+            ${this.tooltip !== "none" && !this.disabled ? $`
+                  <output part="tooltip" class="range__tooltip">
+                    ${typeof this.tooltipFormatter === "function" ? this.tooltipFormatter(this.value) : this.value}
+                  </output>
+                ` : ""}
+          </div>
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${hasHelpText ? "false" : "true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `;
+  }
+};
+SlRange.styles = range_styles_default;
+__decorateClass([
+  i2$2(".range__control")
+], SlRange.prototype, "input", 2);
+__decorateClass([
+  i2$2(".range__tooltip")
+], SlRange.prototype, "output", 2);
+__decorateClass([
+  t$1()
+], SlRange.prototype, "hasFocus", 2);
+__decorateClass([
+  t$1()
+], SlRange.prototype, "hasTooltip", 2);
+__decorateClass([
+  e$1()
+], SlRange.prototype, "name", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlRange.prototype, "value", 2);
+__decorateClass([
+  e$1()
+], SlRange.prototype, "label", 2);
+__decorateClass([
+  e$1({ attribute: "help-text" })
+], SlRange.prototype, "helpText", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlRange.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlRange.prototype, "invalid", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlRange.prototype, "min", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlRange.prototype, "max", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlRange.prototype, "step", 2);
+__decorateClass([
+  e$1()
+], SlRange.prototype, "tooltip", 2);
+__decorateClass([
+  e$1({ attribute: false })
+], SlRange.prototype, "tooltipFormatter", 2);
+__decorateClass([
+  defaultValue()
+], SlRange.prototype, "defaultValue", 2);
+__decorateClass([
+  watch("value", { waitUntilFirstUpdate: true })
+], SlRange.prototype, "handleValueChange", 1);
+__decorateClass([
+  watch("disabled", { waitUntilFirstUpdate: true })
+], SlRange.prototype, "handleDisabledChange", 1);
+__decorateClass([
+  watch("hasTooltip", { waitUntilFirstUpdate: true })
+], SlRange.prototype, "syncRange", 1);
+SlRange = __decorateClass([
+  n$1("sl-range")
+], SlRange);
+
+// src/components/rating/rating.styles.ts
+var rating_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --symbol-color: var(--sl-color-neutral-300);
+    --symbol-color-active: var(--sl-color-amber-500);
+    --symbol-size: 1.2rem;
+    --symbol-spacing: var(--sl-spacing-3x-small);
+
+    display: inline-flex;
+  }
+
+  .rating {
+    position: relative;
+    display: inline-flex;
+    border-radius: var(--sl-border-radius-medium);
+    vertical-align: middle;
+  }
+
+  .rating:focus {
+    outline: none;
+  }
+
+  .rating:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .rating__symbols {
+    display: inline-flex;
+    position: relative;
+    font-size: var(--symbol-size);
+    line-height: 0;
+    color: var(--symbol-color);
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .rating__symbols > * {
+    padding: var(--symbol-spacing);
+  }
+
+  .rating__symbols--indicator {
+    position: absolute;
+    top: 0;
+    left: 0;
+    color: var(--symbol-color-active);
+    pointer-events: none;
+  }
+
+  .rating__symbol {
+    transition: var(--sl-transition-fast) transform;
+  }
+
+  .rating__symbol--hover {
+    transform: scale(1.2);
+  }
+
+  .rating--disabled .rating__symbols,
+  .rating--readonly .rating__symbols {
+    cursor: default;
+  }
+
+  .rating--disabled .rating__symbol--hover,
+  .rating--readonly .rating__symbol--hover {
+    transform: none;
+  }
+
+  .rating--disabled {
+    opacity: 0.5;
+  }
+
+  .rating--disabled .rating__symbols {
+    cursor: not-allowed;
+  }
+`;
+
+// node_modules/lit-html/directives/style-map.js
+var i2$1 = e$2(class extends i$1 {
+  constructor(t2) {
+    var e2;
+    if (super(t2), t2.type !== t$2.ATTRIBUTE || "style" !== t2.name || (null === (e2 = t2.strings) || void 0 === e2 ? void 0 : e2.length) > 2)
+      throw Error("The `styleMap` directive must be used in the `style` attribute and must be the only part in the attribute.");
+  }
+  render(t2) {
+    return Object.keys(t2).reduce((e2, r) => {
+      const s = t2[r];
+      return null == s ? e2 : e2 + `${r = r.replace(/(?:^(webkit|moz|ms|o)|)(?=[A-Z])/g, "-$&").toLowerCase()}:${s};`;
+    }, "");
+  }
+  update(e2, [r]) {
+    const { style: s } = e2.element;
+    if (void 0 === this.ct) {
+      this.ct = /* @__PURE__ */ new Set();
+      for (const t2 in r)
+        this.ct.add(t2);
+      return this.render(r);
+    }
+    this.ct.forEach((t2) => {
+      null == r[t2] && (this.ct.delete(t2), t2.includes("-") ? s.removeProperty(t2) : s[t2] = "");
+    });
+    for (const t2 in r) {
+      const e3 = r[t2];
+      null != e3 && (this.ct.add(t2), t2.includes("-") ? s.setProperty(t2, e3) : s[t2] = e3);
+    }
+    return b$1;
+  }
+});
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// src/utilities/base-path.ts
+var basePath = "";
+function setBasePath(path) {
+  basePath = path;
+}
+function getBasePath() {
+  if (!basePath) {
+    const scripts = [...document.getElementsByTagName("script")];
+    const configScript = scripts.find((script) => script.hasAttribute("data-shoelace"));
+    if (configScript) {
+      setBasePath(configScript.getAttribute("data-shoelace"));
+    } else {
+      const fallbackScript = scripts.find((s) => /shoelace(\.min)?\.js($|\?)/.test(s.src));
+      let path = "";
+      if (fallbackScript) {
+        path = fallbackScript.getAttribute("src");
+      }
+      setBasePath(path.split("/").slice(0, -1).join("/"));
+    }
+  }
+  return basePath.replace(/\/$/, "");
+}
+
+// src/components/icon/library.default.ts
+var library = {
+  name: "default",
+  resolver: (name) => `${getBasePath()}/assets/icons/${name}.svg`
+};
+var library_default_default = library;
+
+// src/components/icon/library.system.ts
+var icons = {
+  "check-lg": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-lg" viewBox="0 0 16 16">
+      <path d="M12.736 3.97a.733.733 0 0 1 1.047 0c.286.289.29.756.01 1.05L7.88 12.01a.733.733 0 0 1-1.065.02L3.217 8.384a.757.757 0 0 1 0-1.06.733.733 0 0 1 1.047 0l3.052 3.093 5.4-6.425a.247.247 0 0 1 .02-.022Z"></path>
+    </svg>
+  `,
+  "chevron-down": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+    </svg>
+  `,
+  "chevron-left": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
+    </svg>
+  `,
+  "chevron-right": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
+    </svg>
+  `,
+  eye: `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye" viewBox="0 0 16 16">
+      <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.134 13.134 0 0 1 1.172 8z"/>
+      <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/>
+    </svg>
+  `,
+  "eye-slash": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-slash" viewBox="0 0 16 16">
+      <path d="M13.359 11.238C15.06 9.72 16 8 16 8s-3-5.5-8-5.5a7.028 7.028 0 0 0-2.79.588l.77.771A5.944 5.944 0 0 1 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.134 13.134 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755-.165.165-.337.328-.517.486l.708.709z"/>
+      <path d="M11.297 9.176a3.5 3.5 0 0 0-4.474-4.474l.823.823a2.5 2.5 0 0 1 2.829 2.829l.822.822zm-2.943 1.299.822.822a3.5 3.5 0 0 1-4.474-4.474l.823.823a2.5 2.5 0 0 0 2.829 2.829z"/>
+      <path d="M3.35 5.47c-.18.16-.353.322-.518.487A13.134 13.134 0 0 0 1.172 8l.195.288c.335.48.83 1.12 1.465 1.755C4.121 11.332 5.881 12.5 8 12.5c.716 0 1.39-.133 2.02-.36l.77.772A7.029 7.029 0 0 1 8 13.5C3 13.5 0 8 0 8s.939-1.721 2.641-3.238l.708.709zm10.296 8.884-12-12 .708-.708 12 12-.708.708z"/>
+    </svg>
+  `,
+  eyedropper: `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eyedropper" viewBox="0 0 16 16">
+      <path d="M13.354.646a1.207 1.207 0 0 0-1.708 0L8.5 3.793l-.646-.647a.5.5 0 1 0-.708.708L8.293 5l-7.147 7.146A.5.5 0 0 0 1 12.5v1.793l-.854.853a.5.5 0 1 0 .708.707L1.707 15H3.5a.5.5 0 0 0 .354-.146L11 7.707l1.146 1.147a.5.5 0 0 0 .708-.708l-.647-.646 3.147-3.146a1.207 1.207 0 0 0 0-1.708l-2-2zM2 12.707l7-7L10.293 7l-7 7H2v-1.293z"></path>
+    </svg>
+  `,
+  "person-fill": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-person-fill" viewBox="0 0 16 16">
+      <path d="M3 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H3zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/>
+    </svg>
+  `,
+  "play-fill": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-fill" viewBox="0 0 16 16">
+      <path d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z"></path>
+    </svg>
+  `,
+  "pause-fill": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pause-fill" viewBox="0 0 16 16">
+      <path d="M5.5 3.5A1.5 1.5 0 0 1 7 5v6a1.5 1.5 0 0 1-3 0V5a1.5 1.5 0 0 1 1.5-1.5zm5 0A1.5 1.5 0 0 1 12 5v6a1.5 1.5 0 0 1-3 0V5a1.5 1.5 0 0 1 1.5-1.5z"></path>
+    </svg>
+  `,
+  "star-fill": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-star-fill" viewBox="0 0 16 16">
+      <path d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z"/>
+    </svg>
+  `,
+  x: `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x" viewBox="0 0 16 16">
+      <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
+    </svg>
+  `,
+  "x-circle-fill": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-circle-fill" viewBox="0 0 16 16">
+      <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.354 4.646a.5.5 0 1 0-.708.708L7.293 8l-2.647 2.646a.5.5 0 0 0 .708.708L8 8.707l2.646 2.647a.5.5 0 0 0 .708-.708L8.707 8l2.647-2.646a.5.5 0 0 0-.708-.708L8 7.293 5.354 4.646z"></path>
+    </svg>
+  `
+};
+var systemLibrary = {
+  name: "system",
+  resolver: (name) => {
+    if (name in icons) {
+      return `data:image/svg+xml,${encodeURIComponent(icons[name])}`;
+    }
+    return "";
+  }
+};
+var library_system_default = systemLibrary;
+
+// src/components/icon/library.ts
+var registry = [library_default_default, library_system_default];
+var watchedIcons = [];
+function watchIcon(icon) {
+  watchedIcons.push(icon);
+}
+function unwatchIcon(icon) {
+  watchedIcons = watchedIcons.filter((el) => el !== icon);
+}
+function getIconLibrary(name) {
+  return registry.find((lib) => lib.name === name);
+}
+
+// src/components/include/request.ts
+var includeFiles = /* @__PURE__ */ new Map();
+function requestInclude(src, mode = "cors") {
+  if (includeFiles.has(src)) {
+    return includeFiles.get(src);
+  }
+  const fileDataPromise = fetch(src, { mode }).then(async (response) => {
+    return {
+      ok: response.ok,
+      status: response.status,
+      html: await response.text()
+    };
+  });
+  includeFiles.set(src, fileDataPromise);
+  return fileDataPromise;
+}
+
+// src/components/icon/request.ts
+var iconFiles = /* @__PURE__ */ new Map();
+async function requestIcon(url) {
+  if (iconFiles.has(url)) {
+    return iconFiles.get(url);
+  }
+  const fileData = await requestInclude(url);
+  const iconFileData = {
+    ok: fileData.ok,
+    status: fileData.status,
+    svg: null
+  };
+  if (fileData.ok) {
+    const div = document.createElement("div");
+    div.innerHTML = fileData.html;
+    const svg = div.firstElementChild;
+    iconFileData.svg = (svg == null ? void 0 : svg.tagName.toLowerCase()) === "svg" ? svg.outerHTML : "";
+  }
+  iconFiles.set(url, iconFileData);
+  return iconFileData;
+}
+
+// src/components/icon/icon.styles.ts
+var icon_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    contain: strict;
+    box-sizing: content-box !important;
+  }
+
+  .icon,
+  svg {
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+`;
+
+// node_modules/lit-html/directives/unsafe-html.js
+var e3 = class extends i$1 {
+  constructor(i2) {
+    if (super(i2), this.it = w, i2.type !== t$2.CHILD)
+      throw Error(this.constructor.directiveName + "() can only be used in child bindings");
+  }
+  render(r) {
+    if (r === w || null == r)
+      return this.ft = void 0, this.it = r;
+    if (r === b$1)
+      return r;
+    if ("string" != typeof r)
+      throw Error(this.constructor.directiveName + "() called with a non-string value");
+    if (r === this.it)
+      return this.ft;
+    this.it = r;
+    const s = [r];
+    return s.raw = s, this.ft = { _$litType$: this.constructor.resultType, strings: s, values: [] };
+  }
+};
+e3.directiveName = "unsafeHTML", e3.resultType = 1;
+var o = e$2(e3);
+
+// node_modules/lit-html/directives/unsafe-svg.js
+var t3 = class extends e3 {
+};
+t3.directiveName = "unsafeSVG", t3.resultType = 2;
+var o2$1 = e$2(t3);
+
+// src/components/icon/icon.ts
+var parser;
+var SlIcon = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.svg = "";
+    this.label = "";
+    this.library = "default";
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    watchIcon(this);
+  }
+  firstUpdated() {
+    this.setIcon();
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    unwatchIcon(this);
+  }
+  getUrl() {
+    const library = getIconLibrary(this.library);
+    if (this.name && library) {
+      return library.resolver(this.name);
+    }
+    return this.src;
+  }
+  redraw() {
+    this.setIcon();
+  }
+  async setIcon() {
+    var _a;
+    const library = getIconLibrary(this.library);
+    const url = this.getUrl();
+    if (!parser) {
+      parser = new DOMParser();
+    }
+    if (url) {
+      try {
+        const file = await requestIcon(url);
+        if (url !== this.getUrl()) {
+          return;
+        } else if (file.ok) {
+          const doc = parser.parseFromString(file.svg, "text/html");
+          const svgEl = doc.body.querySelector("svg");
+          if (svgEl !== null) {
+            (_a = library == null ? void 0 : library.mutator) == null ? void 0 : _a.call(library, svgEl);
+            this.svg = svgEl.outerHTML;
+            this.emit("sl-load");
+          } else {
+            this.svg = "";
+            this.emit("sl-error");
+          }
+        } else {
+          this.svg = "";
+          this.emit("sl-error");
+        }
+      } catch (e4) {
+        this.emit("sl-error");
+      }
+    } else if (this.svg.length > 0) {
+      this.svg = "";
+    }
+  }
+  handleChange() {
+    this.setIcon();
+  }
+  render() {
+    const hasLabel = typeof this.label === "string" && this.label.length > 0;
+    return $` <div
+      part="base"
+      class="icon"
+      role=${l$2(hasLabel ? "img" : void 0)}
+      aria-label=${l$2(hasLabel ? this.label : void 0)}
+      aria-hidden=${l$2(hasLabel ? void 0 : "true")}
+    >
+      ${o2$1(this.svg)}
+    </div>`;
+  }
+};
+SlIcon.styles = icon_styles_default;
+__decorateClass([
+  t$1()
+], SlIcon.prototype, "svg", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlIcon.prototype, "name", 2);
+__decorateClass([
+  e$1()
+], SlIcon.prototype, "src", 2);
+__decorateClass([
+  e$1()
+], SlIcon.prototype, "label", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlIcon.prototype, "library", 2);
+__decorateClass([
+  watch("name"),
+  watch("src"),
+  watch("library")
+], SlIcon.prototype, "setIcon", 1);
+SlIcon = __decorateClass([
+  n$1("sl-icon")
+], SlIcon);
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// src/components/rating/rating.ts
+var SlRating = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.hoverValue = 0;
+    this.isHovering = false;
+    this.label = "";
+    this.value = 0;
+    this.max = 5;
+    this.precision = 1;
+    this.readonly = false;
+    this.disabled = false;
+    this.getSymbol = () => '<sl-icon name="star-fill" library="system"></sl-icon>';
+  }
+  focus(options) {
+    this.rating.focus(options);
+  }
+  blur() {
+    this.rating.blur();
+  }
+  getValueFromMousePosition(event) {
+    return this.getValueFromXCoordinate(event.clientX);
+  }
+  getValueFromTouchPosition(event) {
+    return this.getValueFromXCoordinate(event.touches[0].clientX);
+  }
+  getValueFromXCoordinate(coordinate) {
+    const isRtl = this.localize.dir() === "rtl";
+    const { left, right, width } = this.rating.getBoundingClientRect();
+    const value = isRtl ? this.roundToPrecision((right - coordinate) / width * this.max, this.precision) : this.roundToPrecision((coordinate - left) / width * this.max, this.precision);
+    return clamp(value, 0, this.max);
+  }
+  handleClick(event) {
+    this.setValue(this.getValueFromMousePosition(event));
+  }
+  setValue(newValue) {
+    if (this.disabled || this.readonly) {
+      return;
+    }
+    this.value = newValue === this.value ? 0 : newValue;
+    this.isHovering = false;
+  }
+  handleKeyDown(event) {
+    const isLtr = this.localize.dir() === "ltr";
+    const isRtl = this.localize.dir() === "rtl";
+    if (this.disabled || this.readonly) {
+      return;
+    }
+    if (event.key === "ArrowDown" || isLtr && event.key === "ArrowLeft" || isRtl && event.key === "ArrowRight") {
+      const decrement = event.shiftKey ? 1 : this.precision;
+      this.value = Math.max(0, this.value - decrement);
+      event.preventDefault();
+    }
+    if (event.key === "ArrowUp" || isLtr && event.key === "ArrowRight" || isRtl && event.key === "ArrowLeft") {
+      const increment = event.shiftKey ? 1 : this.precision;
+      this.value = Math.min(this.max, this.value + increment);
+      event.preventDefault();
+    }
+    if (event.key === "Home") {
+      this.value = 0;
+      event.preventDefault();
+    }
+    if (event.key === "End") {
+      this.value = this.max;
+      event.preventDefault();
+    }
+  }
+  handleMouseEnter() {
+    this.isHovering = true;
+  }
+  handleMouseMove(event) {
+    this.hoverValue = this.getValueFromMousePosition(event);
+  }
+  handleMouseLeave() {
+    this.isHovering = false;
+  }
+  handleTouchStart(event) {
+    this.hoverValue = this.getValueFromTouchPosition(event);
+    event.preventDefault();
+  }
+  handleTouchMove(event) {
+    this.isHovering = true;
+    this.hoverValue = this.getValueFromTouchPosition(event);
+  }
+  handleTouchEnd(event) {
+    this.isHovering = false;
+    this.setValue(this.hoverValue);
+    event.preventDefault();
+  }
+  handleValueChange() {
+    this.emit("sl-change");
+  }
+  roundToPrecision(numberToRound, precision = 0.5) {
+    const multiplier = 1 / precision;
+    return Math.ceil(numberToRound * multiplier) / multiplier;
+  }
+  render() {
+    const isRtl = this.localize.dir() === "rtl";
+    const counter = Array.from(Array(this.max).keys());
+    let displayValue = 0;
+    if (this.disabled || this.readonly) {
+      displayValue = this.value;
+    } else {
+      displayValue = this.isHovering ? this.hoverValue : this.value;
+    }
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      rating: true,
+      "rating--readonly": this.readonly,
+      "rating--disabled": this.disabled,
+      "rating--rtl": isRtl
+    })}
+        role="slider"
+        aria-label=${this.label}
+        aria-disabled=${this.disabled ? "true" : "false"}
+        aria-readonly=${this.readonly ? "true" : "false"}
+        aria-valuenow=${this.value}
+        aria-valuemin=${0}
+        aria-valuemax=${this.max}
+        tabindex=${this.disabled ? "-1" : "0"}
+        @click=${this.handleClick}
+        @keydown=${this.handleKeyDown}
+        @mouseenter=${this.handleMouseEnter}
+        @touchstart=${this.handleTouchStart}
+        @mouseleave=${this.handleMouseLeave}
+        @touchend=${this.handleTouchEnd}
+        @mousemove=${this.handleMouseMove}
+        @touchmove=${this.handleTouchMove}
+      >
+        <span class="rating__symbols rating__symbols--inactive">
+          ${counter.map((index) => {
+      return $`
+              <span
+                class=${o$3({
+        rating__symbol: true,
+        "rating__symbol--hover": this.isHovering && Math.ceil(displayValue) === index + 1
+      })}
+                role="presentation"
+                @mouseenter=${this.handleMouseEnter}
+              >
+                ${o(this.getSymbol(index + 1))}
+              </span>
+            `;
+    })}
+        </span>
+
+        <span class="rating__symbols rating__symbols--indicator">
+          ${counter.map((index) => {
+      return $`
+              <span
+                class=${o$3({
+        rating__symbol: true,
+        "rating__symbol--hover": this.isHovering && Math.ceil(displayValue) === index + 1
+      })}
+                style=${i2$1({
+        clipPath: displayValue > index + 1 ? "none" : isRtl ? `inset(0 0 0 ${100 - (displayValue - index) / 1 * 100}%)` : `inset(0 ${100 - (displayValue - index) / 1 * 100}% 0 0)`
+      })}
+                role="presentation"
+              >
+                ${o(this.getSymbol(index + 1))}
+              </span>
+            `;
+    })}
+        </span>
+      </div>
+    `;
+  }
+};
+SlRating.styles = rating_styles_default;
+__decorateClass([
+  i2$2(".rating")
+], SlRating.prototype, "rating", 2);
+__decorateClass([
+  t$1()
+], SlRating.prototype, "hoverValue", 2);
+__decorateClass([
+  t$1()
+], SlRating.prototype, "isHovering", 2);
+__decorateClass([
+  e$1()
+], SlRating.prototype, "label", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlRating.prototype, "value", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlRating.prototype, "max", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlRating.prototype, "precision", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlRating.prototype, "readonly", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlRating.prototype, "disabled", 2);
+__decorateClass([
+  e$1()
+], SlRating.prototype, "getSymbol", 2);
+__decorateClass([
+  watch("value", { waitUntilFirstUpdate: true })
+], SlRating.prototype, "handleValueChange", 1);
+SlRating = __decorateClass([
+  n$1("sl-rating")
+], SlRating);
+
+// src/components/progress-bar/progress-bar.styles.ts
+var progress_bar_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --height: 1rem;
+    --track-color: var(--sl-color-neutral-200);
+    --indicator-color: var(--sl-color-primary-600);
+    --label-color: var(--sl-color-neutral-0);
+
+    display: block;
+  }
+
+  .progress-bar {
+    position: relative;
+    background-color: var(--track-color);
+    height: var(--height);
+    border-radius: var(--sl-border-radius-pill);
+    box-shadow: inset var(--sl-shadow-small);
+    overflow: hidden;
+  }
+
+  .progress-bar__indicator {
+    height: 100%;
+    font-family: var(--sl-font-sans);
+    font-size: 12px;
+    font-weight: var(--sl-font-weight-normal);
+    background-color: var(--indicator-color);
+    color: var(--label-color);
+    text-align: center;
+    line-height: var(--height);
+    white-space: nowrap;
+    overflow: hidden;
+    transition: 400ms width, 400ms background-color;
+    user-select: none;
+  }
+
+  /* Indeterminate */
+  .progress-bar--indeterminate .progress-bar__indicator {
+    position: absolute;
+    animation: indeterminate 2.5s infinite cubic-bezier(0.37, 0, 0.63, 1);
+  }
+
+  .progress-bar--indeterminate.progress-bar--rtl .progress-bar__indicator {
+    animation-name: indeterminate-rtl;
+  }
+
+  @keyframes indeterminate {
+    0% {
+      left: -50%;
+      width: 50%;
+    }
+    75%,
+    100% {
+      left: 100%;
+      width: 50%;
+    }
+  }
+
+  @keyframes indeterminate-rtl {
+    0% {
+      right: -50%;
+      width: 50%;
+    }
+    75%,
+    100% {
+      right: 100%;
+      width: 50%;
+    }
+  }
+`;
+
+// src/components/progress-bar/progress-bar.ts
+var SlProgressBar = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.value = 0;
+    this.indeterminate = false;
+    this.label = "";
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      "progress-bar": true,
+      "progress-bar--indeterminate": this.indeterminate,
+      "progress-bar--rtl": this.localize.dir() === "rtl"
+    })}
+        role="progressbar"
+        title=${l$2(this.title)}
+        aria-label=${this.label.length > 0 ? this.label : this.localize.term("progress")}
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow=${this.indeterminate ? 0 : this.value}
+      >
+        <div part="indicator" class="progress-bar__indicator" style=${i2$1({ width: `${this.value}%` })}>
+          ${!this.indeterminate ? $`
+                <span part="label" class="progress-bar__label">
+                  <slot></slot>
+                </span>
+              ` : ""}
+        </div>
+      </div>
+    `;
+  }
+};
+SlProgressBar.styles = progress_bar_styles_default;
+__decorateClass([
+  e$1({ type: Number, reflect: true })
+], SlProgressBar.prototype, "value", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlProgressBar.prototype, "indeterminate", 2);
+__decorateClass([
+  e$1()
+], SlProgressBar.prototype, "label", 2);
+SlProgressBar = __decorateClass([
+  n$1("sl-progress-bar")
+], SlProgressBar);
+
+// src/components/progress-ring/progress-ring.styles.ts
+var progress_ring_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --size: 128px;
+    --track-width: 4px;
+    --track-color: var(--sl-color-neutral-200);
+    --indicator-width: var(--track-width);
+    --indicator-color: var(--sl-color-primary-600);
+
+    display: inline-flex;
+  }
+
+  .progress-ring {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+  }
+
+  .progress-ring__image {
+    width: var(--size);
+    height: var(--size);
+    transform: rotate(-90deg);
+    transform-origin: 50% 50%;
+  }
+
+  .progress-ring__track,
+  .progress-ring__indicator {
+    --radius: calc(var(--size) / 2 - max(var(--track-width), var(--indicator-width)) * 0.5);
+    --circumference: calc(var(--radius) * 2 * 3.141592654);
+
+    fill: none;
+    r: var(--radius);
+    cx: calc(var(--size) / 2);
+    cy: calc(var(--size) / 2);
+  }
+
+  .progress-ring__track {
+    stroke: var(--track-color);
+    stroke-width: var(--track-width);
+  }
+
+  .progress-ring__indicator {
+    stroke: var(--indicator-color);
+    stroke-width: var(--indicator-width);
+    stroke-linecap: round;
+    transition: 0.35s stroke-dashoffset;
+    stroke-dasharray: var(--circumference) var(--circumference);
+    stroke-dashoffset: calc(var(--circumference) - var(--percentage) * var(--circumference));
+  }
+
+  .progress-ring__label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    user-select: none;
+  }
+`;
+
+// src/components/progress-ring/progress-ring.ts
+var SlProgressRing = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.value = 0;
+    this.label = "";
+  }
+  updated(changedProps) {
+    super.updated(changedProps);
+    if (changedProps.has("value")) {
+      const radius = parseFloat(getComputedStyle(this.indicator).getPropertyValue("r"));
+      const circumference = 2 * Math.PI * radius;
+      const offset = circumference - this.value / 100 * circumference;
+      this.indicatorOffset = `${offset}px`;
+    }
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class="progress-ring"
+        role="progressbar"
+        aria-label=${this.label.length > 0 ? this.label : this.localize.term("progress")}
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="${this.value}"
+        style="--percentage: ${this.value / 100}"
+      >
+        <svg class="progress-ring__image">
+          <circle class="progress-ring__track"></circle>
+          <circle class="progress-ring__indicator" style="stroke-dashoffset: ${this.indicatorOffset}"></circle>
+        </svg>
+
+        <span part="label" class="progress-ring__label">
+          <slot></slot>
+        </span>
+      </div>
+    `;
+  }
+};
+SlProgressRing.styles = progress_ring_styles_default;
+__decorateClass([
+  i2$2(".progress-ring__indicator")
+], SlProgressRing.prototype, "indicator", 2);
+__decorateClass([
+  t$1()
+], SlProgressRing.prototype, "indicatorOffset", 2);
+__decorateClass([
+  e$1({ type: Number, reflect: true })
+], SlProgressRing.prototype, "value", 2);
+__decorateClass([
+  e$1()
+], SlProgressRing.prototype, "label", 2);
+SlProgressRing = __decorateClass([
+  n$1("sl-progress-ring")
+], SlProgressRing);
+
+// src/components/qr-code/qr-code.styles.ts
+var qr_code_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .qr-code {
+    position: relative;
+  }
+
+  canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+// node_modules/qr-creator/dist/qr-creator.es6.min.js
+var G = null;
+var H$1 = class {
+};
+H$1.render = function(w, B) {
+  G(w, B);
+};
+self.QrCreator = H$1;
+(function(w) {
+  function B(t, c, a, e2) {
+    var b = {}, h = w(a, c);
+    h.u(t);
+    h.J();
+    e2 = e2 || 0;
+    var r = h.h(), d = h.h() + 2 * e2;
+    b.text = t;
+    b.level = c;
+    b.version = a;
+    b.O = d;
+    b.a = function(b2, a2) {
+      b2 -= e2;
+      a2 -= e2;
+      return 0 > b2 || b2 >= r || 0 > a2 || a2 >= r ? false : h.a(b2, a2);
+    };
+    return b;
+  }
+  function C(t, c, a, e2, b, h, r, d, g, x) {
+    function u(b2, a2, f, c2, d2, r2, g2) {
+      b2 ? (t.lineTo(a2 + r2, f + g2), t.arcTo(a2, f, c2, d2, h)) : t.lineTo(a2, f);
+    }
+    r ? t.moveTo(c + h, a) : t.moveTo(c, a);
+    u(d, e2, a, e2, b, -h, 0);
+    u(g, e2, b, c, b, 0, -h);
+    u(x, c, b, c, a, h, 0);
+    u(r, c, a, e2, a, 0, h);
+  }
+  function z(t, c, a, e2, b, h, r, d, g, x) {
+    function u(b2, a2, c2, d2) {
+      t.moveTo(b2 + c2, a2);
+      t.lineTo(
+        b2,
+        a2
+      );
+      t.lineTo(b2, a2 + d2);
+      t.arcTo(b2, a2, b2 + c2, a2, h);
+    }
+    r && u(c, a, h, h);
+    d && u(e2, a, -h, h);
+    g && u(e2, b, -h, -h);
+    x && u(c, b, h, -h);
+  }
+  function A(t, c) {
+    var a = c.fill;
+    if ("string" === typeof a)
+      t.fillStyle = a;
+    else {
+      var e2 = a.type, b = a.colorStops;
+      a = a.position.map((b2) => Math.round(b2 * c.size));
+      if ("linear-gradient" === e2)
+        var h = t.createLinearGradient.apply(t, a);
+      else if ("radial-gradient" === e2)
+        h = t.createRadialGradient.apply(t, a);
+      else
+        throw Error("Unsupported fill");
+      b.forEach(([b2, a2]) => {
+        h.addColorStop(b2, a2);
+      });
+      t.fillStyle = h;
+    }
+  }
+  function y(t, c) {
+    a: {
+      var a = c.text, e2 = c.v, b = c.N, h = c.K, r = c.P;
+      b = Math.max(1, b || 1);
+      for (h = Math.min(40, h || 40); b <= h; b += 1)
+        try {
+          var d = B(a, e2, b, r);
+          break a;
+        } catch (J) {
+        }
+      d = void 0;
+    }
+    if (!d)
+      return null;
+    a = t.getContext("2d");
+    c.background && (a.fillStyle = c.background, a.fillRect(c.left, c.top, c.size, c.size));
+    e2 = d.O;
+    h = c.size / e2;
+    a.beginPath();
+    for (r = 0; r < e2; r += 1)
+      for (b = 0; b < e2; b += 1) {
+        var g = a, x = c.left + b * h, u = c.top + r * h, p = r, q = b, f = d.a, k = x + h, m = u + h, D = p - 1, E = p + 1, n2 = q - 1, l = q + 1, y2 = Math.floor(Math.min(0.5, Math.max(0, c.R)) * h), v2 = f(p, q), I = f(D, n2), w2 = f(D, q);
+        D = f(D, l);
+        var F = f(p, l);
+        l = f(E, l);
+        q = f(
+          E,
+          q
+        );
+        E = f(E, n2);
+        p = f(p, n2);
+        x = Math.round(x);
+        u = Math.round(u);
+        k = Math.round(k);
+        m = Math.round(m);
+        v2 ? C(g, x, u, k, m, y2, !w2 && !p, !w2 && !F, !q && !F, !q && !p) : z(g, x, u, k, m, y2, w2 && p && I, w2 && F && D, q && F && l, q && p && E);
+      }
+    A(a, c);
+    a.fill();
+    return t;
+  }
+  var v = { minVersion: 1, maxVersion: 40, ecLevel: "L", left: 0, top: 0, size: 200, fill: "#000", background: null, text: "no text", radius: 0.5, quiet: 0 };
+  G = function(t, c) {
+    var a = {};
+    Object.assign(a, v, t);
+    a.N = a.minVersion;
+    a.K = a.maxVersion;
+    a.v = a.ecLevel;
+    a.left = a.left;
+    a.top = a.top;
+    a.size = a.size;
+    a.fill = a.fill;
+    a.background = a.background;
+    a.text = a.text;
+    a.R = a.radius;
+    a.P = a.quiet;
+    if (c instanceof HTMLCanvasElement) {
+      if (c.width !== a.size || c.height !== a.size)
+        c.width = a.size, c.height = a.size;
+      c.getContext("2d").clearRect(0, 0, c.width, c.height);
+      y(c, a);
+    } else
+      t = document.createElement("canvas"), t.width = a.size, t.height = a.size, a = y(t, a), c.appendChild(a);
+  };
+})(function() {
+  function w(c) {
+    var a = C.s(c);
+    return { S: function() {
+      return 4;
+    }, b: function() {
+      return a.length;
+    }, write: function(c2) {
+      for (var b = 0; b < a.length; b += 1)
+        c2.put(a[b], 8);
+    } };
+  }
+  function B() {
+    var c = [], a = 0, e2 = {
+      B: function() {
+        return c;
+      },
+      c: function(b) {
+        return 1 == (c[Math.floor(b / 8)] >>> 7 - b % 8 & 1);
+      },
+      put: function(b, h) {
+        for (var a2 = 0; a2 < h; a2 += 1)
+          e2.m(1 == (b >>> h - a2 - 1 & 1));
+      },
+      f: function() {
+        return a;
+      },
+      m: function(b) {
+        var h = Math.floor(a / 8);
+        c.length <= h && c.push(0);
+        b && (c[h] |= 128 >>> a % 8);
+        a += 1;
+      }
+    };
+    return e2;
+  }
+  function C(c, a) {
+    function e2(b2, h2) {
+      for (var a2 = -1; 7 >= a2; a2 += 1)
+        if (!(-1 >= b2 + a2 || d <= b2 + a2))
+          for (var c2 = -1; 7 >= c2; c2 += 1)
+            -1 >= h2 + c2 || d <= h2 + c2 || (r[b2 + a2][h2 + c2] = 0 <= a2 && 6 >= a2 && (0 == c2 || 6 == c2) || 0 <= c2 && 6 >= c2 && (0 == a2 || 6 == a2) || 2 <= a2 && 4 >= a2 && 2 <= c2 && 4 >= c2 ? true : false);
+    }
+    function b(b2, a2) {
+      for (var f = d = 4 * c + 17, k = Array(f), m = 0; m < f; m += 1) {
+        k[m] = Array(f);
+        for (var p = 0; p < f; p += 1)
+          k[m][p] = null;
+      }
+      r = k;
+      e2(0, 0);
+      e2(d - 7, 0);
+      e2(0, d - 7);
+      f = y.G(c);
+      for (k = 0; k < f.length; k += 1)
+        for (m = 0; m < f.length; m += 1) {
+          p = f[k];
+          var q = f[m];
+          if (null == r[p][q])
+            for (var n2 = -2; 2 >= n2; n2 += 1)
+              for (var l = -2; 2 >= l; l += 1)
+                r[p + n2][q + l] = -2 == n2 || 2 == n2 || -2 == l || 2 == l || 0 == n2 && 0 == l;
+        }
+      for (f = 8; f < d - 8; f += 1)
+        null == r[f][6] && (r[f][6] = 0 == f % 2);
+      for (f = 8; f < d - 8; f += 1)
+        null == r[6][f] && (r[6][f] = 0 == f % 2);
+      f = y.w(h << 3 | a2);
+      for (k = 0; 15 > k; k += 1)
+        m = !b2 && 1 == (f >> k & 1), r[6 > k ? k : 8 > k ? k + 1 : d - 15 + k][8] = m, r[8][8 > k ? d - k - 1 : 9 > k ? 15 - k : 14 - k] = m;
+      r[d - 8][8] = !b2;
+      if (7 <= c) {
+        f = y.A(c);
+        for (k = 0; 18 > k; k += 1)
+          m = !b2 && 1 == (f >> k & 1), r[Math.floor(k / 3)][k % 3 + d - 8 - 3] = m;
+        for (k = 0; 18 > k; k += 1)
+          m = !b2 && 1 == (f >> k & 1), r[k % 3 + d - 8 - 3][Math.floor(k / 3)] = m;
+      }
+      if (null == g) {
+        b2 = t.I(c, h);
+        f = B();
+        for (k = 0; k < x.length; k += 1)
+          m = x[k], f.put(4, 4), f.put(m.b(), y.f(4, c)), m.write(f);
+        for (k = m = 0; k < b2.length; k += 1)
+          m += b2[k].j;
+        if (f.f() > 8 * m)
+          throw Error("code length overflow. (" + f.f() + ">" + 8 * m + ")");
+        for (f.f() + 4 <= 8 * m && f.put(0, 4); 0 != f.f() % 8; )
+          f.m(false);
+        for (; !(f.f() >= 8 * m); ) {
+          f.put(236, 8);
+          if (f.f() >= 8 * m)
+            break;
+          f.put(17, 8);
+        }
+        var u2 = 0;
+        m = k = 0;
+        p = Array(b2.length);
+        q = Array(b2.length);
+        for (n2 = 0; n2 < b2.length; n2 += 1) {
+          var v2 = b2[n2].j, w2 = b2[n2].o - v2;
+          k = Math.max(k, v2);
+          m = Math.max(m, w2);
+          p[n2] = Array(v2);
+          for (l = 0; l < p[n2].length; l += 1)
+            p[n2][l] = 255 & f.B()[l + u2];
+          u2 += v2;
+          l = y.C(w2);
+          v2 = z(p[n2], l.b() - 1).l(l);
+          q[n2] = Array(l.b() - 1);
+          for (l = 0; l < q[n2].length; l += 1)
+            w2 = l + v2.b() - q[n2].length, q[n2][l] = 0 <= w2 ? v2.c(w2) : 0;
+        }
+        for (l = f = 0; l < b2.length; l += 1)
+          f += b2[l].o;
+        f = Array(f);
+        for (l = u2 = 0; l < k; l += 1)
+          for (n2 = 0; n2 < b2.length; n2 += 1)
+            l < p[n2].length && (f[u2] = p[n2][l], u2 += 1);
+        for (l = 0; l < m; l += 1)
+          for (n2 = 0; n2 < b2.length; n2 += 1)
+            l < q[n2].length && (f[u2] = q[n2][l], u2 += 1);
+        g = f;
+      }
+      b2 = g;
+      f = -1;
+      k = d - 1;
+      m = 7;
+      p = 0;
+      a2 = y.F(a2);
+      for (q = d - 1; 0 < q; q -= 2)
+        for (6 == q && --q; ; ) {
+          for (n2 = 0; 2 > n2; n2 += 1)
+            null == r[k][q - n2] && (l = false, p < b2.length && (l = 1 == (b2[p] >>> m & 1)), a2(k, q - n2) && (l = !l), r[k][q - n2] = l, --m, -1 == m && (p += 1, m = 7));
+          k += f;
+          if (0 > k || d <= k) {
+            k -= f;
+            f = -f;
+            break;
+          }
+        }
+    }
+    var h = A[a], r = null, d = 0, g = null, x = [], u = { u: function(b2) {
+      b2 = w(b2);
+      x.push(b2);
+      g = null;
+    }, a: function(b2, a2) {
+      if (0 > b2 || d <= b2 || 0 > a2 || d <= a2)
+        throw Error(b2 + "," + a2);
+      return r[b2][a2];
+    }, h: function() {
+      return d;
+    }, J: function() {
+      for (var a2 = 0, h2 = 0, c2 = 0; 8 > c2; c2 += 1) {
+        b(true, c2);
+        var d2 = y.D(u);
+        if (0 == c2 || a2 > d2)
+          a2 = d2, h2 = c2;
+      }
+      b(false, h2);
+    } };
+    return u;
+  }
+  function z(c, a) {
+    if ("undefined" == typeof c.length)
+      throw Error(c.length + "/" + a);
+    var e2 = function() {
+      for (var b2 = 0; b2 < c.length && 0 == c[b2]; )
+        b2 += 1;
+      for (var r = Array(c.length - b2 + a), d = 0; d < c.length - b2; d += 1)
+        r[d] = c[d + b2];
+      return r;
+    }(), b = { c: function(b2) {
+      return e2[b2];
+    }, b: function() {
+      return e2.length;
+    }, multiply: function(a2) {
+      for (var h = Array(b.b() + a2.b() - 1), c2 = 0; c2 < b.b(); c2 += 1)
+        for (var g = 0; g < a2.b(); g += 1)
+          h[c2 + g] ^= v.i(v.g(b.c(c2)) + v.g(a2.c(g)));
+      return z(h, 0);
+    }, l: function(a2) {
+      if (0 > b.b() - a2.b())
+        return b;
+      for (var c2 = v.g(b.c(0)) - v.g(a2.c(0)), h = Array(b.b()), g = 0; g < b.b(); g += 1)
+        h[g] = b.c(g);
+      for (g = 0; g < a2.b(); g += 1)
+        h[g] ^= v.i(v.g(a2.c(g)) + c2);
+      return z(h, 0).l(a2);
+    } };
+    return b;
+  }
+  C.s = function(c) {
+    for (var a = [], e2 = 0; e2 < c.length; e2++) {
+      var b = c.charCodeAt(e2);
+      128 > b ? a.push(b) : 2048 > b ? a.push(192 | b >> 6, 128 | b & 63) : 55296 > b || 57344 <= b ? a.push(224 | b >> 12, 128 | b >> 6 & 63, 128 | b & 63) : (e2++, b = 65536 + ((b & 1023) << 10 | c.charCodeAt(e2) & 1023), a.push(240 | b >> 18, 128 | b >> 12 & 63, 128 | b >> 6 & 63, 128 | b & 63));
+    }
+    return a;
+  };
+  var A = { L: 1, M: 0, Q: 3, H: 2 }, y = function() {
+    function c(b) {
+      for (var a2 = 0; 0 != b; )
+        a2 += 1, b >>>= 1;
+      return a2;
+    }
+    var a = [
+      [],
+      [6, 18],
+      [6, 22],
+      [6, 26],
+      [6, 30],
+      [6, 34],
+      [6, 22, 38],
+      [6, 24, 42],
+      [6, 26, 46],
+      [6, 28, 50],
+      [6, 30, 54],
+      [6, 32, 58],
+      [6, 34, 62],
+      [6, 26, 46, 66],
+      [6, 26, 48, 70],
+      [6, 26, 50, 74],
+      [6, 30, 54, 78],
+      [6, 30, 56, 82],
+      [6, 30, 58, 86],
+      [6, 34, 62, 90],
+      [6, 28, 50, 72, 94],
+      [6, 26, 50, 74, 98],
+      [6, 30, 54, 78, 102],
+      [6, 28, 54, 80, 106],
+      [6, 32, 58, 84, 110],
+      [6, 30, 58, 86, 114],
+      [6, 34, 62, 90, 118],
+      [6, 26, 50, 74, 98, 122],
+      [6, 30, 54, 78, 102, 126],
+      [6, 26, 52, 78, 104, 130],
+      [6, 30, 56, 82, 108, 134],
+      [6, 34, 60, 86, 112, 138],
+      [6, 30, 58, 86, 114, 142],
+      [6, 34, 62, 90, 118, 146],
+      [6, 30, 54, 78, 102, 126, 150],
+      [6, 24, 50, 76, 102, 128, 154],
+      [6, 28, 54, 80, 106, 132, 158],
+      [6, 32, 58, 84, 110, 136, 162],
+      [6, 26, 54, 82, 110, 138, 166],
+      [6, 30, 58, 86, 114, 142, 170]
+    ], e2 = { w: function(b) {
+      for (var a2 = b << 10; 0 <= c(a2) - c(1335); )
+        a2 ^= 1335 << c(a2) - c(1335);
+      return (b << 10 | a2) ^ 21522;
+    }, A: function(b) {
+      for (var a2 = b << 12; 0 <= c(a2) - c(7973); )
+        a2 ^= 7973 << c(a2) - c(7973);
+      return b << 12 | a2;
+    }, G: function(b) {
+      return a[b - 1];
+    }, F: function(b) {
+      switch (b) {
+        case 0:
+          return function(b2, a2) {
+            return 0 == (b2 + a2) % 2;
+          };
+        case 1:
+          return function(b2) {
+            return 0 == b2 % 2;
+          };
+        case 2:
+          return function(b2, a2) {
+            return 0 == a2 % 3;
+          };
+        case 3:
+          return function(b2, a2) {
+            return 0 == (b2 + a2) % 3;
+          };
+        case 4:
+          return function(b2, a2) {
+            return 0 == (Math.floor(b2 / 2) + Math.floor(a2 / 3)) % 2;
+          };
+        case 5:
+          return function(b2, a2) {
+            return 0 == b2 * a2 % 2 + b2 * a2 % 3;
+          };
+        case 6:
+          return function(b2, a2) {
+            return 0 == (b2 * a2 % 2 + b2 * a2 % 3) % 2;
+          };
+        case 7:
+          return function(b2, a2) {
+            return 0 == (b2 * a2 % 3 + (b2 + a2) % 2) % 2;
+          };
+        default:
+          throw Error("bad maskPattern:" + b);
+      }
+    }, C: function(b) {
+      for (var a2 = z([1], 0), c2 = 0; c2 < b; c2 += 1)
+        a2 = a2.multiply(z([1, v.i(c2)], 0));
+      return a2;
+    }, f: function(b, a2) {
+      if (4 != b || 1 > a2 || 40 < a2)
+        throw Error("mode: " + b + "; type: " + a2);
+      return 10 > a2 ? 8 : 16;
+    }, D: function(b) {
+      for (var a2 = b.h(), c2 = 0, d = 0; d < a2; d += 1)
+        for (var g = 0; g < a2; g += 1) {
+          for (var e3 = 0, t2 = b.a(d, g), p = -1; 1 >= p; p += 1)
+            if (!(0 > d + p || a2 <= d + p))
+              for (var q = -1; 1 >= q; q += 1)
+                0 > g + q || a2 <= g + q || (0 != p || 0 != q) && t2 == b.a(d + p, g + q) && (e3 += 1);
+          5 < e3 && (c2 += 3 + e3 - 5);
+        }
+      for (d = 0; d < a2 - 1; d += 1)
+        for (g = 0; g < a2 - 1; g += 1)
+          if (e3 = 0, b.a(d, g) && (e3 += 1), b.a(d + 1, g) && (e3 += 1), b.a(d, g + 1) && (e3 += 1), b.a(d + 1, g + 1) && (e3 += 1), 0 == e3 || 4 == e3)
+            c2 += 3;
+      for (d = 0; d < a2; d += 1)
+        for (g = 0; g < a2 - 6; g += 1)
+          b.a(d, g) && !b.a(d, g + 1) && b.a(d, g + 2) && b.a(d, g + 3) && b.a(d, g + 4) && !b.a(d, g + 5) && b.a(d, g + 6) && (c2 += 40);
+      for (g = 0; g < a2; g += 1)
+        for (d = 0; d < a2 - 6; d += 1)
+          b.a(d, g) && !b.a(d + 1, g) && b.a(d + 2, g) && b.a(d + 3, g) && b.a(d + 4, g) && !b.a(d + 5, g) && b.a(d + 6, g) && (c2 += 40);
+      for (g = e3 = 0; g < a2; g += 1)
+        for (d = 0; d < a2; d += 1)
+          b.a(d, g) && (e3 += 1);
+      return c2 += Math.abs(100 * e3 / a2 / a2 - 50) / 5 * 10;
+    } };
+    return e2;
+  }(), v = function() {
+    for (var c = Array(256), a = Array(256), e2 = 0; 8 > e2; e2 += 1)
+      c[e2] = 1 << e2;
+    for (e2 = 8; 256 > e2; e2 += 1)
+      c[e2] = c[e2 - 4] ^ c[e2 - 5] ^ c[e2 - 6] ^ c[e2 - 8];
+    for (e2 = 0; 255 > e2; e2 += 1)
+      a[c[e2]] = e2;
+    return { g: function(b) {
+      if (1 > b)
+        throw Error("glog(" + b + ")");
+      return a[b];
+    }, i: function(b) {
+      for (; 0 > b; )
+        b += 255;
+      for (; 256 <= b; )
+        b -= 255;
+      return c[b];
+    } };
+  }(), t = function() {
+    function c(b, c2) {
+      switch (c2) {
+        case A.L:
+          return a[4 * (b - 1)];
+        case A.M:
+          return a[4 * (b - 1) + 1];
+        case A.Q:
+          return a[4 * (b - 1) + 2];
+        case A.H:
+          return a[4 * (b - 1) + 3];
+      }
+    }
+    var a = [
+      [1, 26, 19],
+      [1, 26, 16],
+      [1, 26, 13],
+      [1, 26, 9],
+      [1, 44, 34],
+      [1, 44, 28],
+      [1, 44, 22],
+      [1, 44, 16],
+      [1, 70, 55],
+      [1, 70, 44],
+      [2, 35, 17],
+      [2, 35, 13],
+      [1, 100, 80],
+      [2, 50, 32],
+      [2, 50, 24],
+      [4, 25, 9],
+      [1, 134, 108],
+      [2, 67, 43],
+      [2, 33, 15, 2, 34, 16],
+      [2, 33, 11, 2, 34, 12],
+      [2, 86, 68],
+      [4, 43, 27],
+      [4, 43, 19],
+      [4, 43, 15],
+      [2, 98, 78],
+      [4, 49, 31],
+      [2, 32, 14, 4, 33, 15],
+      [4, 39, 13, 1, 40, 14],
+      [2, 121, 97],
+      [2, 60, 38, 2, 61, 39],
+      [4, 40, 18, 2, 41, 19],
+      [4, 40, 14, 2, 41, 15],
+      [2, 146, 116],
+      [
+        3,
+        58,
+        36,
+        2,
+        59,
+        37
+      ],
+      [4, 36, 16, 4, 37, 17],
+      [4, 36, 12, 4, 37, 13],
+      [2, 86, 68, 2, 87, 69],
+      [4, 69, 43, 1, 70, 44],
+      [6, 43, 19, 2, 44, 20],
+      [6, 43, 15, 2, 44, 16],
+      [4, 101, 81],
+      [1, 80, 50, 4, 81, 51],
+      [4, 50, 22, 4, 51, 23],
+      [3, 36, 12, 8, 37, 13],
+      [2, 116, 92, 2, 117, 93],
+      [6, 58, 36, 2, 59, 37],
+      [4, 46, 20, 6, 47, 21],
+      [7, 42, 14, 4, 43, 15],
+      [4, 133, 107],
+      [8, 59, 37, 1, 60, 38],
+      [8, 44, 20, 4, 45, 21],
+      [12, 33, 11, 4, 34, 12],
+      [3, 145, 115, 1, 146, 116],
+      [4, 64, 40, 5, 65, 41],
+      [11, 36, 16, 5, 37, 17],
+      [11, 36, 12, 5, 37, 13],
+      [5, 109, 87, 1, 110, 88],
+      [5, 65, 41, 5, 66, 42],
+      [5, 54, 24, 7, 55, 25],
+      [11, 36, 12, 7, 37, 13],
+      [5, 122, 98, 1, 123, 99],
+      [
+        7,
+        73,
+        45,
+        3,
+        74,
+        46
+      ],
+      [15, 43, 19, 2, 44, 20],
+      [3, 45, 15, 13, 46, 16],
+      [1, 135, 107, 5, 136, 108],
+      [10, 74, 46, 1, 75, 47],
+      [1, 50, 22, 15, 51, 23],
+      [2, 42, 14, 17, 43, 15],
+      [5, 150, 120, 1, 151, 121],
+      [9, 69, 43, 4, 70, 44],
+      [17, 50, 22, 1, 51, 23],
+      [2, 42, 14, 19, 43, 15],
+      [3, 141, 113, 4, 142, 114],
+      [3, 70, 44, 11, 71, 45],
+      [17, 47, 21, 4, 48, 22],
+      [9, 39, 13, 16, 40, 14],
+      [3, 135, 107, 5, 136, 108],
+      [3, 67, 41, 13, 68, 42],
+      [15, 54, 24, 5, 55, 25],
+      [15, 43, 15, 10, 44, 16],
+      [4, 144, 116, 4, 145, 117],
+      [17, 68, 42],
+      [17, 50, 22, 6, 51, 23],
+      [19, 46, 16, 6, 47, 17],
+      [2, 139, 111, 7, 140, 112],
+      [17, 74, 46],
+      [7, 54, 24, 16, 55, 25],
+      [34, 37, 13],
+      [
+        4,
+        151,
+        121,
+        5,
+        152,
+        122
+      ],
+      [4, 75, 47, 14, 76, 48],
+      [11, 54, 24, 14, 55, 25],
+      [16, 45, 15, 14, 46, 16],
+      [6, 147, 117, 4, 148, 118],
+      [6, 73, 45, 14, 74, 46],
+      [11, 54, 24, 16, 55, 25],
+      [30, 46, 16, 2, 47, 17],
+      [8, 132, 106, 4, 133, 107],
+      [8, 75, 47, 13, 76, 48],
+      [7, 54, 24, 22, 55, 25],
+      [22, 45, 15, 13, 46, 16],
+      [10, 142, 114, 2, 143, 115],
+      [19, 74, 46, 4, 75, 47],
+      [28, 50, 22, 6, 51, 23],
+      [33, 46, 16, 4, 47, 17],
+      [8, 152, 122, 4, 153, 123],
+      [22, 73, 45, 3, 74, 46],
+      [8, 53, 23, 26, 54, 24],
+      [12, 45, 15, 28, 46, 16],
+      [3, 147, 117, 10, 148, 118],
+      [3, 73, 45, 23, 74, 46],
+      [4, 54, 24, 31, 55, 25],
+      [11, 45, 15, 31, 46, 16],
+      [7, 146, 116, 7, 147, 117],
+      [21, 73, 45, 7, 74, 46],
+      [1, 53, 23, 37, 54, 24],
+      [19, 45, 15, 26, 46, 16],
+      [5, 145, 115, 10, 146, 116],
+      [19, 75, 47, 10, 76, 48],
+      [15, 54, 24, 25, 55, 25],
+      [23, 45, 15, 25, 46, 16],
+      [13, 145, 115, 3, 146, 116],
+      [2, 74, 46, 29, 75, 47],
+      [42, 54, 24, 1, 55, 25],
+      [23, 45, 15, 28, 46, 16],
+      [17, 145, 115],
+      [10, 74, 46, 23, 75, 47],
+      [10, 54, 24, 35, 55, 25],
+      [19, 45, 15, 35, 46, 16],
+      [17, 145, 115, 1, 146, 116],
+      [14, 74, 46, 21, 75, 47],
+      [29, 54, 24, 19, 55, 25],
+      [11, 45, 15, 46, 46, 16],
+      [13, 145, 115, 6, 146, 116],
+      [14, 74, 46, 23, 75, 47],
+      [44, 54, 24, 7, 55, 25],
+      [59, 46, 16, 1, 47, 17],
+      [12, 151, 121, 7, 152, 122],
+      [12, 75, 47, 26, 76, 48],
+      [39, 54, 24, 14, 55, 25],
+      [22, 45, 15, 41, 46, 16],
+      [6, 151, 121, 14, 152, 122],
+      [6, 75, 47, 34, 76, 48],
+      [46, 54, 24, 10, 55, 25],
+      [2, 45, 15, 64, 46, 16],
+      [17, 152, 122, 4, 153, 123],
+      [29, 74, 46, 14, 75, 47],
+      [49, 54, 24, 10, 55, 25],
+      [24, 45, 15, 46, 46, 16],
+      [4, 152, 122, 18, 153, 123],
+      [13, 74, 46, 32, 75, 47],
+      [48, 54, 24, 14, 55, 25],
+      [42, 45, 15, 32, 46, 16],
+      [20, 147, 117, 4, 148, 118],
+      [40, 75, 47, 7, 76, 48],
+      [43, 54, 24, 22, 55, 25],
+      [10, 45, 15, 67, 46, 16],
+      [19, 148, 118, 6, 149, 119],
+      [18, 75, 47, 31, 76, 48],
+      [34, 54, 24, 34, 55, 25],
+      [20, 45, 15, 61, 46, 16]
+    ], e2 = { I: function(b, a2) {
+      var e3 = c(b, a2);
+      if ("undefined" == typeof e3)
+        throw Error("bad rs block @ typeNumber:" + b + "/errorCorrectLevel:" + a2);
+      b = e3.length / 3;
+      a2 = [];
+      for (var d = 0; d < b; d += 1)
+        for (var g = e3[3 * d], h = e3[3 * d + 1], t2 = e3[3 * d + 2], p = 0; p < g; p += 1) {
+          var q = t2, f = {};
+          f.o = h;
+          f.j = q;
+          a2.push(f);
+        }
+      return a2;
+    } };
+    return e2;
+  }();
+  return C;
+}());
+var qr_creator_es6_min_default = QrCreator;
+
+// src/components/qr-code/qr-code.ts
+var SlQrCode = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.value = "";
+    this.label = "";
+    this.size = 128;
+    this.fill = "#000";
+    this.background = "#fff";
+    this.radius = 0;
+    this.errorCorrection = "H";
+  }
+  firstUpdated() {
+    this.generate();
+  }
+  generate() {
+    if (!this.hasUpdated) {
+      return;
+    }
+    qr_creator_es6_min_default.render(
+      {
+        text: this.value,
+        radius: this.radius,
+        ecLevel: this.errorCorrection,
+        fill: this.fill,
+        background: this.background === "transparent" ? null : this.background,
+        size: this.size * 2
+      },
+      this.canvas
+    );
+  }
+  render() {
+    return $`
+      <div
+        class="qr-code"
+        part="base"
+        style=${i2$1({
+      width: `${this.size}px`,
+      height: `${this.size}px`
+    })}
+      >
+        <canvas role="img" aria-label=${this.label.length > 0 ? this.label : this.value}></canvas>
+      </div>
+    `;
+  }
+};
+SlQrCode.styles = qr_code_styles_default;
+__decorateClass([
+  i2$2("canvas")
+], SlQrCode.prototype, "canvas", 2);
+__decorateClass([
+  e$1()
+], SlQrCode.prototype, "value", 2);
+__decorateClass([
+  e$1()
+], SlQrCode.prototype, "label", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlQrCode.prototype, "size", 2);
+__decorateClass([
+  e$1()
+], SlQrCode.prototype, "fill", 2);
+__decorateClass([
+  e$1()
+], SlQrCode.prototype, "background", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlQrCode.prototype, "radius", 2);
+__decorateClass([
+  e$1({ attribute: "error-correction" })
+], SlQrCode.prototype, "errorCorrection", 2);
+__decorateClass([
+  watch("background"),
+  watch("errorCorrection"),
+  watch("fill"),
+  watch("radius"),
+  watch("size"),
+  watch("value")
+], SlQrCode.prototype, "generate", 1);
+SlQrCode = __decorateClass([
+  n$1("sl-qr-code")
+], SlQrCode);
+
+// src/components/radio/radio.styles.ts
+var radio_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  :host(:focus-visible) {
+    outline: 0px;
+  }
+
+  .radio {
+    display: inline-flex;
+    align-items: top;
+    font-family: var(--sl-input-font-family);
+    font-size: var(--sl-input-font-size-medium);
+    font-weight: var(--sl-input-font-weight);
+    color: var(--sl-input-color);
+    vertical-align: middle;
+    cursor: pointer;
+  }
+
+  .radio__icon {
+    display: inline-flex;
+    width: var(--sl-toggle-size);
+    height: var(--sl-toggle-size);
+  }
+
+  .radio__icon svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  .radio__control {
+    flex: 0 0 auto;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--sl-toggle-size);
+    height: var(--sl-toggle-size);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+    border-radius: 50%;
+    background-color: var(--sl-input-background-color);
+    color: transparent;
+    transition: var(--sl-transition-fast) border-color, var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) color, var(--sl-transition-fast) box-shadow;
+  }
+
+  .radio__input {
+    position: absolute;
+    opacity: 0;
+    padding: 0;
+    margin: 0;
+    pointer-events: none;
+  }
+
+  /* Hover */
+  .radio:not(.radio--checked):not(.radio--disabled) .radio__control:hover {
+    border-color: var(--sl-input-border-color-hover);
+    background-color: var(--sl-input-background-color-hover);
+  }
+
+  /* Checked */
+  .radio--checked .radio__control {
+    color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-primary-600);
+    background-color: var(--sl-color-primary-600);
+  }
+
+  /* Checked + hover */
+  .radio.radio--checked:not(.radio--disabled) .radio__control:hover {
+    border-color: var(--sl-color-primary-500);
+    background-color: var(--sl-color-primary-500);
+  }
+
+  /* Checked + focus */
+  :host(:focus-visible) .radio__control {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Disabled */
+  .radio--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* When the control isn't checked, hide the circle for Windows High Contrast mode a11y */
+  .radio:not(.radio--checked) svg circle {
+    opacity: 0;
+  }
+
+  .radio__label {
+    color: var(--sl-input-label-color);
+    line-height: var(--sl-toggle-size);
+    margin-inline-start: 0.5em;
+    user-select: none;
+  }
+`;
+
+// src/components/radio/radio.ts
+var SlRadio = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.checked = false;
+    this.hasFocus = false;
+    this.disabled = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.setInitialAttributes();
+    this.addEventListeners();
+  }
+  handleCheckedChange() {
+    this.setAttribute("aria-checked", this.checked ? "true" : "false");
+    this.setAttribute("tabindex", this.checked ? "0" : "-1");
+  }
+  handleDisabledChange() {
+    this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+  }
+  handleBlur() {
+    this.hasFocus = false;
+    this.emit("sl-blur");
+  }
+  handleClick() {
+    if (!this.disabled) {
+      this.checked = true;
+    }
+  }
+  handleFocus() {
+    this.hasFocus = true;
+    this.emit("sl-focus");
+  }
+  addEventListeners() {
+    this.addEventListener("blur", () => this.handleBlur());
+    this.addEventListener("click", () => this.handleClick());
+    this.addEventListener("focus", () => this.handleFocus());
+  }
+  setInitialAttributes() {
+    this.setAttribute("role", "radio");
+    this.setAttribute("tabindex", "-1");
+    this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+  }
+  render() {
+    return $`
+      <span
+        part="base"
+        class=${o$3({
+      radio: true,
+      "radio--checked": this.checked,
+      "radio--disabled": this.disabled,
+      "radio--focused": this.hasFocus
+    })}
+      >
+        <span part="control" class="radio__control">
+          <svg part="checked-icon" class="radio__icon" viewBox="0 0 16 16">
+            <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+              <g fill="currentColor">
+                <circle cx="8" cy="8" r="3.42857143"></circle>
+              </g>
+            </g>
+          </svg>
+        </span>
+
+        <span part="label" class="radio__label">
+          <slot></slot>
+        </span>
+      </span>
+    `;
+  }
+};
+SlRadio.styles = radio_styles_default;
+__decorateClass([
+  t$1()
+], SlRadio.prototype, "checked", 2);
+__decorateClass([
+  t$1()
+], SlRadio.prototype, "hasFocus", 2);
+__decorateClass([
+  e$1()
+], SlRadio.prototype, "value", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlRadio.prototype, "disabled", 2);
+__decorateClass([
+  watch("checked")
+], SlRadio.prototype, "handleCheckedChange", 1);
+__decorateClass([
+  watch("disabled", { waitUntilFirstUpdate: true })
+], SlRadio.prototype, "handleDisabledChange", 1);
+SlRadio = __decorateClass([
+  n$1("sl-radio")
+], SlRadio);
+
+// src/components/menu-item/menu-item.styles.ts
+var menu_item_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .menu-item {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+    font-weight: var(--sl-font-weight-normal);
+    line-height: var(--sl-line-height-normal);
+    letter-spacing: var(--sl-letter-spacing-normal);
+    color: var(--sl-color-neutral-700);
+    padding: var(--sl-spacing-2x-small) var(--sl-spacing-2x-small);
+    transition: var(--sl-transition-fast) fill;
+    user-select: none;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .menu-item.menu-item--disabled {
+    outline: none;
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .menu-item .menu-item__label {
+    flex: 1 1 auto;
+  }
+
+  .menu-item .menu-item__prefix {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .menu-item .menu-item__prefix ::slotted(*) {
+    margin-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .menu-item .menu-item__suffix {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .menu-item .menu-item__suffix ::slotted(*) {
+    margin-inline-start: var(--sl-spacing-x-small);
+  }
+
+  :host(:focus) {
+    outline: none;
+  }
+
+  :host(:hover:not([aria-disabled='true'])) .menu-item,
+  :host(:focus-visible:not(.sl-focus-invisible):not([aria-disabled='true'])) .menu-item {
+    outline: none;
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .menu-item .menu-item__check,
+  .menu-item .menu-item__chevron {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5em;
+    visibility: hidden;
+  }
+
+  .menu-item--checked .menu-item__check,
+  .menu-item--has-submenu .menu-item__chevron {
+    visibility: visible;
+  }
+`;
+
+// src/components/menu-item/menu-item.ts
+var SlMenuItem = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.checked = false;
+    this.value = "";
+    this.disabled = false;
+  }
+  firstUpdated() {
+    this.setAttribute("role", "menuitem");
+  }
+  getTextLabel() {
+    return getTextContent(this.defaultSlot);
+  }
+  handleCheckedChange() {
+    this.setAttribute("aria-checked", this.checked ? "true" : "false");
+  }
+  handleDisabledChange() {
+    this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+  }
+  handleDefaultSlotChange() {
+    const textLabel = this.getTextLabel();
+    if (typeof this.cachedTextLabel === "undefined") {
+      this.cachedTextLabel = textLabel;
+      return;
+    }
+    if (textLabel !== this.cachedTextLabel) {
+      this.cachedTextLabel = textLabel;
+      this.emit("sl-label-change");
+    }
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      "menu-item": true,
+      "menu-item--checked": this.checked,
+      "menu-item--disabled": this.disabled,
+      "menu-item--has-submenu": false
+    })}
+      >
+        <span part="checked-icon" class="menu-item__check">
+          <sl-icon name="check-lg" library="system" aria-hidden="true"></sl-icon>
+        </span>
+
+        <span part="prefix" class="menu-item__prefix">
+          <slot name="prefix"></slot>
+        </span>
+
+        <span part="label" class="menu-item__label">
+          <slot @slotchange=${this.handleDefaultSlotChange}></slot>
+        </span>
+
+        <span part="suffix" class="menu-item__suffix">
+          <slot name="suffix"></slot>
+        </span>
+
+        <span class="menu-item__chevron">
+          <sl-icon name="chevron-right" library="system" aria-hidden="true"></sl-icon>
+        </span>
+      </div>
+    `;
+  }
+};
+SlMenuItem.styles = menu_item_styles_default;
+__decorateClass([
+  i2$2("slot:not([name])")
+], SlMenuItem.prototype, "defaultSlot", 2);
+__decorateClass([
+  i2$2(".menu-item")
+], SlMenuItem.prototype, "menuItem", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlMenuItem.prototype, "checked", 2);
+__decorateClass([
+  e$1()
+], SlMenuItem.prototype, "value", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlMenuItem.prototype, "disabled", 2);
+__decorateClass([
+  watch("checked")
+], SlMenuItem.prototype, "handleCheckedChange", 1);
+__decorateClass([
+  watch("disabled")
+], SlMenuItem.prototype, "handleDisabledChange", 1);
+SlMenuItem = __decorateClass([
+  n$1("sl-menu-item")
+], SlMenuItem);
+
+// src/components/menu-label/menu-label.styles.ts
+var menu_label_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .menu-label {
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-small);
+    font-weight: var(--sl-font-weight-semibold);
+    line-height: var(--sl-line-height-normal);
+    letter-spacing: var(--sl-letter-spacing-normal);
+    color: var(--sl-color-neutral-500);
+    padding: var(--sl-spacing-2x-small) var(--sl-spacing-x-large);
+    user-select: none;
+  }
+`;
+
+// src/components/menu-label/menu-label.ts
+var SlMenuLabel = class extends ShoelaceElement {
+  render() {
+    return $`
+      <div part="base" class="menu-label">
+        <slot></slot>
+      </div>
+    `;
+  }
+};
+SlMenuLabel.styles = menu_label_styles_default;
+SlMenuLabel = __decorateClass([
+  n$1("sl-menu-label")
+], SlMenuLabel);
+
+// src/components/mutation-observer/mutation-observer.styles.ts
+var mutation_observer_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: contents;
+  }
+`;
+
+// src/components/mutation-observer/mutation-observer.ts
+var SlMutationObserver = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.attrOldValue = false;
+    this.charData = false;
+    this.charDataOldValue = false;
+    this.childList = false;
+    this.disabled = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.handleMutation = this.handleMutation.bind(this);
+    this.mutationObserver = new MutationObserver(this.handleMutation);
+    if (!this.disabled) {
+      this.startObserver();
+    }
+  }
+  disconnectedCallback() {
+    this.stopObserver();
+  }
+  handleDisabledChange() {
+    if (this.disabled) {
+      this.stopObserver();
+    } else {
+      this.startObserver();
+    }
+  }
+  handleChange() {
+    this.stopObserver();
+    this.startObserver();
+  }
+  handleMutation(mutationList) {
+    this.emit("sl-mutation", {
+      detail: { mutationList }
+    });
+  }
+  startObserver() {
+    const observeAttributes = typeof this.attr === "string" && this.attr.length > 0;
+    const attributeFilter = observeAttributes && this.attr !== "*" ? this.attr.split(" ") : void 0;
+    try {
+      this.mutationObserver.observe(this, {
+        subtree: true,
+        childList: this.childList,
+        attributes: observeAttributes,
+        attributeFilter,
+        attributeOldValue: this.attrOldValue,
+        characterData: this.charData,
+        characterDataOldValue: this.charDataOldValue
+      });
+    } catch (e2) {
+    }
+  }
+  stopObserver() {
+    this.mutationObserver.disconnect();
+  }
+  render() {
+    return $` <slot></slot> `;
+  }
+};
+SlMutationObserver.styles = mutation_observer_styles_default;
+__decorateClass([
+  e$1({ reflect: true })
+], SlMutationObserver.prototype, "attr", 2);
+__decorateClass([
+  e$1({ attribute: "attr-old-value", type: Boolean, reflect: true })
+], SlMutationObserver.prototype, "attrOldValue", 2);
+__decorateClass([
+  e$1({ attribute: "char-data", type: Boolean, reflect: true })
+], SlMutationObserver.prototype, "charData", 2);
+__decorateClass([
+  e$1({ attribute: "char-data-old-value", type: Boolean, reflect: true })
+], SlMutationObserver.prototype, "charDataOldValue", 2);
+__decorateClass([
+  e$1({ attribute: "child-list", type: Boolean, reflect: true })
+], SlMutationObserver.prototype, "childList", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlMutationObserver.prototype, "disabled", 2);
+__decorateClass([
+  watch("disabled")
+], SlMutationObserver.prototype, "handleDisabledChange", 1);
+__decorateClass([
+  watch("attr", { waitUntilFirstUpdate: true }),
+  watch("attr-old-value", { waitUntilFirstUpdate: true }),
+  watch("char-data", { waitUntilFirstUpdate: true }),
+  watch("char-data-old-value", { waitUntilFirstUpdate: true }),
+  watch("childList", { waitUntilFirstUpdate: true })
+], SlMutationObserver.prototype, "handleChange", 1);
+SlMutationObserver = __decorateClass([
+  n$1("sl-mutation-observer")
+], SlMutationObserver);
+
+// src/components/image-comparer/image-comparer.styles.ts
+var image_comparer_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --divider-width: 2px;
+    --handle-size: 2.5rem;
+
+    display: inline-block;
+    position: relative;
+  }
+
+  .image-comparer {
+    max-width: 100%;
+    max-height: 100%;
+    overflow: hidden;
+  }
+
+  .image-comparer__before,
+  .image-comparer__after {
+    pointer-events: none;
+  }
+
+  .image-comparer__before ::slotted(img),
+  .image-comparer__after ::slotted(img),
+  .image-comparer__before ::slotted(svg),
+  .image-comparer__after ::slotted(svg) {
+    display: block;
+    max-width: 100% !important;
+    height: auto;
+  }
+
+  .image-comparer__after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+  }
+
+  .image-comparer__divider {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0;
+    width: var(--divider-width);
+    height: 100%;
+    background-color: var(--sl-color-neutral-0);
+    transform: translateX(calc(var(--divider-width) / -2));
+    cursor: ew-resize;
+  }
+
+  .image-comparer__handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: calc(50% - (var(--handle-size) / 2));
+    width: var(--handle-size);
+    height: var(--handle-size);
+    background-color: var(--sl-color-neutral-0);
+    border-radius: var(--sl-border-radius-circle);
+    font-size: calc(var(--handle-size) * 0.5);
+    color: var(--sl-color-neutral-600);
+    cursor: inherit;
+    z-index: 10;
+  }
+
+  .image-comparer__handle:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+`;
+
+// src/components/image-comparer/image-comparer.ts
+var SlImageComparer = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.position = 50;
+  }
+  handleDrag(event) {
+    const { width } = this.base.getBoundingClientRect();
+    const isRtl = this.localize.dir() === "rtl";
+    event.preventDefault();
+    drag(this.base, {
+      onMove: (x) => {
+        this.position = parseFloat(clamp(x / width * 100, 0, 100).toFixed(2));
+        if (isRtl)
+          this.position = 100 - this.position;
+      },
+      initialEvent: event
+    });
+  }
+  handleKeyDown(event) {
+    const isLtr = this.localize.dir() === "ltr";
+    const isRtl = this.localize.dir() === "rtl";
+    if (["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
+      const incr = event.shiftKey ? 10 : 1;
+      let newPosition = this.position;
+      event.preventDefault();
+      if (isLtr && event.key === "ArrowLeft" || isRtl && event.key === "ArrowRight") {
+        newPosition -= incr;
+      }
+      if (isLtr && event.key === "ArrowRight" || isRtl && event.key === "ArrowLeft") {
+        newPosition += incr;
+      }
+      if (event.key === "Home") {
+        newPosition = 0;
+      }
+      if (event.key === "End") {
+        newPosition = 100;
+      }
+      newPosition = clamp(newPosition, 0, 100);
+      this.position = newPosition;
+    }
+  }
+  handlePositionChange() {
+    this.emit("sl-change");
+  }
+  render() {
+    const isRtl = this.localize.dir() === "rtl";
+    return $`
+      <div
+        part="base"
+        id="image-comparer"
+        class=${o$3({
+      "image-comparer": true,
+      "image-comparer--rtl": isRtl
+    })}
+        @keydown=${this.handleKeyDown}
+      >
+        <div class="image-comparer__image">
+          <div part="before" class="image-comparer__before">
+            <slot name="before"></slot>
+          </div>
+
+          <div
+            part="after"
+            class="image-comparer__after"
+            style=${i2$1({
+      clipPath: isRtl ? `inset(0 0 0 ${100 - this.position}%)` : `inset(0 ${100 - this.position}% 0 0)`
+    })}
+          >
+            <slot name="after"></slot>
+          </div>
+        </div>
+
+        <div
+          part="divider"
+          class="image-comparer__divider"
+          style=${i2$1({
+      left: isRtl ? `${100 - this.position}%` : `${this.position}%`
+    })}
+          @mousedown=${this.handleDrag}
+          @touchstart=${this.handleDrag}
+        >
+          <div
+            part="handle"
+            class="image-comparer__handle"
+            role="scrollbar"
+            aria-valuenow=${this.position}
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-controls="image-comparer"
+            tabindex="0"
+          >
+            <slot name="handle-icon">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <g fill="currentColor" fill-rule="nonzero">
+                  <path
+                    d="m21.14 12.55-5.482 4.796c-.646.566-1.658.106-1.658-.753V7a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506h.001ZM2.341 12.55l5.482 4.796c.646.566 1.658.106 1.658-.753V7a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506h-.001Z"
+                  />
+                </g>
+              </svg>
+            </slot>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+};
+SlImageComparer.styles = image_comparer_styles_default;
+__decorateClass([
+  i2$2(".image-comparer")
+], SlImageComparer.prototype, "base", 2);
+__decorateClass([
+  i2$2(".image-comparer__handle")
+], SlImageComparer.prototype, "handle", 2);
+__decorateClass([
+  e$1({ type: Number, reflect: true })
+], SlImageComparer.prototype, "position", 2);
+__decorateClass([
+  watch("position", { waitUntilFirstUpdate: true })
+], SlImageComparer.prototype, "handlePositionChange", 1);
+SlImageComparer = __decorateClass([
+  n$1("sl-image-comparer")
+], SlImageComparer);
+
+// src/components/include/include.styles.ts
+var include_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+`;
+
+// src/components/include/include.ts
+var SlInclude = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.mode = "cors";
+    this.allowScripts = false;
+  }
+  executeScript(script) {
+    const newScript = document.createElement("script");
+    [...script.attributes].forEach((attr) => newScript.setAttribute(attr.name, attr.value));
+    newScript.textContent = script.textContent;
+    script.parentNode.replaceChild(newScript, script);
+  }
+  async handleSrcChange() {
+    try {
+      const src = this.src;
+      const file = await requestInclude(src, this.mode);
+      if (src !== this.src) {
+        return;
+      }
+      if (!file.ok) {
+        this.emit("sl-error", { detail: { status: file.status } });
+        return;
+      }
+      this.innerHTML = file.html;
+      if (this.allowScripts) {
+        [...this.querySelectorAll("script")].forEach((script) => this.executeScript(script));
+      }
+      this.emit("sl-load");
+    } catch (e2) {
+      this.emit("sl-error", { detail: { status: -1 } });
+    }
+  }
+  render() {
+    return $`<slot></slot>`;
+  }
+};
+SlInclude.styles = include_styles_default;
+__decorateClass([
+  e$1()
+], SlInclude.prototype, "src", 2);
+__decorateClass([
+  e$1()
+], SlInclude.prototype, "mode", 2);
+__decorateClass([
+  e$1({ attribute: "allow-scripts", type: Boolean })
+], SlInclude.prototype, "allowScripts", 2);
+__decorateClass([
+  watch("src")
+], SlInclude.prototype, "handleSrcChange", 1);
+SlInclude = __decorateClass([
+  n$1("sl-include")
+], SlInclude);
+
+// src/components/menu/menu.styles.ts
+var menu_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+    position: relative;
+    background: var(--sl-panel-background-color);
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+    border-radius: var(--sl-border-radius-medium);
+    padding: var(--sl-spacing-x-small) 0;
+    overflow: auto;
+    overscroll-behavior: none;
+  }
+
+  ::slotted(sl-divider) {
+    --spacing: var(--sl-spacing-x-small);
+  }
+`;
+
+// src/components/menu/menu.ts
+var SlMenu = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.typeToSelectString = "";
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("role", "menu");
+  }
+  getAllItems(options = { includeDisabled: true }) {
+    return [...this.defaultSlot.assignedElements({ flatten: true })].filter((el) => {
+      if (el.getAttribute("role") !== "menuitem") {
+        return false;
+      }
+      if (!options.includeDisabled && el.disabled) {
+        return false;
+      }
+      return true;
+    });
+  }
+  getCurrentItem() {
+    return this.getAllItems({ includeDisabled: false }).find((i2) => i2.getAttribute("tabindex") === "0");
+  }
+  setCurrentItem(item) {
+    const items = this.getAllItems({ includeDisabled: false });
+    const activeItem = item.disabled ? items[0] : item;
+    items.forEach((i2) => {
+      i2.setAttribute("tabindex", i2 === activeItem ? "0" : "-1");
+    });
+  }
+  typeToSelect(event) {
+    var _a;
+    const items = this.getAllItems({ includeDisabled: false });
+    clearTimeout(this.typeToSelectTimeout);
+    this.typeToSelectTimeout = window.setTimeout(() => this.typeToSelectString = "", 1e3);
+    if (event.key === "Backspace") {
+      if (event.metaKey || event.ctrlKey) {
+        this.typeToSelectString = "";
+      } else {
+        this.typeToSelectString = this.typeToSelectString.slice(0, -1);
+      }
+    } else {
+      this.typeToSelectString += event.key.toLowerCase();
+    }
+    for (const item of items) {
+      const slot = (_a = item.shadowRoot) == null ? void 0 : _a.querySelector("slot:not([name])");
+      const label = getTextContent(slot).toLowerCase().trim();
+      if (label.startsWith(this.typeToSelectString)) {
+        this.setCurrentItem(item);
+        item.focus();
+        break;
+      }
+    }
+  }
+  handleClick(event) {
+    const target = event.target;
+    const item = target.closest("sl-menu-item");
+    if ((item == null ? void 0 : item.disabled) === false) {
+      this.emit("sl-select", { detail: { item } });
+    }
+  }
+  handleKeyDown(event) {
+    if (event.key === "Enter") {
+      const item = this.getCurrentItem();
+      event.preventDefault();
+      item == null ? void 0 : item.click();
+    }
+    if (event.key === " ") {
+      event.preventDefault();
+    }
+    if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+      const items = this.getAllItems({ includeDisabled: false });
+      const activeItem = this.getCurrentItem();
+      let index = activeItem ? items.indexOf(activeItem) : 0;
+      if (items.length > 0) {
+        event.preventDefault();
+        if (event.key === "ArrowDown") {
+          index++;
+        } else if (event.key === "ArrowUp") {
+          index--;
+        } else if (event.key === "Home") {
+          index = 0;
+        } else if (event.key === "End") {
+          index = items.length - 1;
+        }
+        if (index < 0) {
+          index = items.length - 1;
+        }
+        if (index > items.length - 1) {
+          index = 0;
+        }
+        this.setCurrentItem(items[index]);
+        items[index].focus();
+        return;
+      }
+    }
+    this.typeToSelect(event);
+  }
+  handleMouseDown(event) {
+    const target = event.target;
+    if (target.getAttribute("role") === "menuitem") {
+      this.setCurrentItem(target);
+    }
+  }
+  handleSlotChange() {
+    const items = this.getAllItems({ includeDisabled: false });
+    if (items.length > 0) {
+      this.setCurrentItem(items[0]);
+    }
+  }
+  render() {
+    return $`
+      <slot
+        @slotchange=${this.handleSlotChange}
+        @click=${this.handleClick}
+        @keydown=${this.handleKeyDown}
+        @mousedown=${this.handleMouseDown}
+      ></slot>
+    `;
+  }
+};
+SlMenu.styles = menu_styles_default;
+__decorateClass([
+  i2$2("slot")
+], SlMenu.prototype, "defaultSlot", 2);
+SlMenu = __decorateClass([
+  n$1("sl-menu")
+], SlMenu);
+
+// src/components/drawer/drawer.styles.ts
+var drawer_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --size: 25rem;
+    --header-spacing: var(--sl-spacing-large);
+    --body-spacing: var(--sl-spacing-large);
+    --footer-spacing: var(--sl-spacing-large);
+
+    display: contents;
+  }
+
+  .drawer {
+    top: 0;
+    inset-inline-start: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .drawer--contained {
+    position: absolute;
+    z-index: initial;
+  }
+
+  .drawer--fixed {
+    position: fixed;
+    z-index: var(--sl-z-index-drawer);
+  }
+
+  .drawer__panel {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    z-index: 2;
+    max-width: 100%;
+    max-height: 100%;
+    background-color: var(--sl-panel-background-color);
+    box-shadow: var(--sl-shadow-x-large);
+    transition: var(--sl-transition-medium) transform;
+    overflow: auto;
+    pointer-events: all;
+  }
+
+  .drawer__panel:focus {
+    outline: none;
+  }
+
+  .drawer--top .drawer__panel {
+    top: 0;
+    inset-inline-end: auto;
+    bottom: auto;
+    inset-inline-start: 0;
+    width: 100%;
+    height: var(--size);
+  }
+
+  .drawer--end .drawer__panel {
+    top: 0;
+    inset-inline-end: 0;
+    bottom: auto;
+    inset-inline-start: auto;
+    width: var(--size);
+    height: 100%;
+  }
+
+  .drawer--bottom .drawer__panel {
+    top: auto;
+    inset-inline-end: auto;
+    bottom: 0;
+    inset-inline-start: 0;
+    width: 100%;
+    height: var(--size);
+  }
+
+  .drawer--start .drawer__panel {
+    top: 0;
+    inset-inline-end: auto;
+    bottom: auto;
+    inset-inline-start: 0;
+    width: var(--size);
+    height: 100%;
+  }
+
+  .drawer__header {
+    display: flex;
+  }
+
+  .drawer__title {
+    flex: 1 1 auto;
+    font: inherit;
+    font-size: var(--sl-font-size-large);
+    line-height: var(--sl-line-height-dense);
+    padding: var(--header-spacing);
+    margin: 0;
+  }
+
+  .drawer__close {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    font-size: var(--sl-font-size-x-large);
+    padding: 0 var(--header-spacing);
+  }
+
+  .drawer__body {
+    flex: 1 1 auto;
+    padding: var(--body-spacing);
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .drawer__footer {
+    text-align: right;
+    padding: var(--footer-spacing);
+  }
+
+  .drawer__footer ::slotted(sl-button:not(:last-of-type)) {
+    margin-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .drawer:not(.drawer--has-footer) .drawer__footer {
+    display: none;
+  }
+
+  .drawer__overlay {
+    display: block;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: var(--sl-overlay-background-color);
+    pointer-events: all;
+  }
+
+  .drawer--contained .drawer__overlay {
+    position: absolute;
+  }
+`;
+
+// src/internal/tabbable.ts
+function isTabbable(el) {
+  const tag = el.tagName.toLowerCase();
+  if (el.getAttribute("tabindex") === "-1") {
+    return false;
+  }
+  if (el.hasAttribute("disabled")) {
+    return false;
+  }
+  if (el.hasAttribute("aria-disabled") && el.getAttribute("aria-disabled") !== "false") {
+    return false;
+  }
+  if (tag === "input" && el.getAttribute("type") === "radio" && !el.hasAttribute("checked")) {
+    return false;
+  }
+  if (el.offsetParent === null) {
+    return false;
+  }
+  if (window.getComputedStyle(el).visibility === "hidden") {
+    return false;
+  }
+  if ((tag === "audio" || tag === "video") && el.hasAttribute("controls")) {
+    return true;
+  }
+  if (el.hasAttribute("tabindex")) {
+    return true;
+  }
+  if (el.hasAttribute("contenteditable") && el.getAttribute("contenteditable") !== "false") {
+    return true;
+  }
+  return ["button", "input", "select", "textarea", "a", "audio", "video", "summary"].includes(tag);
+}
+function getTabbableBoundary(root) {
+  var _a, _b;
+  const allElements = [];
+  function walk(el) {
+    if (el instanceof HTMLElement) {
+      allElements.push(el);
+      if (el.shadowRoot !== null && el.shadowRoot.mode === "open") {
+        walk(el.shadowRoot);
+      }
+    }
+    [...el.children].forEach((e) => walk(e));
+  }
+  walk(root);
+  const start = (_a = allElements.find((el) => isTabbable(el))) != null ? _a : null;
+  const end = (_b = allElements.reverse().find((el) => isTabbable(el))) != null ? _b : null;
+  return { start, end };
+}
+
+// src/internal/modal.ts
+var activeModals = [];
+var Modal = class {
+  constructor(element) {
+    this.tabDirection = "forward";
+    this.element = element;
+    this.handleFocusIn = this.handleFocusIn.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleKeyUp = this.handleKeyUp.bind(this);
+  }
+  activate() {
+    activeModals.push(this.element);
+    document.addEventListener("focusin", this.handleFocusIn);
+    document.addEventListener("keydown", this.handleKeyDown);
+    document.addEventListener("keyup", this.handleKeyUp);
+  }
+  deactivate() {
+    activeModals = activeModals.filter((modal) => modal !== this.element);
+    document.removeEventListener("focusin", this.handleFocusIn);
+    document.removeEventListener("keydown", this.handleKeyDown);
+    document.removeEventListener("keyup", this.handleKeyUp);
+  }
+  isActive() {
+    return activeModals[activeModals.length - 1] === this.element;
+  }
+  checkFocus() {
+    if (this.isActive()) {
+      if (!this.element.matches(":focus-within")) {
+        const { start, end } = getTabbableBoundary(this.element);
+        const target = this.tabDirection === "forward" ? start : end;
+        if (typeof (target == null ? void 0 : target.focus) === "function") {
+          target.focus({ preventScroll: true });
+        }
+      }
+    }
+  }
+  handleFocusIn() {
+    this.checkFocus();
+  }
+  handleKeyDown(event) {
+    if (event.key === "Tab" && event.shiftKey) {
+      this.tabDirection = "backward";
+    }
+    requestAnimationFrame(() => this.checkFocus());
+  }
+  handleKeyUp() {
+    this.tabDirection = "forward";
+  }
+};
+
+// src/internal/string.ts
+function uppercaseFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+// src/components/drawer/drawer.ts
+var SlDrawer = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.hasSlotController = new HasSlotController(this, "footer");
+    this.localize = new LocalizeController2(this);
+    this.open = false;
+    this.label = "";
+    this.placement = "end";
+    this.contained = false;
+    this.noHeader = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.modal = new Modal(this);
+  }
+  firstUpdated() {
+    this.drawer.hidden = !this.open;
+    if (this.open && !this.contained) {
+      this.modal.activate();
+      lockBodyScrolling(this);
+    }
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    unlockBodyScrolling(this);
+  }
+  async show() {
+    if (this.open) {
+      return void 0;
+    }
+    this.open = true;
+    return waitForEvent(this, "sl-after-show");
+  }
+  async hide() {
+    if (!this.open) {
+      return void 0;
+    }
+    this.open = false;
+    return waitForEvent(this, "sl-after-hide");
+  }
+  requestClose(source) {
+    const slRequestClose = this.emit("sl-request-close", {
+      cancelable: true,
+      detail: { source }
+    });
+    if (slRequestClose.defaultPrevented) {
+      const animation = getAnimation(this, "drawer.denyClose", { dir: this.localize.dir() });
+      animateTo(this.panel, animation.keyframes, animation.options);
+      return;
+    }
+    this.hide();
+  }
+  handleKeyDown(event) {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      this.requestClose("keyboard");
+    }
+  }
+  async handleOpenChange() {
+    if (this.open) {
+      this.emit("sl-show");
+      this.originalTrigger = document.activeElement;
+      if (!this.contained) {
+        this.modal.activate();
+        lockBodyScrolling(this);
+      }
+      const autoFocusTarget = this.querySelector("[autofocus]");
+      if (autoFocusTarget) {
+        autoFocusTarget.removeAttribute("autofocus");
+      }
+      await Promise.all([stopAnimations(this.drawer), stopAnimations(this.overlay)]);
+      this.drawer.hidden = false;
+      requestAnimationFrame(() => {
+        const slInitialFocus = this.emit("sl-initial-focus", { cancelable: true });
+        if (!slInitialFocus.defaultPrevented) {
+          if (autoFocusTarget) {
+            autoFocusTarget.focus({ preventScroll: true });
+          } else {
+            this.panel.focus({ preventScroll: true });
+          }
+        }
+        if (autoFocusTarget) {
+          autoFocusTarget.setAttribute("autofocus", "");
+        }
+      });
+      const panelAnimation = getAnimation(this, `drawer.show${uppercaseFirstLetter(this.placement)}`, {
+        dir: this.localize.dir()
+      });
+      const overlayAnimation = getAnimation(this, "drawer.overlay.show", { dir: this.localize.dir() });
+      await Promise.all([
+        animateTo(this.panel, panelAnimation.keyframes, panelAnimation.options),
+        animateTo(this.overlay, overlayAnimation.keyframes, overlayAnimation.options)
+      ]);
+      this.emit("sl-after-show");
+    } else {
+      this.emit("sl-hide");
+      this.modal.deactivate();
+      unlockBodyScrolling(this);
+      await Promise.all([stopAnimations(this.drawer), stopAnimations(this.overlay)]);
+      const panelAnimation = getAnimation(this, `drawer.hide${uppercaseFirstLetter(this.placement)}`, {
+        dir: this.localize.dir()
+      });
+      const overlayAnimation = getAnimation(this, "drawer.overlay.hide", { dir: this.localize.dir() });
+      await Promise.all([
+        animateTo(this.overlay, overlayAnimation.keyframes, overlayAnimation.options).then(() => {
+          this.overlay.hidden = true;
+        }),
+        animateTo(this.panel, panelAnimation.keyframes, panelAnimation.options).then(() => {
+          this.panel.hidden = true;
+        })
+      ]);
+      this.drawer.hidden = true;
+      this.overlay.hidden = false;
+      this.panel.hidden = false;
+      const trigger = this.originalTrigger;
+      if (typeof (trigger == null ? void 0 : trigger.focus) === "function") {
+        setTimeout(() => trigger.focus());
+      }
+      this.emit("sl-after-hide");
+    }
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      drawer: true,
+      "drawer--open": this.open,
+      "drawer--top": this.placement === "top",
+      "drawer--end": this.placement === "end",
+      "drawer--bottom": this.placement === "bottom",
+      "drawer--start": this.placement === "start",
+      "drawer--contained": this.contained,
+      "drawer--fixed": !this.contained,
+      "drawer--rtl": this.localize.dir() === "rtl",
+      "drawer--has-footer": this.hasSlotController.test("footer")
+    })}
+        @keydown=${this.handleKeyDown}
+      >
+        <div part="overlay" class="drawer__overlay" @click=${() => this.requestClose("overlay")} tabindex="-1"></div>
+
+        <div
+          part="panel"
+          class="drawer__panel"
+          role="dialog"
+          aria-modal="true"
+          aria-hidden=${this.open ? "false" : "true"}
+          aria-label=${l$2(this.noHeader ? this.label : void 0)}
+          aria-labelledby=${l$2(!this.noHeader ? "title" : void 0)}
+          tabindex="0"
+        >
+          ${!this.noHeader ? $`
+                <header part="header" class="drawer__header">
+                  <h2 part="title" class="drawer__title" id="title">
+                    <!-- If there's no label, use an invisible character to prevent the header from collapsing -->
+                    <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(65279)} </slot>
+                  </h2>
+                  <sl-icon-button
+                    part="close-button"
+                    exportparts="base:close-button__base"
+                    class="drawer__close"
+                    name="x"
+                    label=${this.localize.term("close")}
+                    library="system"
+                    @click=${() => this.requestClose("close-button")}
+                  ></sl-icon-button>
+                </header>
+              ` : ""}
+
+          <div part="body" class="drawer__body">
+            <slot></slot>
+          </div>
+
+          <footer part="footer" class="drawer__footer">
+            <slot name="footer"></slot>
+          </footer>
+        </div>
+      </div>
+    `;
+  }
+};
+SlDrawer.styles = drawer_styles_default;
+__decorateClass([
+  i2$2(".drawer")
+], SlDrawer.prototype, "drawer", 2);
+__decorateClass([
+  i2$2(".drawer__panel")
+], SlDrawer.prototype, "panel", 2);
+__decorateClass([
+  i2$2(".drawer__overlay")
+], SlDrawer.prototype, "overlay", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlDrawer.prototype, "open", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlDrawer.prototype, "label", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlDrawer.prototype, "placement", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlDrawer.prototype, "contained", 2);
+__decorateClass([
+  e$1({ attribute: "no-header", type: Boolean, reflect: true })
+], SlDrawer.prototype, "noHeader", 2);
+__decorateClass([
+  watch("open", { waitUntilFirstUpdate: true })
+], SlDrawer.prototype, "handleOpenChange", 1);
+SlDrawer = __decorateClass([
+  n$1("sl-drawer")
+], SlDrawer);
+setDefaultAnimation("drawer.showTop", {
+  keyframes: [
+    { opacity: 0, transform: "translateY(-100%)" },
+    { opacity: 1, transform: "translateY(0)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("drawer.hideTop", {
+  keyframes: [
+    { opacity: 1, transform: "translateY(0)" },
+    { opacity: 0, transform: "translateY(-100%)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("drawer.showEnd", {
+  keyframes: [
+    { opacity: 0, transform: "translateX(100%)" },
+    { opacity: 1, transform: "translateX(0)" }
+  ],
+  rtlKeyframes: [
+    { opacity: 0, transform: "translateX(-100%)" },
+    { opacity: 1, transform: "translateX(0)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("drawer.hideEnd", {
+  keyframes: [
+    { opacity: 1, transform: "translateX(0)" },
+    { opacity: 0, transform: "translateX(100%)" }
+  ],
+  rtlKeyframes: [
+    { opacity: 1, transform: "translateX(0)" },
+    { opacity: 0, transform: "translateX(-100%)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("drawer.showBottom", {
+  keyframes: [
+    { opacity: 0, transform: "translateY(100%)" },
+    { opacity: 1, transform: "translateY(0)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("drawer.hideBottom", {
+  keyframes: [
+    { opacity: 1, transform: "translateY(0)" },
+    { opacity: 0, transform: "translateY(100%)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("drawer.showStart", {
+  keyframes: [
+    { opacity: 0, transform: "translateX(-100%)" },
+    { opacity: 1, transform: "translateX(0)" }
+  ],
+  rtlKeyframes: [
+    { opacity: 0, transform: "translateX(100%)" },
+    { opacity: 1, transform: "translateX(0)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("drawer.hideStart", {
+  keyframes: [
+    { opacity: 1, transform: "translateX(0)" },
+    { opacity: 0, transform: "translateX(-100%)" }
+  ],
+  rtlKeyframes: [
+    { opacity: 1, transform: "translateX(0)" },
+    { opacity: 0, transform: "translateX(100%)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("drawer.denyClose", {
+  keyframes: [{ transform: "scale(1)" }, { transform: "scale(1.01)" }, { transform: "scale(1)" }],
+  options: { duration: 250 }
+});
+setDefaultAnimation("drawer.overlay.show", {
+  keyframes: [{ opacity: 0 }, { opacity: 1 }],
+  options: { duration: 250 }
+});
+setDefaultAnimation("drawer.overlay.hide", {
+  keyframes: [{ opacity: 1 }, { opacity: 0 }],
+  options: { duration: 250 }
+});
+
+// src/components/format-bytes/format-bytes.ts
+var SlFormatBytes = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.value = 0;
+    this.unit = "byte";
+    this.display = "short";
+  }
+  render() {
+    if (isNaN(this.value)) {
+      return "";
+    }
+    const bitPrefixes = ["", "kilo", "mega", "giga", "tera"];
+    const bytePrefixes = ["", "kilo", "mega", "giga", "tera", "peta"];
+    const prefix = this.unit === "bit" ? bitPrefixes : bytePrefixes;
+    const index = Math.max(0, Math.min(Math.floor(Math.log10(this.value) / 3), prefix.length - 1));
+    const unit = prefix[index] + this.unit;
+    const valueToFormat = parseFloat((this.value / Math.pow(1e3, index)).toPrecision(3));
+    return this.localize.number(valueToFormat, {
+      style: "unit",
+      unit,
+      unitDisplay: this.display
+    });
+  }
+};
+__decorateClass([
+  e$1({ type: Number })
+], SlFormatBytes.prototype, "value", 2);
+__decorateClass([
+  e$1()
+], SlFormatBytes.prototype, "unit", 2);
+__decorateClass([
+  e$1()
+], SlFormatBytes.prototype, "display", 2);
+SlFormatBytes = __decorateClass([
+  n$1("sl-format-bytes")
+], SlFormatBytes);
+
+// src/components/format-date/format-date.ts
+var SlFormatDate = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.date = new Date();
+    this.hourFormat = "auto";
+  }
+  render() {
+    const date = new Date(this.date);
+    const hour12 = this.hourFormat === "auto" ? void 0 : this.hourFormat === "12";
+    if (isNaN(date.getMilliseconds())) {
+      return void 0;
+    }
+    return $`
+      <time datetime=${date.toISOString()}>
+        ${this.localize.date(date, {
+      weekday: this.weekday,
+      era: this.era,
+      year: this.year,
+      month: this.month,
+      day: this.day,
+      hour: this.hour,
+      minute: this.minute,
+      second: this.second,
+      timeZoneName: this.timeZoneName,
+      timeZone: this.timeZone,
+      hour12
+    })}
+      </time>
+    `;
+  }
+};
+__decorateClass([
+  e$1()
+], SlFormatDate.prototype, "date", 2);
+__decorateClass([
+  e$1()
+], SlFormatDate.prototype, "weekday", 2);
+__decorateClass([
+  e$1()
+], SlFormatDate.prototype, "era", 2);
+__decorateClass([
+  e$1()
+], SlFormatDate.prototype, "year", 2);
+__decorateClass([
+  e$1()
+], SlFormatDate.prototype, "month", 2);
+__decorateClass([
+  e$1()
+], SlFormatDate.prototype, "day", 2);
+__decorateClass([
+  e$1()
+], SlFormatDate.prototype, "hour", 2);
+__decorateClass([
+  e$1()
+], SlFormatDate.prototype, "minute", 2);
+__decorateClass([
+  e$1()
+], SlFormatDate.prototype, "second", 2);
+__decorateClass([
+  e$1({ attribute: "time-zone-name" })
+], SlFormatDate.prototype, "timeZoneName", 2);
+__decorateClass([
+  e$1({ attribute: "time-zone" })
+], SlFormatDate.prototype, "timeZone", 2);
+__decorateClass([
+  e$1({ attribute: "hour-format" })
+], SlFormatDate.prototype, "hourFormat", 2);
+SlFormatDate = __decorateClass([
+  n$1("sl-format-date")
+], SlFormatDate);
+
+// src/components/format-number/format-number.ts
+var SlFormatNumber = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.value = 0;
+    this.type = "decimal";
+    this.noGrouping = false;
+    this.currency = "USD";
+    this.currencyDisplay = "symbol";
+  }
+  render() {
+    if (isNaN(this.value)) {
+      return "";
+    }
+    return this.localize.number(this.value, {
+      style: this.type,
+      currency: this.currency,
+      currencyDisplay: this.currencyDisplay,
+      useGrouping: !this.noGrouping,
+      minimumIntegerDigits: this.minimumIntegerDigits,
+      minimumFractionDigits: this.minimumFractionDigits,
+      maximumFractionDigits: this.maximumFractionDigits,
+      minimumSignificantDigits: this.minimumSignificantDigits,
+      maximumSignificantDigits: this.maximumSignificantDigits
+    });
+  }
+};
+__decorateClass([
+  e$1({ type: Number })
+], SlFormatNumber.prototype, "value", 2);
+__decorateClass([
+  e$1()
+], SlFormatNumber.prototype, "type", 2);
+__decorateClass([
+  e$1({ attribute: "no-grouping", type: Boolean })
+], SlFormatNumber.prototype, "noGrouping", 2);
+__decorateClass([
+  e$1()
+], SlFormatNumber.prototype, "currency", 2);
+__decorateClass([
+  e$1({ attribute: "currency-display" })
+], SlFormatNumber.prototype, "currencyDisplay", 2);
+__decorateClass([
+  e$1({ attribute: "minimum-integer-digits", type: Number })
+], SlFormatNumber.prototype, "minimumIntegerDigits", 2);
+__decorateClass([
+  e$1({ attribute: "minimum-fraction-digits", type: Number })
+], SlFormatNumber.prototype, "minimumFractionDigits", 2);
+__decorateClass([
+  e$1({ attribute: "maximum-fraction-digits", type: Number })
+], SlFormatNumber.prototype, "maximumFractionDigits", 2);
+__decorateClass([
+  e$1({ attribute: "minimum-significant-digits", type: Number })
+], SlFormatNumber.prototype, "minimumSignificantDigits", 2);
+__decorateClass([
+  e$1({ attribute: "maximum-significant-digits", type: Number })
+], SlFormatNumber.prototype, "maximumSignificantDigits", 2);
+SlFormatNumber = __decorateClass([
+  n$1("sl-format-number")
+], SlFormatNumber);
+
+// src/components/color-picker/color-picker.styles.ts
+var color_picker_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --grid-width: 280px;
+    --grid-height: 200px;
+    --grid-handle-size: 16px;
+    --slider-height: 15px;
+    --slider-handle-size: 17px;
+    --swatch-size: 25px;
+
+    display: inline-block;
+  }
+
+  .color-picker {
+    width: var(--grid-width);
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+    font-weight: var(--sl-font-weight-normal);
+    color: var(--color);
+    background-color: var(--sl-panel-background-color);
+    border-radius: var(--sl-border-radius-medium);
+    user-select: none;
+  }
+
+  .color-picker--inline {
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+  }
+
+  .color-picker--inline:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .color-picker__grid {
+    position: relative;
+    height: var(--grid-height);
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%),
+      linear-gradient(to right, #fff 0%, rgba(255, 255, 255, 0) 100%);
+    border-top-left-radius: var(--sl-border-radius-medium);
+    border-top-right-radius: var(--sl-border-radius-medium);
+    cursor: crosshair;
+  }
+
+  .color-picker__grid-handle {
+    position: absolute;
+    width: var(--grid-handle-size);
+    height: var(--grid-handle-size);
+    border-radius: 50%;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+    border: solid 2px white;
+    margin-top: calc(var(--grid-handle-size) / -2);
+    margin-left: calc(var(--grid-handle-size) / -2);
+    transition: var(--sl-transition-fast) transform;
+  }
+
+  .color-picker__grid-handle--dragging {
+    cursor: none;
+    transform: scale(1.5);
+  }
+
+  .color-picker__grid-handle:focus-visible {
+    outline: var(--sl-focus-ring);
+  }
+
+  .color-picker__controls {
+    padding: var(--sl-spacing-small);
+    display: flex;
+    align-items: center;
+  }
+
+  .color-picker__sliders {
+    flex: 1 1 auto;
+  }
+
+  .color-picker__slider {
+    position: relative;
+    height: var(--slider-height);
+    border-radius: var(--sl-border-radius-pill);
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+  }
+
+  .color-picker__slider:not(:last-of-type) {
+    margin-bottom: var(--sl-spacing-small);
+  }
+
+  .color-picker__slider-handle {
+    position: absolute;
+    top: calc(50% - var(--slider-handle-size) / 2);
+    width: var(--slider-handle-size);
+    height: var(--slider-handle-size);
+    background-color: white;
+    border-radius: 50%;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+    margin-left: calc(var(--slider-handle-size) / -2);
+  }
+
+  .color-picker__slider-handle:focus-visible {
+    outline: var(--sl-focus-ring);
+  }
+
+  .color-picker__hue {
+    background-image: linear-gradient(
+      to right,
+      rgb(255, 0, 0) 0%,
+      rgb(255, 255, 0) 17%,
+      rgb(0, 255, 0) 33%,
+      rgb(0, 255, 255) 50%,
+      rgb(0, 0, 255) 67%,
+      rgb(255, 0, 255) 83%,
+      rgb(255, 0, 0) 100%
+    );
+  }
+
+  .color-picker__alpha .color-picker__alpha-gradient {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+  }
+
+  .color-picker__preview {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    width: 2.25rem;
+    height: 2.25rem;
+    border: none;
+    border-radius: var(--sl-border-radius-circle);
+    background: none;
+    margin-left: var(--sl-spacing-small);
+    cursor: copy;
+  }
+
+  .color-picker__preview:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+
+    /* We use a custom property in lieu of currentColor because of https://bugs.webkit.org/show_bug.cgi?id=216780 */
+    background-color: var(--preview-color);
+  }
+
+  .color-picker__preview:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .color-picker__preview-color {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: solid 1px rgba(0, 0, 0, 0.125);
+  }
+
+  .color-picker__preview-color--copied {
+    animation: pulse 0.75s;
+  }
+
+  @keyframes pulse {
+    0% {
+      box-shadow: 0 0 0 0 var(--sl-color-primary-500);
+    }
+    70% {
+      box-shadow: 0 0 0 0.5rem transparent;
+    }
+    100% {
+      box-shadow: 0 0 0 0 transparent;
+    }
+  }
+
+  .color-picker__user-input {
+    display: flex;
+    padding: 0 var(--sl-spacing-small) var(--sl-spacing-small) var(--sl-spacing-small);
+  }
+
+  .color-picker__user-input sl-input {
+    min-width: 0; /* fix input width in Safari */
+    flex: 1 1 auto;
+  }
+
+  .color-picker__user-input sl-button-group {
+    margin-left: var(--sl-spacing-small);
+  }
+
+  .color-picker__user-input sl-button {
+    min-width: 3.25rem;
+    max-width: 3.25rem;
+    font-size: 1rem;
+  }
+
+  .color-picker__swatches {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    grid-gap: 0.5rem;
+    justify-items: center;
+    border-top: solid 1px var(--sl-color-neutral-200);
+    padding: var(--sl-spacing-small);
+  }
+
+  .color-picker__swatch {
+    position: relative;
+    width: var(--swatch-size);
+    height: var(--swatch-size);
+    border-radius: var(--sl-border-radius-small);
+  }
+
+  .color-picker__swatch .color-picker__swatch-color {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: solid 1px rgba(0, 0, 0, 0.125);
+    border-radius: inherit;
+    cursor: pointer;
+  }
+
+  .color-picker__swatch:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .color-picker__transparent-bg {
+    background-image: linear-gradient(45deg, var(--sl-color-neutral-300) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--sl-color-neutral-300) 75%),
+      linear-gradient(45deg, transparent 75%, var(--sl-color-neutral-300) 75%),
+      linear-gradient(45deg, var(--sl-color-neutral-300) 25%, transparent 25%);
+    background-size: 10px 10px;
+    background-position: 0 0, 0 0, -5px -5px, 5px 5px;
+  }
+
+  .color-picker--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .color-picker--disabled .color-picker__grid,
+  .color-picker--disabled .color-picker__grid-handle,
+  .color-picker--disabled .color-picker__slider,
+  .color-picker--disabled .color-picker__slider-handle,
+  .color-picker--disabled .color-picker__preview,
+  .color-picker--disabled .color-picker__swatch,
+  .color-picker--disabled .color-picker__swatch-color {
+    pointer-events: none;
+  }
+
+  /*
+   * Color dropdown
+   */
+
+  .color-dropdown::part(panel) {
+    max-height: none;
+    background-color: var(--sl-panel-background-color);
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+    border-radius: var(--sl-border-radius-medium);
+    overflow: visible;
+  }
+
+  .color-dropdown__trigger {
+    display: inline-block;
+    position: relative;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+  }
+
+  .color-dropdown__trigger.color-dropdown__trigger--small {
+    width: var(--sl-input-height-small);
+    height: var(--sl-input-height-small);
+    border-radius: var(--sl-border-radius-circle);
+  }
+
+  .color-dropdown__trigger.color-dropdown__trigger--medium {
+    width: var(--sl-input-height-medium);
+    height: var(--sl-input-height-medium);
+    border-radius: var(--sl-border-radius-circle);
+  }
+
+  .color-dropdown__trigger.color-dropdown__trigger--large {
+    width: var(--sl-input-height-large);
+    height: var(--sl-input-height-large);
+    border-radius: var(--sl-border-radius-circle);
+  }
+
+  .color-dropdown__trigger:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    background-color: currentColor;
+    box-shadow: inset 0 0 0 2px var(--sl-input-border-color), inset 0 0 0 4px var(--sl-color-neutral-0);
+  }
+
+  .color-dropdown__trigger--empty:before {
+    background-color: transparent;
+  }
+
+  .color-dropdown__trigger:focus-visible {
+    outline: none;
+  }
+
+  .color-dropdown__trigger:focus-visible:not(.color-dropdown__trigger--disabled) {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .color-dropdown__trigger.color-dropdown__trigger--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+// node_modules/color-name/index.js
+var require_color_name = __commonJS({
+  "node_modules/color-name/index.js"(exports, module) {
+    module.exports = {
+      "aliceblue": [240, 248, 255],
+      "antiquewhite": [250, 235, 215],
+      "aqua": [0, 255, 255],
+      "aquamarine": [127, 255, 212],
+      "azure": [240, 255, 255],
+      "beige": [245, 245, 220],
+      "bisque": [255, 228, 196],
+      "black": [0, 0, 0],
+      "blanchedalmond": [255, 235, 205],
+      "blue": [0, 0, 255],
+      "blueviolet": [138, 43, 226],
+      "brown": [165, 42, 42],
+      "burlywood": [222, 184, 135],
+      "cadetblue": [95, 158, 160],
+      "chartreuse": [127, 255, 0],
+      "chocolate": [210, 105, 30],
+      "coral": [255, 127, 80],
+      "cornflowerblue": [100, 149, 237],
+      "cornsilk": [255, 248, 220],
+      "crimson": [220, 20, 60],
+      "cyan": [0, 255, 255],
+      "darkblue": [0, 0, 139],
+      "darkcyan": [0, 139, 139],
+      "darkgoldenrod": [184, 134, 11],
+      "darkgray": [169, 169, 169],
+      "darkgreen": [0, 100, 0],
+      "darkgrey": [169, 169, 169],
+      "darkkhaki": [189, 183, 107],
+      "darkmagenta": [139, 0, 139],
+      "darkolivegreen": [85, 107, 47],
+      "darkorange": [255, 140, 0],
+      "darkorchid": [153, 50, 204],
+      "darkred": [139, 0, 0],
+      "darksalmon": [233, 150, 122],
+      "darkseagreen": [143, 188, 143],
+      "darkslateblue": [72, 61, 139],
+      "darkslategray": [47, 79, 79],
+      "darkslategrey": [47, 79, 79],
+      "darkturquoise": [0, 206, 209],
+      "darkviolet": [148, 0, 211],
+      "deeppink": [255, 20, 147],
+      "deepskyblue": [0, 191, 255],
+      "dimgray": [105, 105, 105],
+      "dimgrey": [105, 105, 105],
+      "dodgerblue": [30, 144, 255],
+      "firebrick": [178, 34, 34],
+      "floralwhite": [255, 250, 240],
+      "forestgreen": [34, 139, 34],
+      "fuchsia": [255, 0, 255],
+      "gainsboro": [220, 220, 220],
+      "ghostwhite": [248, 248, 255],
+      "gold": [255, 215, 0],
+      "goldenrod": [218, 165, 32],
+      "gray": [128, 128, 128],
+      "green": [0, 128, 0],
+      "greenyellow": [173, 255, 47],
+      "grey": [128, 128, 128],
+      "honeydew": [240, 255, 240],
+      "hotpink": [255, 105, 180],
+      "indianred": [205, 92, 92],
+      "indigo": [75, 0, 130],
+      "ivory": [255, 255, 240],
+      "khaki": [240, 230, 140],
+      "lavender": [230, 230, 250],
+      "lavenderblush": [255, 240, 245],
+      "lawngreen": [124, 252, 0],
+      "lemonchiffon": [255, 250, 205],
+      "lightblue": [173, 216, 230],
+      "lightcoral": [240, 128, 128],
+      "lightcyan": [224, 255, 255],
+      "lightgoldenrodyellow": [250, 250, 210],
+      "lightgray": [211, 211, 211],
+      "lightgreen": [144, 238, 144],
+      "lightgrey": [211, 211, 211],
+      "lightpink": [255, 182, 193],
+      "lightsalmon": [255, 160, 122],
+      "lightseagreen": [32, 178, 170],
+      "lightskyblue": [135, 206, 250],
+      "lightslategray": [119, 136, 153],
+      "lightslategrey": [119, 136, 153],
+      "lightsteelblue": [176, 196, 222],
+      "lightyellow": [255, 255, 224],
+      "lime": [0, 255, 0],
+      "limegreen": [50, 205, 50],
+      "linen": [250, 240, 230],
+      "magenta": [255, 0, 255],
+      "maroon": [128, 0, 0],
+      "mediumaquamarine": [102, 205, 170],
+      "mediumblue": [0, 0, 205],
+      "mediumorchid": [186, 85, 211],
+      "mediumpurple": [147, 112, 219],
+      "mediumseagreen": [60, 179, 113],
+      "mediumslateblue": [123, 104, 238],
+      "mediumspringgreen": [0, 250, 154],
+      "mediumturquoise": [72, 209, 204],
+      "mediumvioletred": [199, 21, 133],
+      "midnightblue": [25, 25, 112],
+      "mintcream": [245, 255, 250],
+      "mistyrose": [255, 228, 225],
+      "moccasin": [255, 228, 181],
+      "navajowhite": [255, 222, 173],
+      "navy": [0, 0, 128],
+      "oldlace": [253, 245, 230],
+      "olive": [128, 128, 0],
+      "olivedrab": [107, 142, 35],
+      "orange": [255, 165, 0],
+      "orangered": [255, 69, 0],
+      "orchid": [218, 112, 214],
+      "palegoldenrod": [238, 232, 170],
+      "palegreen": [152, 251, 152],
+      "paleturquoise": [175, 238, 238],
+      "palevioletred": [219, 112, 147],
+      "papayawhip": [255, 239, 213],
+      "peachpuff": [255, 218, 185],
+      "peru": [205, 133, 63],
+      "pink": [255, 192, 203],
+      "plum": [221, 160, 221],
+      "powderblue": [176, 224, 230],
+      "purple": [128, 0, 128],
+      "rebeccapurple": [102, 51, 153],
+      "red": [255, 0, 0],
+      "rosybrown": [188, 143, 143],
+      "royalblue": [65, 105, 225],
+      "saddlebrown": [139, 69, 19],
+      "salmon": [250, 128, 114],
+      "sandybrown": [244, 164, 96],
+      "seagreen": [46, 139, 87],
+      "seashell": [255, 245, 238],
+      "sienna": [160, 82, 45],
+      "silver": [192, 192, 192],
+      "skyblue": [135, 206, 235],
+      "slateblue": [106, 90, 205],
+      "slategray": [112, 128, 144],
+      "slategrey": [112, 128, 144],
+      "snow": [255, 250, 250],
+      "springgreen": [0, 255, 127],
+      "steelblue": [70, 130, 180],
+      "tan": [210, 180, 140],
+      "teal": [0, 128, 128],
+      "thistle": [216, 191, 216],
+      "tomato": [255, 99, 71],
+      "turquoise": [64, 224, 208],
+      "violet": [238, 130, 238],
+      "wheat": [245, 222, 179],
+      "white": [255, 255, 255],
+      "whitesmoke": [245, 245, 245],
+      "yellow": [255, 255, 0],
+      "yellowgreen": [154, 205, 50]
+    };
+  }
+});
+
+// node_modules/simple-swizzle/node_modules/is-arrayish/index.js
+var require_is_arrayish = __commonJS({
+  "node_modules/simple-swizzle/node_modules/is-arrayish/index.js"(exports, module) {
+    module.exports = function isArrayish(obj) {
+      if (!obj || typeof obj === "string") {
+        return false;
+      }
+      return obj instanceof Array || Array.isArray(obj) || obj.length >= 0 && (obj.splice instanceof Function || Object.getOwnPropertyDescriptor(obj, obj.length - 1) && obj.constructor.name !== "String");
+    };
+  }
+});
+
+// node_modules/simple-swizzle/index.js
+var require_simple_swizzle = __commonJS({
+  "node_modules/simple-swizzle/index.js"(exports, module) {
+    var isArrayish = require_is_arrayish();
+    var concat = Array.prototype.concat;
+    var slice = Array.prototype.slice;
+    var swizzle = module.exports = function swizzle2(args) {
+      var results = [];
+      for (var i3 = 0, len = args.length; i3 < len; i3++) {
+        var arg = args[i3];
+        if (isArrayish(arg)) {
+          results = concat.call(results, slice.call(arg));
+        } else {
+          results.push(arg);
+        }
+      }
+      return results;
+    };
+    swizzle.wrap = function(fn) {
+      return function() {
+        return fn(swizzle(arguments));
+      };
+    };
+  }
+});
+
+// node_modules/color-string/index.js
+var require_color_string = __commonJS({
+  "node_modules/color-string/index.js"(exports, module) {
+    var colorNames = require_color_name();
+    var swizzle = require_simple_swizzle();
+    var hasOwnProperty = Object.hasOwnProperty;
+    var reverseNames = {};
+    for (name in colorNames) {
+      if (hasOwnProperty.call(colorNames, name)) {
+        reverseNames[colorNames[name]] = name;
+      }
+    }
+    var name;
+    var cs = module.exports = {
+      to: {},
+      get: {}
+    };
+    cs.get = function(string) {
+      var prefix = string.substring(0, 3).toLowerCase();
+      var val;
+      var model;
+      switch (prefix) {
+        case "hsl":
+          val = cs.get.hsl(string);
+          model = "hsl";
+          break;
+        case "hwb":
+          val = cs.get.hwb(string);
+          model = "hwb";
+          break;
+        default:
+          val = cs.get.rgb(string);
+          model = "rgb";
+          break;
+      }
+      if (!val) {
+        return null;
+      }
+      return { model, value: val };
+    };
+    cs.get.rgb = function(string) {
+      if (!string) {
+        return null;
+      }
+      var abbr = /^#([a-f0-9]{3,4})$/i;
+      var hex = /^#([a-f0-9]{6})([a-f0-9]{2})?$/i;
+      var rgba = /^rgba?\(\s*([+-]?\d+)(?=[\s,])\s*(?:,\s*)?([+-]?\d+)(?=[\s,])\s*(?:,\s*)?([+-]?\d+)\s*(?:[,|\/]\s*([+-]?[\d\.]+)(%?)\s*)?\)$/;
+      var per = /^rgba?\(\s*([+-]?[\d\.]+)\%\s*,?\s*([+-]?[\d\.]+)\%\s*,?\s*([+-]?[\d\.]+)\%\s*(?:[,|\/]\s*([+-]?[\d\.]+)(%?)\s*)?\)$/;
+      var keyword = /^(\w+)$/;
+      var rgb = [0, 0, 0, 1];
+      var match;
+      var i3;
+      var hexAlpha;
+      if (match = string.match(hex)) {
+        hexAlpha = match[2];
+        match = match[1];
+        for (i3 = 0; i3 < 3; i3++) {
+          var i22 = i3 * 2;
+          rgb[i3] = parseInt(match.slice(i22, i22 + 2), 16);
+        }
+        if (hexAlpha) {
+          rgb[3] = parseInt(hexAlpha, 16) / 255;
+        }
+      } else if (match = string.match(abbr)) {
+        match = match[1];
+        hexAlpha = match[3];
+        for (i3 = 0; i3 < 3; i3++) {
+          rgb[i3] = parseInt(match[i3] + match[i3], 16);
+        }
+        if (hexAlpha) {
+          rgb[3] = parseInt(hexAlpha + hexAlpha, 16) / 255;
+        }
+      } else if (match = string.match(rgba)) {
+        for (i3 = 0; i3 < 3; i3++) {
+          rgb[i3] = parseInt(match[i3 + 1], 0);
+        }
+        if (match[4]) {
+          if (match[5]) {
+            rgb[3] = parseFloat(match[4]) * 0.01;
+          } else {
+            rgb[3] = parseFloat(match[4]);
+          }
+        }
+      } else if (match = string.match(per)) {
+        for (i3 = 0; i3 < 3; i3++) {
+          rgb[i3] = Math.round(parseFloat(match[i3 + 1]) * 2.55);
+        }
+        if (match[4]) {
+          if (match[5]) {
+            rgb[3] = parseFloat(match[4]) * 0.01;
+          } else {
+            rgb[3] = parseFloat(match[4]);
+          }
+        }
+      } else if (match = string.match(keyword)) {
+        if (match[1] === "transparent") {
+          return [0, 0, 0, 0];
+        }
+        if (!hasOwnProperty.call(colorNames, match[1])) {
+          return null;
+        }
+        rgb = colorNames[match[1]];
+        rgb[3] = 1;
+        return rgb;
+      } else {
+        return null;
+      }
+      for (i3 = 0; i3 < 3; i3++) {
+        rgb[i3] = clamp2(rgb[i3], 0, 255);
+      }
+      rgb[3] = clamp2(rgb[3], 0, 1);
+      return rgb;
+    };
+    cs.get.hsl = function(string) {
+      if (!string) {
+        return null;
+      }
+      var hsl = /^hsla?\(\s*([+-]?(?:\d{0,3}\.)?\d+)(?:deg)?\s*,?\s*([+-]?[\d\.]+)%\s*,?\s*([+-]?[\d\.]+)%\s*(?:[,|\/]\s*([+-]?(?=\.\d|\d)(?:0|[1-9]\d*)?(?:\.\d*)?(?:[eE][+-]?\d+)?)\s*)?\)$/;
+      var match = string.match(hsl);
+      if (match) {
+        var alpha = parseFloat(match[4]);
+        var h = (parseFloat(match[1]) % 360 + 360) % 360;
+        var s = clamp2(parseFloat(match[2]), 0, 100);
+        var l3 = clamp2(parseFloat(match[3]), 0, 100);
+        var a = clamp2(isNaN(alpha) ? 1 : alpha, 0, 1);
+        return [h, s, l3, a];
+      }
+      return null;
+    };
+    cs.get.hwb = function(string) {
+      if (!string) {
+        return null;
+      }
+      var hwb = /^hwb\(\s*([+-]?\d{0,3}(?:\.\d+)?)(?:deg)?\s*,\s*([+-]?[\d\.]+)%\s*,\s*([+-]?[\d\.]+)%\s*(?:,\s*([+-]?(?=\.\d|\d)(?:0|[1-9]\d*)?(?:\.\d*)?(?:[eE][+-]?\d+)?)\s*)?\)$/;
+      var match = string.match(hwb);
+      if (match) {
+        var alpha = parseFloat(match[4]);
+        var h = (parseFloat(match[1]) % 360 + 360) % 360;
+        var w = clamp2(parseFloat(match[2]), 0, 100);
+        var b = clamp2(parseFloat(match[3]), 0, 100);
+        var a = clamp2(isNaN(alpha) ? 1 : alpha, 0, 1);
+        return [h, w, b, a];
+      }
+      return null;
+    };
+    cs.to.hex = function() {
+      var rgba = swizzle(arguments);
+      return "#" + hexDouble(rgba[0]) + hexDouble(rgba[1]) + hexDouble(rgba[2]) + (rgba[3] < 1 ? hexDouble(Math.round(rgba[3] * 255)) : "");
+    };
+    cs.to.rgb = function() {
+      var rgba = swizzle(arguments);
+      return rgba.length < 4 || rgba[3] === 1 ? "rgb(" + Math.round(rgba[0]) + ", " + Math.round(rgba[1]) + ", " + Math.round(rgba[2]) + ")" : "rgba(" + Math.round(rgba[0]) + ", " + Math.round(rgba[1]) + ", " + Math.round(rgba[2]) + ", " + rgba[3] + ")";
+    };
+    cs.to.rgb.percent = function() {
+      var rgba = swizzle(arguments);
+      var r = Math.round(rgba[0] / 255 * 100);
+      var g = Math.round(rgba[1] / 255 * 100);
+      var b = Math.round(rgba[2] / 255 * 100);
+      return rgba.length < 4 || rgba[3] === 1 ? "rgb(" + r + "%, " + g + "%, " + b + "%)" : "rgba(" + r + "%, " + g + "%, " + b + "%, " + rgba[3] + ")";
+    };
+    cs.to.hsl = function() {
+      var hsla = swizzle(arguments);
+      return hsla.length < 4 || hsla[3] === 1 ? "hsl(" + hsla[0] + ", " + hsla[1] + "%, " + hsla[2] + "%)" : "hsla(" + hsla[0] + ", " + hsla[1] + "%, " + hsla[2] + "%, " + hsla[3] + ")";
+    };
+    cs.to.hwb = function() {
+      var hwba = swizzle(arguments);
+      var a = "";
+      if (hwba.length >= 4 && hwba[3] !== 1) {
+        a = ", " + hwba[3];
+      }
+      return "hwb(" + hwba[0] + ", " + hwba[1] + "%, " + hwba[2] + "%" + a + ")";
+    };
+    cs.to.keyword = function(rgb) {
+      return reverseNames[rgb.slice(0, 3)];
+    };
+    function clamp2(num, min, max) {
+      return Math.min(Math.max(min, num), max);
+    }
+    function hexDouble(num) {
+      var str = Math.round(num).toString(16).toUpperCase();
+      return str.length < 2 ? "0" + str : str;
+    }
+  }
+});
+
+// node_modules/color-convert/conversions.js
+var require_conversions = __commonJS({
+  "node_modules/color-convert/conversions.js"(exports, module) {
+    var cssKeywords = require_color_name();
+    var reverseKeywords = {};
+    for (const key of Object.keys(cssKeywords)) {
+      reverseKeywords[cssKeywords[key]] = key;
+    }
+    var convert = {
+      rgb: { channels: 3, labels: "rgb" },
+      hsl: { channels: 3, labels: "hsl" },
+      hsv: { channels: 3, labels: "hsv" },
+      hwb: { channels: 3, labels: "hwb" },
+      cmyk: { channels: 4, labels: "cmyk" },
+      xyz: { channels: 3, labels: "xyz" },
+      lab: { channels: 3, labels: "lab" },
+      lch: { channels: 3, labels: "lch" },
+      hex: { channels: 1, labels: ["hex"] },
+      keyword: { channels: 1, labels: ["keyword"] },
+      ansi16: { channels: 1, labels: ["ansi16"] },
+      ansi256: { channels: 1, labels: ["ansi256"] },
+      hcg: { channels: 3, labels: ["h", "c", "g"] },
+      apple: { channels: 3, labels: ["r16", "g16", "b16"] },
+      gray: { channels: 1, labels: ["gray"] }
+    };
+    module.exports = convert;
+    for (const model of Object.keys(convert)) {
+      if (!("channels" in convert[model])) {
+        throw new Error("missing channels property: " + model);
+      }
+      if (!("labels" in convert[model])) {
+        throw new Error("missing channel labels property: " + model);
+      }
+      if (convert[model].labels.length !== convert[model].channels) {
+        throw new Error("channel and label counts mismatch: " + model);
+      }
+      const { channels, labels } = convert[model];
+      delete convert[model].channels;
+      delete convert[model].labels;
+      Object.defineProperty(convert[model], "channels", { value: channels });
+      Object.defineProperty(convert[model], "labels", { value: labels });
+    }
+    convert.rgb.hsl = function(rgb) {
+      const r = rgb[0] / 255;
+      const g = rgb[1] / 255;
+      const b = rgb[2] / 255;
+      const min = Math.min(r, g, b);
+      const max = Math.max(r, g, b);
+      const delta = max - min;
+      let h;
+      let s;
+      if (max === min) {
+        h = 0;
+      } else if (r === max) {
+        h = (g - b) / delta;
+      } else if (g === max) {
+        h = 2 + (b - r) / delta;
+      } else if (b === max) {
+        h = 4 + (r - g) / delta;
+      }
+      h = Math.min(h * 60, 360);
+      if (h < 0) {
+        h += 360;
+      }
+      const l3 = (min + max) / 2;
+      if (max === min) {
+        s = 0;
+      } else if (l3 <= 0.5) {
+        s = delta / (max + min);
+      } else {
+        s = delta / (2 - max - min);
+      }
+      return [h, s * 100, l3 * 100];
+    };
+    convert.rgb.hsv = function(rgb) {
+      let rdif;
+      let gdif;
+      let bdif;
+      let h;
+      let s;
+      const r = rgb[0] / 255;
+      const g = rgb[1] / 255;
+      const b = rgb[2] / 255;
+      const v = Math.max(r, g, b);
+      const diff = v - Math.min(r, g, b);
+      const diffc = function(c) {
+        return (v - c) / 6 / diff + 1 / 2;
+      };
+      if (diff === 0) {
+        h = 0;
+        s = 0;
+      } else {
+        s = diff / v;
+        rdif = diffc(r);
+        gdif = diffc(g);
+        bdif = diffc(b);
+        if (r === v) {
+          h = bdif - gdif;
+        } else if (g === v) {
+          h = 1 / 3 + rdif - bdif;
+        } else if (b === v) {
+          h = 2 / 3 + gdif - rdif;
+        }
+        if (h < 0) {
+          h += 1;
+        } else if (h > 1) {
+          h -= 1;
+        }
+      }
+      return [
+        h * 360,
+        s * 100,
+        v * 100
+      ];
+    };
+    convert.rgb.hwb = function(rgb) {
+      const r = rgb[0];
+      const g = rgb[1];
+      let b = rgb[2];
+      const h = convert.rgb.hsl(rgb)[0];
+      const w = 1 / 255 * Math.min(r, Math.min(g, b));
+      b = 1 - 1 / 255 * Math.max(r, Math.max(g, b));
+      return [h, w * 100, b * 100];
+    };
+    convert.rgb.cmyk = function(rgb) {
+      const r = rgb[0] / 255;
+      const g = rgb[1] / 255;
+      const b = rgb[2] / 255;
+      const k = Math.min(1 - r, 1 - g, 1 - b);
+      const c = (1 - r - k) / (1 - k) || 0;
+      const m = (1 - g - k) / (1 - k) || 0;
+      const y = (1 - b - k) / (1 - k) || 0;
+      return [c * 100, m * 100, y * 100, k * 100];
+    };
+    function comparativeDistance(x, y) {
+      return (x[0] - y[0]) ** 2 + (x[1] - y[1]) ** 2 + (x[2] - y[2]) ** 2;
+    }
+    convert.rgb.keyword = function(rgb) {
+      const reversed = reverseKeywords[rgb];
+      if (reversed) {
+        return reversed;
+      }
+      let currentClosestDistance = Infinity;
+      let currentClosestKeyword;
+      for (const keyword of Object.keys(cssKeywords)) {
+        const value = cssKeywords[keyword];
+        const distance = comparativeDistance(rgb, value);
+        if (distance < currentClosestDistance) {
+          currentClosestDistance = distance;
+          currentClosestKeyword = keyword;
+        }
+      }
+      return currentClosestKeyword;
+    };
+    convert.keyword.rgb = function(keyword) {
+      return cssKeywords[keyword];
+    };
+    convert.rgb.xyz = function(rgb) {
+      let r = rgb[0] / 255;
+      let g = rgb[1] / 255;
+      let b = rgb[2] / 255;
+      r = r > 0.04045 ? ((r + 0.055) / 1.055) ** 2.4 : r / 12.92;
+      g = g > 0.04045 ? ((g + 0.055) / 1.055) ** 2.4 : g / 12.92;
+      b = b > 0.04045 ? ((b + 0.055) / 1.055) ** 2.4 : b / 12.92;
+      const x = r * 0.4124 + g * 0.3576 + b * 0.1805;
+      const y = r * 0.2126 + g * 0.7152 + b * 0.0722;
+      const z = r * 0.0193 + g * 0.1192 + b * 0.9505;
+      return [x * 100, y * 100, z * 100];
+    };
+    convert.rgb.lab = function(rgb) {
+      const xyz = convert.rgb.xyz(rgb);
+      let x = xyz[0];
+      let y = xyz[1];
+      let z = xyz[2];
+      x /= 95.047;
+      y /= 100;
+      z /= 108.883;
+      x = x > 8856e-6 ? x ** (1 / 3) : 7.787 * x + 16 / 116;
+      y = y > 8856e-6 ? y ** (1 / 3) : 7.787 * y + 16 / 116;
+      z = z > 8856e-6 ? z ** (1 / 3) : 7.787 * z + 16 / 116;
+      const l3 = 116 * y - 16;
+      const a = 500 * (x - y);
+      const b = 200 * (y - z);
+      return [l3, a, b];
+    };
+    convert.hsl.rgb = function(hsl) {
+      const h = hsl[0] / 360;
+      const s = hsl[1] / 100;
+      const l3 = hsl[2] / 100;
+      let t2;
+      let t3;
+      let val;
+      if (s === 0) {
+        val = l3 * 255;
+        return [val, val, val];
+      }
+      if (l3 < 0.5) {
+        t2 = l3 * (1 + s);
+      } else {
+        t2 = l3 + s - l3 * s;
+      }
+      const t1 = 2 * l3 - t2;
+      const rgb = [0, 0, 0];
+      for (let i3 = 0; i3 < 3; i3++) {
+        t3 = h + 1 / 3 * -(i3 - 1);
+        if (t3 < 0) {
+          t3++;
+        }
+        if (t3 > 1) {
+          t3--;
+        }
+        if (6 * t3 < 1) {
+          val = t1 + (t2 - t1) * 6 * t3;
+        } else if (2 * t3 < 1) {
+          val = t2;
+        } else if (3 * t3 < 2) {
+          val = t1 + (t2 - t1) * (2 / 3 - t3) * 6;
+        } else {
+          val = t1;
+        }
+        rgb[i3] = val * 255;
+      }
+      return rgb;
+    };
+    convert.hsl.hsv = function(hsl) {
+      const h = hsl[0];
+      let s = hsl[1] / 100;
+      let l3 = hsl[2] / 100;
+      let smin = s;
+      const lmin = Math.max(l3, 0.01);
+      l3 *= 2;
+      s *= l3 <= 1 ? l3 : 2 - l3;
+      smin *= lmin <= 1 ? lmin : 2 - lmin;
+      const v = (l3 + s) / 2;
+      const sv = l3 === 0 ? 2 * smin / (lmin + smin) : 2 * s / (l3 + s);
+      return [h, sv * 100, v * 100];
+    };
+    convert.hsv.rgb = function(hsv) {
+      const h = hsv[0] / 60;
+      const s = hsv[1] / 100;
+      let v = hsv[2] / 100;
+      const hi = Math.floor(h) % 6;
+      const f = h - Math.floor(h);
+      const p = 255 * v * (1 - s);
+      const q = 255 * v * (1 - s * f);
+      const t2 = 255 * v * (1 - s * (1 - f));
+      v *= 255;
+      switch (hi) {
+        case 0:
+          return [v, t2, p];
+        case 1:
+          return [q, v, p];
+        case 2:
+          return [p, v, t2];
+        case 3:
+          return [p, q, v];
+        case 4:
+          return [t2, p, v];
+        case 5:
+          return [v, p, q];
+      }
+    };
+    convert.hsv.hsl = function(hsv) {
+      const h = hsv[0];
+      const s = hsv[1] / 100;
+      const v = hsv[2] / 100;
+      const vmin = Math.max(v, 0.01);
+      let sl;
+      let l3;
+      l3 = (2 - s) * v;
+      const lmin = (2 - s) * vmin;
+      sl = s * vmin;
+      sl /= lmin <= 1 ? lmin : 2 - lmin;
+      sl = sl || 0;
+      l3 /= 2;
+      return [h, sl * 100, l3 * 100];
+    };
+    convert.hwb.rgb = function(hwb) {
+      const h = hwb[0] / 360;
+      let wh = hwb[1] / 100;
+      let bl = hwb[2] / 100;
+      const ratio = wh + bl;
+      let f;
+      if (ratio > 1) {
+        wh /= ratio;
+        bl /= ratio;
+      }
+      const i3 = Math.floor(6 * h);
+      const v = 1 - bl;
+      f = 6 * h - i3;
+      if ((i3 & 1) !== 0) {
+        f = 1 - f;
+      }
+      const n2 = wh + f * (v - wh);
+      let r;
+      let g;
+      let b;
+      switch (i3) {
+        default:
+        case 6:
+        case 0:
+          r = v;
+          g = n2;
+          b = wh;
+          break;
+        case 1:
+          r = n2;
+          g = v;
+          b = wh;
+          break;
+        case 2:
+          r = wh;
+          g = v;
+          b = n2;
+          break;
+        case 3:
+          r = wh;
+          g = n2;
+          b = v;
+          break;
+        case 4:
+          r = n2;
+          g = wh;
+          b = v;
+          break;
+        case 5:
+          r = v;
+          g = wh;
+          b = n2;
+          break;
+      }
+      return [r * 255, g * 255, b * 255];
+    };
+    convert.cmyk.rgb = function(cmyk) {
+      const c = cmyk[0] / 100;
+      const m = cmyk[1] / 100;
+      const y = cmyk[2] / 100;
+      const k = cmyk[3] / 100;
+      const r = 1 - Math.min(1, c * (1 - k) + k);
+      const g = 1 - Math.min(1, m * (1 - k) + k);
+      const b = 1 - Math.min(1, y * (1 - k) + k);
+      return [r * 255, g * 255, b * 255];
+    };
+    convert.xyz.rgb = function(xyz) {
+      const x = xyz[0] / 100;
+      const y = xyz[1] / 100;
+      const z = xyz[2] / 100;
+      let r;
+      let g;
+      let b;
+      r = x * 3.2406 + y * -1.5372 + z * -0.4986;
+      g = x * -0.9689 + y * 1.8758 + z * 0.0415;
+      b = x * 0.0557 + y * -0.204 + z * 1.057;
+      r = r > 31308e-7 ? 1.055 * r ** (1 / 2.4) - 0.055 : r * 12.92;
+      g = g > 31308e-7 ? 1.055 * g ** (1 / 2.4) - 0.055 : g * 12.92;
+      b = b > 31308e-7 ? 1.055 * b ** (1 / 2.4) - 0.055 : b * 12.92;
+      r = Math.min(Math.max(0, r), 1);
+      g = Math.min(Math.max(0, g), 1);
+      b = Math.min(Math.max(0, b), 1);
+      return [r * 255, g * 255, b * 255];
+    };
+    convert.xyz.lab = function(xyz) {
+      let x = xyz[0];
+      let y = xyz[1];
+      let z = xyz[2];
+      x /= 95.047;
+      y /= 100;
+      z /= 108.883;
+      x = x > 8856e-6 ? x ** (1 / 3) : 7.787 * x + 16 / 116;
+      y = y > 8856e-6 ? y ** (1 / 3) : 7.787 * y + 16 / 116;
+      z = z > 8856e-6 ? z ** (1 / 3) : 7.787 * z + 16 / 116;
+      const l3 = 116 * y - 16;
+      const a = 500 * (x - y);
+      const b = 200 * (y - z);
+      return [l3, a, b];
+    };
+    convert.lab.xyz = function(lab) {
+      const l3 = lab[0];
+      const a = lab[1];
+      const b = lab[2];
+      let x;
+      let y;
+      let z;
+      y = (l3 + 16) / 116;
+      x = a / 500 + y;
+      z = y - b / 200;
+      const y2 = y ** 3;
+      const x2 = x ** 3;
+      const z2 = z ** 3;
+      y = y2 > 8856e-6 ? y2 : (y - 16 / 116) / 7.787;
+      x = x2 > 8856e-6 ? x2 : (x - 16 / 116) / 7.787;
+      z = z2 > 8856e-6 ? z2 : (z - 16 / 116) / 7.787;
+      x *= 95.047;
+      y *= 100;
+      z *= 108.883;
+      return [x, y, z];
+    };
+    convert.lab.lch = function(lab) {
+      const l3 = lab[0];
+      const a = lab[1];
+      const b = lab[2];
+      let h;
+      const hr = Math.atan2(b, a);
+      h = hr * 360 / 2 / Math.PI;
+      if (h < 0) {
+        h += 360;
+      }
+      const c = Math.sqrt(a * a + b * b);
+      return [l3, c, h];
+    };
+    convert.lch.lab = function(lch) {
+      const l3 = lch[0];
+      const c = lch[1];
+      const h = lch[2];
+      const hr = h / 360 * 2 * Math.PI;
+      const a = c * Math.cos(hr);
+      const b = c * Math.sin(hr);
+      return [l3, a, b];
+    };
+    convert.rgb.ansi16 = function(args, saturation = null) {
+      const [r, g, b] = args;
+      let value = saturation === null ? convert.rgb.hsv(args)[2] : saturation;
+      value = Math.round(value / 50);
+      if (value === 0) {
+        return 30;
+      }
+      let ansi = 30 + (Math.round(b / 255) << 2 | Math.round(g / 255) << 1 | Math.round(r / 255));
+      if (value === 2) {
+        ansi += 60;
+      }
+      return ansi;
+    };
+    convert.hsv.ansi16 = function(args) {
+      return convert.rgb.ansi16(convert.hsv.rgb(args), args[2]);
+    };
+    convert.rgb.ansi256 = function(args) {
+      const r = args[0];
+      const g = args[1];
+      const b = args[2];
+      if (r === g && g === b) {
+        if (r < 8) {
+          return 16;
+        }
+        if (r > 248) {
+          return 231;
+        }
+        return Math.round((r - 8) / 247 * 24) + 232;
+      }
+      const ansi = 16 + 36 * Math.round(r / 255 * 5) + 6 * Math.round(g / 255 * 5) + Math.round(b / 255 * 5);
+      return ansi;
+    };
+    convert.ansi16.rgb = function(args) {
+      let color = args % 10;
+      if (color === 0 || color === 7) {
+        if (args > 50) {
+          color += 3.5;
+        }
+        color = color / 10.5 * 255;
+        return [color, color, color];
+      }
+      const mult = (~~(args > 50) + 1) * 0.5;
+      const r = (color & 1) * mult * 255;
+      const g = (color >> 1 & 1) * mult * 255;
+      const b = (color >> 2 & 1) * mult * 255;
+      return [r, g, b];
+    };
+    convert.ansi256.rgb = function(args) {
+      if (args >= 232) {
+        const c = (args - 232) * 10 + 8;
+        return [c, c, c];
+      }
+      args -= 16;
+      let rem;
+      const r = Math.floor(args / 36) / 5 * 255;
+      const g = Math.floor((rem = args % 36) / 6) / 5 * 255;
+      const b = rem % 6 / 5 * 255;
+      return [r, g, b];
+    };
+    convert.rgb.hex = function(args) {
+      const integer = ((Math.round(args[0]) & 255) << 16) + ((Math.round(args[1]) & 255) << 8) + (Math.round(args[2]) & 255);
+      const string = integer.toString(16).toUpperCase();
+      return "000000".substring(string.length) + string;
+    };
+    convert.hex.rgb = function(args) {
+      const match = args.toString(16).match(/[a-f0-9]{6}|[a-f0-9]{3}/i);
+      if (!match) {
+        return [0, 0, 0];
+      }
+      let colorString = match[0];
+      if (match[0].length === 3) {
+        colorString = colorString.split("").map((char) => {
+          return char + char;
+        }).join("");
+      }
+      const integer = parseInt(colorString, 16);
+      const r = integer >> 16 & 255;
+      const g = integer >> 8 & 255;
+      const b = integer & 255;
+      return [r, g, b];
+    };
+    convert.rgb.hcg = function(rgb) {
+      const r = rgb[0] / 255;
+      const g = rgb[1] / 255;
+      const b = rgb[2] / 255;
+      const max = Math.max(Math.max(r, g), b);
+      const min = Math.min(Math.min(r, g), b);
+      const chroma = max - min;
+      let grayscale;
+      let hue;
+      if (chroma < 1) {
+        grayscale = min / (1 - chroma);
+      } else {
+        grayscale = 0;
+      }
+      if (chroma <= 0) {
+        hue = 0;
+      } else if (max === r) {
+        hue = (g - b) / chroma % 6;
+      } else if (max === g) {
+        hue = 2 + (b - r) / chroma;
+      } else {
+        hue = 4 + (r - g) / chroma;
+      }
+      hue /= 6;
+      hue %= 1;
+      return [hue * 360, chroma * 100, grayscale * 100];
+    };
+    convert.hsl.hcg = function(hsl) {
+      const s = hsl[1] / 100;
+      const l3 = hsl[2] / 100;
+      const c = l3 < 0.5 ? 2 * s * l3 : 2 * s * (1 - l3);
+      let f = 0;
+      if (c < 1) {
+        f = (l3 - 0.5 * c) / (1 - c);
+      }
+      return [hsl[0], c * 100, f * 100];
+    };
+    convert.hsv.hcg = function(hsv) {
+      const s = hsv[1] / 100;
+      const v = hsv[2] / 100;
+      const c = s * v;
+      let f = 0;
+      if (c < 1) {
+        f = (v - c) / (1 - c);
+      }
+      return [hsv[0], c * 100, f * 100];
+    };
+    convert.hcg.rgb = function(hcg) {
+      const h = hcg[0] / 360;
+      const c = hcg[1] / 100;
+      const g = hcg[2] / 100;
+      if (c === 0) {
+        return [g * 255, g * 255, g * 255];
+      }
+      const pure = [0, 0, 0];
+      const hi = h % 1 * 6;
+      const v = hi % 1;
+      const w = 1 - v;
+      let mg = 0;
+      switch (Math.floor(hi)) {
+        case 0:
+          pure[0] = 1;
+          pure[1] = v;
+          pure[2] = 0;
+          break;
+        case 1:
+          pure[0] = w;
+          pure[1] = 1;
+          pure[2] = 0;
+          break;
+        case 2:
+          pure[0] = 0;
+          pure[1] = 1;
+          pure[2] = v;
+          break;
+        case 3:
+          pure[0] = 0;
+          pure[1] = w;
+          pure[2] = 1;
+          break;
+        case 4:
+          pure[0] = v;
+          pure[1] = 0;
+          pure[2] = 1;
+          break;
+        default:
+          pure[0] = 1;
+          pure[1] = 0;
+          pure[2] = w;
+      }
+      mg = (1 - c) * g;
+      return [
+        (c * pure[0] + mg) * 255,
+        (c * pure[1] + mg) * 255,
+        (c * pure[2] + mg) * 255
+      ];
+    };
+    convert.hcg.hsv = function(hcg) {
+      const c = hcg[1] / 100;
+      const g = hcg[2] / 100;
+      const v = c + g * (1 - c);
+      let f = 0;
+      if (v > 0) {
+        f = c / v;
+      }
+      return [hcg[0], f * 100, v * 100];
+    };
+    convert.hcg.hsl = function(hcg) {
+      const c = hcg[1] / 100;
+      const g = hcg[2] / 100;
+      const l3 = g * (1 - c) + 0.5 * c;
+      let s = 0;
+      if (l3 > 0 && l3 < 0.5) {
+        s = c / (2 * l3);
+      } else if (l3 >= 0.5 && l3 < 1) {
+        s = c / (2 * (1 - l3));
+      }
+      return [hcg[0], s * 100, l3 * 100];
+    };
+    convert.hcg.hwb = function(hcg) {
+      const c = hcg[1] / 100;
+      const g = hcg[2] / 100;
+      const v = c + g * (1 - c);
+      return [hcg[0], (v - c) * 100, (1 - v) * 100];
+    };
+    convert.hwb.hcg = function(hwb) {
+      const w = hwb[1] / 100;
+      const b = hwb[2] / 100;
+      const v = 1 - b;
+      const c = v - w;
+      let g = 0;
+      if (c < 1) {
+        g = (v - c) / (1 - c);
+      }
+      return [hwb[0], c * 100, g * 100];
+    };
+    convert.apple.rgb = function(apple) {
+      return [apple[0] / 65535 * 255, apple[1] / 65535 * 255, apple[2] / 65535 * 255];
+    };
+    convert.rgb.apple = function(rgb) {
+      return [rgb[0] / 255 * 65535, rgb[1] / 255 * 65535, rgb[2] / 255 * 65535];
+    };
+    convert.gray.rgb = function(args) {
+      return [args[0] / 100 * 255, args[0] / 100 * 255, args[0] / 100 * 255];
+    };
+    convert.gray.hsl = function(args) {
+      return [0, 0, args[0]];
+    };
+    convert.gray.hsv = convert.gray.hsl;
+    convert.gray.hwb = function(gray) {
+      return [0, 100, gray[0]];
+    };
+    convert.gray.cmyk = function(gray) {
+      return [0, 0, 0, gray[0]];
+    };
+    convert.gray.lab = function(gray) {
+      return [gray[0], 0, 0];
+    };
+    convert.gray.hex = function(gray) {
+      const val = Math.round(gray[0] / 100 * 255) & 255;
+      const integer = (val << 16) + (val << 8) + val;
+      const string = integer.toString(16).toUpperCase();
+      return "000000".substring(string.length) + string;
+    };
+    convert.rgb.gray = function(rgb) {
+      const val = (rgb[0] + rgb[1] + rgb[2]) / 3;
+      return [val / 255 * 100];
+    };
+  }
+});
+
+// node_modules/color-convert/route.js
+var require_route = __commonJS({
+  "node_modules/color-convert/route.js"(exports, module) {
+    var conversions = require_conversions();
+    function buildGraph() {
+      const graph = {};
+      const models = Object.keys(conversions);
+      for (let len = models.length, i3 = 0; i3 < len; i3++) {
+        graph[models[i3]] = {
+          distance: -1,
+          parent: null
+        };
+      }
+      return graph;
+    }
+    function deriveBFS(fromModel) {
+      const graph = buildGraph();
+      const queue = [fromModel];
+      graph[fromModel].distance = 0;
+      while (queue.length) {
+        const current = queue.pop();
+        const adjacents = Object.keys(conversions[current]);
+        for (let len = adjacents.length, i3 = 0; i3 < len; i3++) {
+          const adjacent = adjacents[i3];
+          const node = graph[adjacent];
+          if (node.distance === -1) {
+            node.distance = graph[current].distance + 1;
+            node.parent = current;
+            queue.unshift(adjacent);
+          }
+        }
+      }
+      return graph;
+    }
+    function link(from, to) {
+      return function(args) {
+        return to(from(args));
+      };
+    }
+    function wrapConversion(toModel, graph) {
+      const path = [graph[toModel].parent, toModel];
+      let fn = conversions[graph[toModel].parent][toModel];
+      let cur = graph[toModel].parent;
+      while (graph[cur].parent) {
+        path.unshift(graph[cur].parent);
+        fn = link(conversions[graph[cur].parent][cur], fn);
+        cur = graph[cur].parent;
+      }
+      fn.conversion = path;
+      return fn;
+    }
+    module.exports = function(fromModel) {
+      const graph = deriveBFS(fromModel);
+      const conversion = {};
+      const models = Object.keys(graph);
+      for (let len = models.length, i3 = 0; i3 < len; i3++) {
+        const toModel = models[i3];
+        const node = graph[toModel];
+        if (node.parent === null) {
+          continue;
+        }
+        conversion[toModel] = wrapConversion(toModel, graph);
+      }
+      return conversion;
+    };
+  }
+});
+
+// node_modules/color-convert/index.js
+var require_color_convert = __commonJS({
+  "node_modules/color-convert/index.js"(exports, module) {
+    var conversions = require_conversions();
+    var route = require_route();
+    var convert = {};
+    var models = Object.keys(conversions);
+    function wrapRaw(fn) {
+      const wrappedFn = function(...args) {
+        const arg0 = args[0];
+        if (arg0 === void 0 || arg0 === null) {
+          return arg0;
+        }
+        if (arg0.length > 1) {
+          args = arg0;
+        }
+        return fn(args);
+      };
+      if ("conversion" in fn) {
+        wrappedFn.conversion = fn.conversion;
+      }
+      return wrappedFn;
+    }
+    function wrapRounded(fn) {
+      const wrappedFn = function(...args) {
+        const arg0 = args[0];
+        if (arg0 === void 0 || arg0 === null) {
+          return arg0;
+        }
+        if (arg0.length > 1) {
+          args = arg0;
+        }
+        const result = fn(args);
+        if (typeof result === "object") {
+          for (let len = result.length, i3 = 0; i3 < len; i3++) {
+            result[i3] = Math.round(result[i3]);
+          }
+        }
+        return result;
+      };
+      if ("conversion" in fn) {
+        wrappedFn.conversion = fn.conversion;
+      }
+      return wrappedFn;
+    }
+    models.forEach((fromModel) => {
+      convert[fromModel] = {};
+      Object.defineProperty(convert[fromModel], "channels", { value: conversions[fromModel].channels });
+      Object.defineProperty(convert[fromModel], "labels", { value: conversions[fromModel].labels });
+      const routes = route(fromModel);
+      const routeModels = Object.keys(routes);
+      routeModels.forEach((toModel) => {
+        const fn = routes[toModel];
+        convert[fromModel][toModel] = wrapRounded(fn);
+        convert[fromModel][toModel].raw = wrapRaw(fn);
+      });
+    });
+    module.exports = convert;
+  }
+});
+
+// node_modules/color/index.js
+var require_color = __commonJS({
+  "node_modules/color/index.js"(exports, module) {
+    var colorString = require_color_string();
+    var convert = require_color_convert();
+    var _slice = [].slice;
+    var skippedModels = [
+      "keyword",
+      "gray",
+      "hex"
+    ];
+    var hashedModelKeys = {};
+    for (const model of Object.keys(convert)) {
+      hashedModelKeys[_slice.call(convert[model].labels).sort().join("")] = model;
+    }
+    var limiters = {};
+    function Color2(object, model) {
+      if (!(this instanceof Color2)) {
+        return new Color2(object, model);
+      }
+      if (model && model in skippedModels) {
+        model = null;
+      }
+      if (model && !(model in convert)) {
+        throw new Error("Unknown model: " + model);
+      }
+      let i3;
+      let channels;
+      if (object == null) {
+        this.model = "rgb";
+        this.color = [0, 0, 0];
+        this.valpha = 1;
+      } else if (object instanceof Color2) {
+        this.model = object.model;
+        this.color = object.color.slice();
+        this.valpha = object.valpha;
+      } else if (typeof object === "string") {
+        const result = colorString.get(object);
+        if (result === null) {
+          throw new Error("Unable to parse color from string: " + object);
+        }
+        this.model = result.model;
+        channels = convert[this.model].channels;
+        this.color = result.value.slice(0, channels);
+        this.valpha = typeof result.value[channels] === "number" ? result.value[channels] : 1;
+      } else if (object.length > 0) {
+        this.model = model || "rgb";
+        channels = convert[this.model].channels;
+        const newArray = _slice.call(object, 0, channels);
+        this.color = zeroArray(newArray, channels);
+        this.valpha = typeof object[channels] === "number" ? object[channels] : 1;
+      } else if (typeof object === "number") {
+        this.model = "rgb";
+        this.color = [
+          object >> 16 & 255,
+          object >> 8 & 255,
+          object & 255
+        ];
+        this.valpha = 1;
+      } else {
+        this.valpha = 1;
+        const keys = Object.keys(object);
+        if ("alpha" in object) {
+          keys.splice(keys.indexOf("alpha"), 1);
+          this.valpha = typeof object.alpha === "number" ? object.alpha : 0;
+        }
+        const hashedKeys = keys.sort().join("");
+        if (!(hashedKeys in hashedModelKeys)) {
+          throw new Error("Unable to parse color from object: " + JSON.stringify(object));
+        }
+        this.model = hashedModelKeys[hashedKeys];
+        const labels = convert[this.model].labels;
+        const color = [];
+        for (i3 = 0; i3 < labels.length; i3++) {
+          color.push(object[labels[i3]]);
+        }
+        this.color = zeroArray(color);
+      }
+      if (limiters[this.model]) {
+        channels = convert[this.model].channels;
+        for (i3 = 0; i3 < channels; i3++) {
+          const limit = limiters[this.model][i3];
+          if (limit) {
+            this.color[i3] = limit(this.color[i3]);
+          }
+        }
+      }
+      this.valpha = Math.max(0, Math.min(1, this.valpha));
+      if (Object.freeze) {
+        Object.freeze(this);
+      }
+    }
+    Color2.prototype = {
+      toString() {
+        return this.string();
+      },
+      toJSON() {
+        return this[this.model]();
+      },
+      string(places) {
+        let self = this.model in colorString.to ? this : this.rgb();
+        self = self.round(typeof places === "number" ? places : 1);
+        const args = self.valpha === 1 ? self.color : self.color.concat(this.valpha);
+        return colorString.to[self.model](args);
+      },
+      percentString(places) {
+        const self = this.rgb().round(typeof places === "number" ? places : 1);
+        const args = self.valpha === 1 ? self.color : self.color.concat(this.valpha);
+        return colorString.to.rgb.percent(args);
+      },
+      array() {
+        return this.valpha === 1 ? this.color.slice() : this.color.concat(this.valpha);
+      },
+      object() {
+        const result = {};
+        const channels = convert[this.model].channels;
+        const labels = convert[this.model].labels;
+        for (let i3 = 0; i3 < channels; i3++) {
+          result[labels[i3]] = this.color[i3];
+        }
+        if (this.valpha !== 1) {
+          result.alpha = this.valpha;
+        }
+        return result;
+      },
+      unitArray() {
+        const rgb = this.rgb().color;
+        rgb[0] /= 255;
+        rgb[1] /= 255;
+        rgb[2] /= 255;
+        if (this.valpha !== 1) {
+          rgb.push(this.valpha);
+        }
+        return rgb;
+      },
+      unitObject() {
+        const rgb = this.rgb().object();
+        rgb.r /= 255;
+        rgb.g /= 255;
+        rgb.b /= 255;
+        if (this.valpha !== 1) {
+          rgb.alpha = this.valpha;
+        }
+        return rgb;
+      },
+      round(places) {
+        places = Math.max(places || 0, 0);
+        return new Color2(this.color.map(roundToPlace(places)).concat(this.valpha), this.model);
+      },
+      alpha(value) {
+        if (arguments.length > 0) {
+          return new Color2(this.color.concat(Math.max(0, Math.min(1, value))), this.model);
+        }
+        return this.valpha;
+      },
+      red: getset("rgb", 0, maxfn(255)),
+      green: getset("rgb", 1, maxfn(255)),
+      blue: getset("rgb", 2, maxfn(255)),
+      hue: getset(["hsl", "hsv", "hsl", "hwb", "hcg"], 0, (value) => (value % 360 + 360) % 360),
+      saturationl: getset("hsl", 1, maxfn(100)),
+      lightness: getset("hsl", 2, maxfn(100)),
+      saturationv: getset("hsv", 1, maxfn(100)),
+      value: getset("hsv", 2, maxfn(100)),
+      chroma: getset("hcg", 1, maxfn(100)),
+      gray: getset("hcg", 2, maxfn(100)),
+      white: getset("hwb", 1, maxfn(100)),
+      wblack: getset("hwb", 2, maxfn(100)),
+      cyan: getset("cmyk", 0, maxfn(100)),
+      magenta: getset("cmyk", 1, maxfn(100)),
+      yellow: getset("cmyk", 2, maxfn(100)),
+      black: getset("cmyk", 3, maxfn(100)),
+      x: getset("xyz", 0, maxfn(100)),
+      y: getset("xyz", 1, maxfn(100)),
+      z: getset("xyz", 2, maxfn(100)),
+      l: getset("lab", 0, maxfn(100)),
+      a: getset("lab", 1),
+      b: getset("lab", 2),
+      keyword(value) {
+        if (arguments.length > 0) {
+          return new Color2(value);
+        }
+        return convert[this.model].keyword(this.color);
+      },
+      hex(value) {
+        if (arguments.length > 0) {
+          return new Color2(value);
+        }
+        return colorString.to.hex(this.rgb().round().color);
+      },
+      hexa(value) {
+        if (arguments.length > 0) {
+          return new Color2(value);
+        }
+        const rgbArray = this.rgb().round().color;
+        let alphaHex = Math.round(this.valpha * 255).toString(16).toUpperCase();
+        if (alphaHex.length === 1) {
+          alphaHex = "0" + alphaHex;
+        }
+        return colorString.to.hex(rgbArray) + alphaHex;
+      },
+      rgbNumber() {
+        const rgb = this.rgb().color;
+        return (rgb[0] & 255) << 16 | (rgb[1] & 255) << 8 | rgb[2] & 255;
+      },
+      luminosity() {
+        const rgb = this.rgb().color;
+        const lum = [];
+        for (const [i3, element] of rgb.entries()) {
+          const chan = element / 255;
+          lum[i3] = chan <= 0.03928 ? chan / 12.92 : ((chan + 0.055) / 1.055) ** 2.4;
+        }
+        return 0.2126 * lum[0] + 0.7152 * lum[1] + 0.0722 * lum[2];
+      },
+      contrast(color2) {
+        const lum1 = this.luminosity();
+        const lum2 = color2.luminosity();
+        if (lum1 > lum2) {
+          return (lum1 + 0.05) / (lum2 + 0.05);
+        }
+        return (lum2 + 0.05) / (lum1 + 0.05);
+      },
+      level(color2) {
+        const contrastRatio = this.contrast(color2);
+        if (contrastRatio >= 7.1) {
+          return "AAA";
+        }
+        return contrastRatio >= 4.5 ? "AA" : "";
+      },
+      isDark() {
+        const rgb = this.rgb().color;
+        const yiq = (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1e3;
+        return yiq < 128;
+      },
+      isLight() {
+        return !this.isDark();
+      },
+      negate() {
+        const rgb = this.rgb();
+        for (let i3 = 0; i3 < 3; i3++) {
+          rgb.color[i3] = 255 - rgb.color[i3];
+        }
+        return rgb;
+      },
+      lighten(ratio) {
+        const hsl = this.hsl();
+        hsl.color[2] += hsl.color[2] * ratio;
+        return hsl;
+      },
+      darken(ratio) {
+        const hsl = this.hsl();
+        hsl.color[2] -= hsl.color[2] * ratio;
+        return hsl;
+      },
+      saturate(ratio) {
+        const hsl = this.hsl();
+        hsl.color[1] += hsl.color[1] * ratio;
+        return hsl;
+      },
+      desaturate(ratio) {
+        const hsl = this.hsl();
+        hsl.color[1] -= hsl.color[1] * ratio;
+        return hsl;
+      },
+      whiten(ratio) {
+        const hwb = this.hwb();
+        hwb.color[1] += hwb.color[1] * ratio;
+        return hwb;
+      },
+      blacken(ratio) {
+        const hwb = this.hwb();
+        hwb.color[2] += hwb.color[2] * ratio;
+        return hwb;
+      },
+      grayscale() {
+        const rgb = this.rgb().color;
+        const value = rgb[0] * 0.3 + rgb[1] * 0.59 + rgb[2] * 0.11;
+        return Color2.rgb(value, value, value);
+      },
+      fade(ratio) {
+        return this.alpha(this.valpha - this.valpha * ratio);
+      },
+      opaquer(ratio) {
+        return this.alpha(this.valpha + this.valpha * ratio);
+      },
+      rotate(degrees) {
+        const hsl = this.hsl();
+        let hue = hsl.color[0];
+        hue = (hue + degrees) % 360;
+        hue = hue < 0 ? 360 + hue : hue;
+        hsl.color[0] = hue;
+        return hsl;
+      },
+      mix(mixinColor, weight) {
+        if (!mixinColor || !mixinColor.rgb) {
+          throw new Error('Argument to "mix" was not a Color instance, but rather an instance of ' + typeof mixinColor);
+        }
+        const color1 = mixinColor.rgb();
+        const color2 = this.rgb();
+        const p = weight === void 0 ? 0.5 : weight;
+        const w = 2 * p - 1;
+        const a = color1.alpha() - color2.alpha();
+        const w1 = ((w * a === -1 ? w : (w + a) / (1 + w * a)) + 1) / 2;
+        const w2 = 1 - w1;
+        return Color2.rgb(
+          w1 * color1.red() + w2 * color2.red(),
+          w1 * color1.green() + w2 * color2.green(),
+          w1 * color1.blue() + w2 * color2.blue(),
+          color1.alpha() * p + color2.alpha() * (1 - p)
+        );
+      }
+    };
+    for (const model of Object.keys(convert)) {
+      if (skippedModels.includes(model)) {
+        continue;
+      }
+      const channels = convert[model].channels;
+      Color2.prototype[model] = function() {
+        if (this.model === model) {
+          return new Color2(this);
+        }
+        if (arguments.length > 0) {
+          return new Color2(arguments, model);
+        }
+        const newAlpha = typeof arguments[channels] === "number" ? channels : this.valpha;
+        return new Color2(assertArray(convert[this.model][model].raw(this.color)).concat(newAlpha), model);
+      };
+      Color2[model] = function(color) {
+        if (typeof color === "number") {
+          color = zeroArray(_slice.call(arguments), channels);
+        }
+        return new Color2(color, model);
+      };
+    }
+    function roundTo(number, places) {
+      return Number(number.toFixed(places));
+    }
+    function roundToPlace(places) {
+      return function(number) {
+        return roundTo(number, places);
+      };
+    }
+    function getset(model, channel, modifier) {
+      model = Array.isArray(model) ? model : [model];
+      for (const m of model) {
+        (limiters[m] || (limiters[m] = []))[channel] = modifier;
+      }
+      model = model[0];
+      return function(value) {
+        let result;
+        if (arguments.length > 0) {
+          if (modifier) {
+            value = modifier(value);
+          }
+          result = this[model]();
+          result.color[channel] = value;
+          return result;
+        }
+        result = this[model]().color[channel];
+        if (modifier) {
+          result = modifier(result);
+        }
+        return result;
+      };
+    }
+    function maxfn(max) {
+      return function(v) {
+        return Math.max(0, Math.min(max, v));
+      };
+    }
+    function assertArray(value) {
+      return Array.isArray(value) ? value : [value];
+    }
+    function zeroArray(array, length) {
+      for (let i3 = 0; i3 < length; i3++) {
+        if (typeof array[i3] !== "number") {
+          array[i3] = 0;
+        }
+      }
+      return array;
+    }
+    module.exports = Color2;
+  }
+});
+
+// src/components/color-picker/color-picker.ts
+var import_color = __toESM(require_color(), 1);
+var hasEyeDropper = "EyeDropper" in window;
+var SlColorPicker = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.formSubmitController = new FormSubmitController(this);
+    this.isSafeValue = false;
+    this.localize = new LocalizeController2(this);
+    this.isDraggingGridHandle = false;
+    this.isEmpty = false;
+    this.inputValue = "";
+    this.hue = 0;
+    this.saturation = 100;
+    this.lightness = 100;
+    this.brightness = 100;
+    this.alpha = 100;
+    this.value = "";
+    this.defaultValue = "";
+    this.label = "";
+    this.format = "hex";
+    this.inline = false;
+    this.size = "medium";
+    this.noFormatToggle = false;
+    this.name = "";
+    this.disabled = false;
+    this.invalid = false;
+    this.hoist = false;
+    this.opacity = false;
+    this.uppercase = false;
+    this.swatches = [
+      "#d0021b",
+      "#f5a623",
+      "#f8e71c",
+      "#8b572a",
+      "#7ed321",
+      "#417505",
+      "#bd10e0",
+      "#9013fe",
+      "#4a90e2",
+      "#50e3c2",
+      "#b8e986",
+      "#000",
+      "#444",
+      "#888",
+      "#ccc",
+      "#fff"
+    ];
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.value) {
+      this.setColor(this.value);
+      this.inputValue = this.value;
+      this.lastValueEmitted = this.value;
+      this.syncValues();
+    } else {
+      this.isEmpty = true;
+      this.inputValue = "";
+      this.lastValueEmitted = "";
+    }
+  }
+  getFormattedValue(format = "hex") {
+    const currentColor = this.parseColor(
+      `hsla(${this.hue}, ${this.saturation}%, ${this.lightness}%, ${this.alpha / 100})`
+    );
+    if (currentColor === null) {
+      return "";
+    }
+    switch (format) {
+      case "hex":
+        return currentColor.hex;
+      case "hexa":
+        return currentColor.hexa;
+      case "rgb":
+        return currentColor.rgb.string;
+      case "rgba":
+        return currentColor.rgba.string;
+      case "hsl":
+        return currentColor.hsl.string;
+      case "hsla":
+        return currentColor.hsla.string;
+      default:
+        return "";
+    }
+  }
+  getBrightness(lightness) {
+    return clamp(-1 * (200 * lightness / (this.saturation - 200)), 0, 100);
+  }
+  getLightness(brightness) {
+    return clamp((200 - this.saturation) * brightness / 100 * 5 / 10, 0, 100);
+  }
+  reportValidity() {
+    if (!this.inline && this.input.invalid) {
+      return new Promise((resolve) => {
+        this.dropdown.addEventListener(
+          "sl-after-show",
+          () => {
+            this.input.reportValidity();
+            resolve();
+          },
+          { once: true }
+        );
+        this.dropdown.show();
+      });
+    }
+    return this.input.reportValidity();
+  }
+  setCustomValidity(message) {
+    this.input.setCustomValidity(message);
+    this.invalid = this.input.invalid;
+  }
+  handleCopy() {
+    this.input.select();
+    document.execCommand("copy");
+    this.previewButton.focus();
+    this.previewButton.classList.add("color-picker__preview-color--copied");
+    this.previewButton.addEventListener("animationend", () => {
+      this.previewButton.classList.remove("color-picker__preview-color--copied");
+    });
+  }
+  handleFormatToggle() {
+    const formats = ["hex", "rgb", "hsl"];
+    const nextIndex = (formats.indexOf(this.format) + 1) % formats.length;
+    this.format = formats[nextIndex];
+  }
+  handleAlphaDrag(event) {
+    const container = this.shadowRoot.querySelector(".color-picker__slider.color-picker__alpha");
+    const handle = container.querySelector(".color-picker__slider-handle");
+    const { width } = container.getBoundingClientRect();
+    handle.focus();
+    event.preventDefault();
+    drag(container, {
+      onMove: (x) => {
+        this.alpha = clamp(x / width * 100, 0, 100);
+        this.syncValues();
+      },
+      initialEvent: event
+    });
+  }
+  handleHueDrag(event) {
+    const container = this.shadowRoot.querySelector(".color-picker__slider.color-picker__hue");
+    const handle = container.querySelector(".color-picker__slider-handle");
+    const { width } = container.getBoundingClientRect();
+    handle.focus();
+    event.preventDefault();
+    drag(container, {
+      onMove: (x) => {
+        this.hue = clamp(x / width * 360, 0, 360);
+        this.syncValues();
+      },
+      initialEvent: event
+    });
+  }
+  handleGridDrag(event) {
+    const grid = this.shadowRoot.querySelector(".color-picker__grid");
+    const handle = grid.querySelector(".color-picker__grid-handle");
+    const { width, height } = grid.getBoundingClientRect();
+    handle.focus();
+    event.preventDefault();
+    this.isDraggingGridHandle = true;
+    drag(grid, {
+      onMove: (x, y) => {
+        this.saturation = clamp(x / width * 100, 0, 100);
+        this.brightness = clamp(100 - y / height * 100, 0, 100);
+        this.lightness = this.getLightness(this.brightness);
+        this.syncValues();
+      },
+      onStop: () => this.isDraggingGridHandle = false,
+      initialEvent: event
+    });
+  }
+  handleAlphaKeyDown(event) {
+    const increment = event.shiftKey ? 10 : 1;
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      this.alpha = clamp(this.alpha - increment, 0, 100);
+      this.syncValues();
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      this.alpha = clamp(this.alpha + increment, 0, 100);
+      this.syncValues();
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      this.alpha = 0;
+      this.syncValues();
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      this.alpha = 100;
+      this.syncValues();
+    }
+  }
+  handleHueKeyDown(event) {
+    const increment = event.shiftKey ? 10 : 1;
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      this.hue = clamp(this.hue - increment, 0, 360);
+      this.syncValues();
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      this.hue = clamp(this.hue + increment, 0, 360);
+      this.syncValues();
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      this.hue = 0;
+      this.syncValues();
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      this.hue = 360;
+      this.syncValues();
+    }
+  }
+  handleGridKeyDown(event) {
+    const increment = event.shiftKey ? 10 : 1;
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      this.saturation = clamp(this.saturation - increment, 0, 100);
+      this.lightness = this.getLightness(this.brightness);
+      this.syncValues();
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      this.saturation = clamp(this.saturation + increment, 0, 100);
+      this.lightness = this.getLightness(this.brightness);
+      this.syncValues();
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      this.brightness = clamp(this.brightness + increment, 0, 100);
+      this.lightness = this.getLightness(this.brightness);
+      this.syncValues();
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      this.brightness = clamp(this.brightness - increment, 0, 100);
+      this.lightness = this.getLightness(this.brightness);
+      this.syncValues();
+    }
+  }
+  handleInputChange(event) {
+    const target = event.target;
+    if (this.input.value) {
+      this.setColor(target.value);
+      target.value = this.value;
+    } else {
+      this.value = "";
+    }
+    event.stopPropagation();
+  }
+  handleInputKeyDown(event) {
+    if (event.key === "Enter") {
+      if (this.input.value) {
+        this.setColor(this.input.value);
+        this.input.value = this.value;
+        setTimeout(() => this.input.select());
+      } else {
+        this.hue = 0;
+      }
+    }
+  }
+  normalizeColorString(colorString) {
+    if (/rgba?/i.test(colorString)) {
+      const rgba = colorString.replace(/[^\d.%]/g, " ").split(" ").map((val) => val.trim()).filter((val) => val.length);
+      if (rgba.length < 4) {
+        rgba[3] = "1";
+      }
+      if (rgba[3].indexOf("%") > -1) {
+        rgba[3] = (parseFloat(rgba[3].replace(/%/g, "")) / 100).toString();
+      }
+      return `rgba(${rgba[0]}, ${rgba[1]}, ${rgba[2]}, ${rgba[3]})`;
+    }
+    if (/hsla?/i.test(colorString)) {
+      const hsla = colorString.replace(/[^\d.%]/g, " ").split(" ").map((val) => val.trim()).filter((val) => val.length);
+      if (hsla.length < 4) {
+        hsla[3] = "1";
+      }
+      if (hsla[3].indexOf("%") > -1) {
+        hsla[3] = (parseFloat(hsla[3].replace(/%/g, "")) / 100).toString();
+      }
+      return `hsla(${hsla[0]}, ${hsla[1]}, ${hsla[2]}, ${hsla[3]})`;
+    }
+    if (/^[0-9a-f]+$/i.test(colorString)) {
+      return `#${colorString}`;
+    }
+    return colorString;
+  }
+  parseColor(colorString) {
+    let parsed;
+    colorString = this.normalizeColorString(colorString);
+    try {
+      parsed = (0, import_color.default)(colorString);
+    } catch (e2) {
+      return null;
+    }
+    const hslColor = parsed.hsl();
+    const hsl = {
+      h: hslColor.hue(),
+      s: hslColor.saturationl(),
+      l: hslColor.lightness(),
+      a: hslColor.alpha()
+    };
+    const rgbColor = parsed.rgb();
+    const rgb = {
+      r: rgbColor.red(),
+      g: rgbColor.green(),
+      b: rgbColor.blue(),
+      a: rgbColor.alpha()
+    };
+    const hex = {
+      r: toHex(rgb.r),
+      g: toHex(rgb.g),
+      b: toHex(rgb.b),
+      a: toHex(rgb.a * 255)
+    };
+    return {
+      hsl: {
+        h: hsl.h,
+        s: hsl.s,
+        l: hsl.l,
+        string: this.setLetterCase(`hsl(${Math.round(hsl.h)}, ${Math.round(hsl.s)}%, ${Math.round(hsl.l)}%)`)
+      },
+      hsla: {
+        h: hsl.h,
+        s: hsl.s,
+        l: hsl.l,
+        a: hsl.a,
+        string: this.setLetterCase(
+          `hsla(${Math.round(hsl.h)}, ${Math.round(hsl.s)}%, ${Math.round(hsl.l)}%, ${hsl.a.toFixed(2).toString()})`
+        )
+      },
+      rgb: {
+        r: rgb.r,
+        g: rgb.g,
+        b: rgb.b,
+        string: this.setLetterCase(`rgb(${Math.round(rgb.r)}, ${Math.round(rgb.g)}, ${Math.round(rgb.b)})`)
+      },
+      rgba: {
+        r: rgb.r,
+        g: rgb.g,
+        b: rgb.b,
+        a: rgb.a,
+        string: this.setLetterCase(
+          `rgba(${Math.round(rgb.r)}, ${Math.round(rgb.g)}, ${Math.round(rgb.b)}, ${rgb.a.toFixed(2).toString()})`
+        )
+      },
+      hex: this.setLetterCase(`#${hex.r}${hex.g}${hex.b}`),
+      hexa: this.setLetterCase(`#${hex.r}${hex.g}${hex.b}${hex.a}`)
+    };
+  }
+  setColor(colorString) {
+    const newColor = this.parseColor(colorString);
+    if (newColor === null) {
+      return false;
+    }
+    this.hue = newColor.hsla.h;
+    this.saturation = newColor.hsla.s;
+    this.lightness = newColor.hsla.l;
+    this.brightness = this.getBrightness(newColor.hsla.l);
+    this.alpha = this.opacity ? newColor.hsla.a * 100 : 100;
+    this.syncValues();
+    return true;
+  }
+  setLetterCase(string) {
+    if (typeof string !== "string") {
+      return "";
+    }
+    return this.uppercase ? string.toUpperCase() : string.toLowerCase();
+  }
+  async syncValues() {
+    const currentColor = this.parseColor(
+      `hsla(${this.hue}, ${this.saturation}%, ${this.lightness}%, ${this.alpha / 100})`
+    );
+    if (currentColor === null) {
+      return;
+    }
+    if (this.format === "hsl") {
+      this.inputValue = this.opacity ? currentColor.hsla.string : currentColor.hsl.string;
+    } else if (this.format === "rgb") {
+      this.inputValue = this.opacity ? currentColor.rgba.string : currentColor.rgb.string;
+    } else {
+      this.inputValue = this.opacity ? currentColor.hexa : currentColor.hex;
+    }
+    this.isSafeValue = true;
+    this.value = this.inputValue;
+    await this.updateComplete;
+    this.isSafeValue = false;
+  }
+  handleAfterHide() {
+    this.previewButton.classList.remove("color-picker__preview-color--copied");
+  }
+  handleEyeDropper() {
+    if (!hasEyeDropper) {
+      return;
+    }
+    const eyeDropper = new EyeDropper();
+    eyeDropper.open().then((colorSelectionResult) => this.setColor(colorSelectionResult.sRGBHex)).catch(() => {
+    });
+  }
+  handleFormatChange() {
+    this.syncValues();
+  }
+  handleOpacityChange() {
+    this.alpha = 100;
+  }
+  handleValueChange(oldValue, newValue) {
+    this.isEmpty = !newValue;
+    if (!newValue) {
+      this.hue = 0;
+      this.saturation = 100;
+      this.brightness = 100;
+      this.lightness = this.getLightness(this.brightness);
+      this.alpha = 100;
+    }
+    if (!this.isSafeValue && oldValue !== void 0) {
+      const newColor = this.parseColor(newValue);
+      if (newColor !== null) {
+        this.inputValue = this.value;
+        this.hue = newColor.hsla.h;
+        this.saturation = newColor.hsla.s;
+        this.lightness = newColor.hsla.l;
+        this.brightness = this.getBrightness(newColor.hsla.l);
+        this.alpha = newColor.hsla.a * 100;
+      } else {
+        this.inputValue = oldValue;
+      }
+    }
+    if (this.value !== this.lastValueEmitted) {
+      this.emit("sl-change");
+      this.lastValueEmitted = this.value;
+    }
+  }
+  render() {
+    const gridHandleX = this.saturation;
+    const gridHandleY = 100 - this.brightness;
+    const colorPicker = $`
+      <div
+        part="base"
+        class=${o$3({
+      "color-picker": true,
+      "color-picker--inline": this.inline,
+      "color-picker--disabled": this.disabled
+    })}
+        aria-disabled=${this.disabled ? "true" : "false"}
+        aria-labelledby="label"
+        tabindex=${this.inline ? "0" : "-1"}
+      >
+        ${this.inline ? $`
+              <sl-visually-hidden id="label">
+                <slot name="label">${this.label}</slot>
+              </sl-visually-hidden>
+            ` : null}
+
+        <div
+          part="grid"
+          class="color-picker__grid"
+          style=${i2$1({ backgroundColor: `hsl(${this.hue}deg, 100%, 50%)` })}
+          @mousedown=${this.handleGridDrag}
+          @touchstart=${this.handleGridDrag}
+        >
+          <span
+            part="grid-handle"
+            class=${o$3({
+      "color-picker__grid-handle": true,
+      "color-picker__grid-handle--dragging": this.isDraggingGridHandle
+    })}
+            style=${i2$1({
+      top: `${gridHandleY}%`,
+      left: `${gridHandleX}%`,
+      backgroundColor: `hsla(${this.hue}deg, ${this.saturation}%, ${this.lightness}%)`
+    })}
+            role="application"
+            aria-label="HSL"
+            tabindex=${l$2(this.disabled ? void 0 : "0")}
+            @keydown=${this.handleGridKeyDown}
+          ></span>
+        </div>
+
+        <div class="color-picker__controls">
+          <div class="color-picker__sliders">
+            <div
+              part="slider hue-slider"
+              class="color-picker__hue color-picker__slider"
+              @mousedown=${this.handleHueDrag}
+              @touchstart=${this.handleHueDrag}
+            >
+              <span
+                part="slider-handle"
+                class="color-picker__slider-handle"
+                style=${i2$1({
+      left: `${this.hue === 0 ? 0 : 100 / (360 / this.hue)}%`
+    })}
+                role="slider"
+                aria-label="hue"
+                aria-orientation="horizontal"
+                aria-valuemin="0"
+                aria-valuemax="360"
+                aria-valuenow=${`${Math.round(this.hue)}`}
+                tabindex=${l$2(this.disabled ? void 0 : "0")}
+                @keydown=${this.handleHueKeyDown}
+              ></span>
+            </div>
+
+            ${this.opacity ? $`
+                  <div
+                    part="slider opacity-slider"
+                    class="color-picker__alpha color-picker__slider color-picker__transparent-bg"
+                    @mousedown="${this.handleAlphaDrag}"
+                    @touchstart="${this.handleAlphaDrag}"
+                  >
+                    <div
+                      class="color-picker__alpha-gradient"
+                      style=${i2$1({
+      backgroundImage: `linear-gradient(
+                          to right,
+                          hsl(${this.hue}deg, ${this.saturation}%, ${this.lightness}%, 0%) 0%,
+                          hsl(${this.hue}deg, ${this.saturation}%, ${this.lightness}%) 100%
+                        )`
+    })}
+                    ></div>
+                    <span
+                      part="slider-handle"
+                      class="color-picker__slider-handle"
+                      style=${i2$1({
+      left: `${this.alpha}%`
+    })}
+                      role="slider"
+                      aria-label="alpha"
+                      aria-orientation="horizontal"
+                      aria-valuemin="0"
+                      aria-valuemax="100"
+                      aria-valuenow=${Math.round(this.alpha)}
+                      tabindex=${l$2(this.disabled ? void 0 : "0")}
+                      @keydown=${this.handleAlphaKeyDown}
+                    ></span>
+                  </div>
+                ` : ""}
+          </div>
+
+          <button
+            type="button"
+            part="preview"
+            class="color-picker__preview color-picker__transparent-bg"
+            aria-label=${this.localize.term("copy")}
+            style=${i2$1({
+      "--preview-color": `hsla(${this.hue}deg, ${this.saturation}%, ${this.lightness}%, ${this.alpha / 100})`
+    })}
+            @click=${this.handleCopy}
+          ></button>
+        </div>
+
+        <div class="color-picker__user-input" aria-live="polite">
+          <sl-input
+            part="input"
+            type="text"
+            name=${this.name}
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            .value=${l$3(this.isEmpty ? "" : this.inputValue)}
+            ?disabled=${this.disabled}
+            aria-label=${this.localize.term("currentValue")}
+            @keydown=${this.handleInputKeyDown}
+            @sl-change=${this.handleInputChange}
+          ></sl-input>
+
+          <sl-button-group>
+            ${!this.noFormatToggle ? $`
+                  <sl-button
+                    part="format-button"
+                    aria-label=${this.localize.term("toggleColorFormat")}
+                    exportparts="
+                      base:format-button__base,
+                      prefix:format-button__prefix,
+                      label:format-button__label,
+                      suffix:format-button__suffix,
+                      caret:format-button__caret
+                    "
+                    @click=${this.handleFormatToggle}
+                  >
+                    ${this.setLetterCase(this.format)}
+                  </sl-button>
+                ` : ""}
+            ${hasEyeDropper ? $`
+                  <sl-button
+                    part="eye-dropper-button"
+                    exportparts="
+                      base:eye-dropper-button__base,
+                      prefix:eye-dropper-button__prefix,
+                      label:eye-dropper-button__label,
+                      suffix:eye-dropper-button__suffix,
+                      caret:eye-dropper-button__caret
+                    "
+                    @click=${this.handleEyeDropper}
+                  >
+                    <sl-icon
+                      library="system"
+                      name="eyedropper"
+                      label=${this.localize.term("selectAColorFromTheScreen")}
+                    ></sl-icon>
+                  </sl-button>
+                ` : ""}
+          </sl-button-group>
+        </div>
+
+        ${this.swatches.length > 0 ? $`
+              <div part="swatches" class="color-picker__swatches">
+                ${this.swatches.map((swatch) => {
+      return $`
+                    <div
+                      part="swatch"
+                      class="color-picker__swatch color-picker__transparent-bg"
+                      tabindex=${l$2(this.disabled ? void 0 : "0")}
+                      role="button"
+                      aria-label=${swatch}
+                      @click=${() => !this.disabled && this.setColor(swatch)}
+                      @keydown=${(event) => !this.disabled && event.key === "Enter" && this.setColor(swatch)}
+                    >
+                      <div class="color-picker__swatch-color" style=${i2$1({ backgroundColor: swatch })}></div>
+                    </div>
+                  `;
+    })}
+              </div>
+            ` : ""}
+      </div>
+    `;
+    if (this.inline) {
+      return colorPicker;
+    }
+    return $`
+      <sl-dropdown
+        class="color-dropdown"
+        aria-disabled=${this.disabled ? "true" : "false"}
+        .containing-element=${this}
+        ?disabled=${this.disabled}
+        ?hoist=${this.hoist}
+        @sl-after-hide=${this.handleAfterHide}
+      >
+        <button
+          part="trigger"
+          slot="trigger"
+          class=${o$3({
+      "color-dropdown__trigger": true,
+      "color-dropdown__trigger--disabled": this.disabled,
+      "color-dropdown__trigger--small": this.size === "small",
+      "color-dropdown__trigger--medium": this.size === "medium",
+      "color-dropdown__trigger--large": this.size === "large",
+      "color-dropdown__trigger--empty": this.isEmpty,
+      "color-picker__transparent-bg": true
+    })}
+          style=${i2$1({
+      color: `hsla(${this.hue}deg, ${this.saturation}%, ${this.lightness}%, ${this.alpha / 100})`
+    })}
+          type="button"
+        >
+          <sl-visually-hidden>
+            <slot name="label">${this.label}</slot>
+          </sl-visually-hidden>
+        </button>
+        ${colorPicker}
+      </sl-dropdown>
+    `;
+  }
+};
+SlColorPicker.styles = color_picker_styles_default;
+__decorateClass([
+  i2$2('[part="input"]')
+], SlColorPicker.prototype, "input", 2);
+__decorateClass([
+  i2$2('[part="preview"]')
+], SlColorPicker.prototype, "previewButton", 2);
+__decorateClass([
+  i2$2(".color-dropdown")
+], SlColorPicker.prototype, "dropdown", 2);
+__decorateClass([
+  t$1()
+], SlColorPicker.prototype, "isDraggingGridHandle", 2);
+__decorateClass([
+  t$1()
+], SlColorPicker.prototype, "isEmpty", 2);
+__decorateClass([
+  t$1()
+], SlColorPicker.prototype, "inputValue", 2);
+__decorateClass([
+  t$1()
+], SlColorPicker.prototype, "hue", 2);
+__decorateClass([
+  t$1()
+], SlColorPicker.prototype, "saturation", 2);
+__decorateClass([
+  t$1()
+], SlColorPicker.prototype, "lightness", 2);
+__decorateClass([
+  t$1()
+], SlColorPicker.prototype, "brightness", 2);
+__decorateClass([
+  t$1()
+], SlColorPicker.prototype, "alpha", 2);
+__decorateClass([
+  e$1()
+], SlColorPicker.prototype, "value", 2);
+__decorateClass([
+  defaultValue()
+], SlColorPicker.prototype, "defaultValue", 2);
+__decorateClass([
+  e$1()
+], SlColorPicker.prototype, "label", 2);
+__decorateClass([
+  e$1()
+], SlColorPicker.prototype, "format", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlColorPicker.prototype, "inline", 2);
+__decorateClass([
+  e$1()
+], SlColorPicker.prototype, "size", 2);
+__decorateClass([
+  e$1({ attribute: "no-format-toggle", type: Boolean })
+], SlColorPicker.prototype, "noFormatToggle", 2);
+__decorateClass([
+  e$1()
+], SlColorPicker.prototype, "name", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlColorPicker.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlColorPicker.prototype, "invalid", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlColorPicker.prototype, "hoist", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlColorPicker.prototype, "opacity", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlColorPicker.prototype, "uppercase", 2);
+__decorateClass([
+  e$1({ attribute: false })
+], SlColorPicker.prototype, "swatches", 2);
+__decorateClass([
+  watch("format", { waitUntilFirstUpdate: true })
+], SlColorPicker.prototype, "handleFormatChange", 1);
+__decorateClass([
+  watch("opacity", { waitUntilFirstUpdate: true })
+], SlColorPicker.prototype, "handleOpacityChange", 1);
+__decorateClass([
+  watch("value")
+], SlColorPicker.prototype, "handleValueChange", 1);
+SlColorPicker = __decorateClass([
+  n$1("sl-color-picker")
+], SlColorPicker);
+function toHex(value) {
+  const hex = Math.round(value).toString(16);
+  return hex.length === 1 ? `0${hex}` : hex;
+}
+
+// src/components/visually-hidden/visually-hidden.styles.ts
+var visually_hidden_styles_default = r$2`
+  ${component_styles_default}
+
+  :host(:not(:focus-within)) {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    clip: rect(0 0 0 0) !important;
+    clip-path: inset(50%) !important;
+    border: none !important;
+    overflow: hidden !important;
+    white-space: nowrap !important;
+    padding: 0 !important;
+  }
+`;
+
+// src/components/visually-hidden/visually-hidden.ts
+var SlVisuallyHidden = class extends ShoelaceElement {
+  render() {
+    return $` <slot></slot> `;
+  }
+};
+SlVisuallyHidden.styles = visually_hidden_styles_default;
+SlVisuallyHidden = __decorateClass([
+  n$1("sl-visually-hidden")
+], SlVisuallyHidden);
+
+// src/components/input/input.styles.ts
+var input_styles_default = r$2`
+  ${component_styles_default}
+  ${form_control_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .input {
+    flex: 1 1 auto;
+    display: inline-flex;
+    align-items: stretch;
+    justify-content: start;
+    position: relative;
+    width: 100%;
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-input-font-weight);
+    letter-spacing: var(--sl-input-letter-spacing);
+    vertical-align: middle;
+    overflow: hidden;
+    cursor: text;
+    transition: var(--sl-transition-fast) color, var(--sl-transition-fast) border, var(--sl-transition-fast) box-shadow,
+      var(--sl-transition-fast) background-color;
+  }
+
+  /* Standard inputs */
+  .input--standard {
+    background-color: var(--sl-input-background-color);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+  }
+
+  .input--standard:hover:not(.input--disabled) {
+    background-color: var(--sl-input-background-color-hover);
+    border-color: var(--sl-input-border-color-hover);
+  }
+
+  .input--standard.input--focused:not(.input--disabled) {
+    background-color: var(--sl-input-background-color-focus);
+    border-color: var(--sl-input-border-color-focus);
+    box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-input-focus-ring-color);
+  }
+
+  .input--standard.input--focused:not(.input--disabled) .input__control {
+    color: var(--sl-input-color-focus);
+  }
+
+  .input--standard.input--disabled {
+    background-color: var(--sl-input-background-color-disabled);
+    border-color: var(--sl-input-border-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .input--standard.input--disabled .input__control {
+    color: var(--sl-input-color-disabled);
+  }
+
+  .input--standard.input--disabled .input__control::placeholder {
+    color: var(--sl-input-placeholder-color-disabled);
+  }
+
+  /* Filled inputs */
+  .input--filled {
+    border: none;
+    background-color: var(--sl-input-filled-background-color);
+    color: var(--sl-input-color);
+  }
+
+  .input--filled:hover:not(.input--disabled) {
+    background-color: var(--sl-input-filled-background-color-hover);
+  }
+
+  .input--filled.input--focused:not(.input--disabled) {
+    background-color: var(--sl-input-filled-background-color-focus);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .input--filled.input--disabled {
+    background-color: var(--sl-input-filled-background-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .input__control {
+    flex: 1 1 auto;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    min-width: 0;
+    height: 100%;
+    color: var(--sl-input-color);
+    border: none;
+    background: none;
+    box-shadow: none;
+    padding: 0;
+    margin: 0;
+    cursor: inherit;
+    -webkit-appearance: none;
+  }
+
+  .input__control::-webkit-search-decoration,
+  .input__control::-webkit-search-cancel-button,
+  .input__control::-webkit-search-results-button,
+  .input__control::-webkit-search-results-decoration {
+    -webkit-appearance: none;
+  }
+
+  .input__control:-webkit-autofill,
+  .input__control:-webkit-autofill:hover,
+  .input__control:-webkit-autofill:focus,
+  .input__control:-webkit-autofill:active {
+    box-shadow: 0 0 0 var(--sl-input-height-large) var(--sl-input-background-color-hover) inset !important;
+    -webkit-text-fill-color: var(--sl-color-primary-500);
+    caret-color: var(--sl-input-color);
+  }
+
+  .input--filled .input__control:-webkit-autofill,
+  .input--filled .input__control:-webkit-autofill:hover,
+  .input--filled .input__control:-webkit-autofill:focus,
+  .input--filled .input__control:-webkit-autofill:active {
+    box-shadow: 0 0 0 var(--sl-input-height-large) var(--sl-input-filled-background-color) inset !important;
+  }
+
+  .input__control::placeholder {
+    color: var(--sl-input-placeholder-color);
+    user-select: none;
+  }
+
+  .input:hover:not(.input--disabled) .input__control {
+    color: var(--sl-input-color-hover);
+  }
+
+  .input__control:focus {
+    outline: none;
+  }
+
+  .input__prefix,
+  .input__suffix {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    cursor: default;
+  }
+
+  .input__prefix ::slotted(sl-icon),
+  .input__suffix ::slotted(sl-icon) {
+    color: var(--sl-input-icon-color);
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .input--small {
+    border-radius: var(--sl-input-border-radius-small);
+    font-size: var(--sl-input-font-size-small);
+    height: var(--sl-input-height-small);
+  }
+
+  .input--small .input__control {
+    height: calc(var(--sl-input-height-small) - var(--sl-input-border-width) * 2);
+    padding: 0 var(--sl-input-spacing-small);
+  }
+
+  .input--small .input__clear,
+  .input--small .input__password-toggle {
+    width: calc(1em + var(--sl-input-spacing-small) * 2);
+  }
+
+  .input--small .input__prefix ::slotted(*) {
+    padding-inline-start: var(--sl-input-spacing-small);
+  }
+
+  .input--small .input__suffix ::slotted(*) {
+    padding-inline-end: var(--sl-input-spacing-small);
+  }
+
+  .input--medium {
+    border-radius: var(--sl-input-border-radius-medium);
+    font-size: var(--sl-input-font-size-medium);
+    height: var(--sl-input-height-medium);
+  }
+
+  .input--medium .input__control {
+    height: calc(var(--sl-input-height-medium) - var(--sl-input-border-width) * 2);
+    padding: 0 var(--sl-input-spacing-medium);
+  }
+
+  .input--medium .input__clear,
+  .input--medium .input__password-toggle {
+    width: calc(1em + var(--sl-input-spacing-medium) * 2);
+  }
+
+  .input--medium .input__prefix ::slotted(*) {
+    padding-inline-start: var(--sl-input-spacing-medium);
+  }
+
+  .input--medium .input__suffix ::slotted(*) {
+    padding-inline-end: var(--sl-input-spacing-medium);
+  }
+
+  .input--large {
+    border-radius: var(--sl-input-border-radius-large);
+    font-size: var(--sl-input-font-size-large);
+    height: var(--sl-input-height-large);
+  }
+
+  .input--large .input__control {
+    height: calc(var(--sl-input-height-large) - var(--sl-input-border-width) * 2);
+    padding: 0 var(--sl-input-spacing-large);
+  }
+
+  .input--large .input__clear,
+  .input--large .input__password-toggle {
+    width: calc(1em + var(--sl-input-spacing-large) * 2);
+  }
+
+  .input--large .input__prefix ::slotted(*) {
+    padding-inline-start: var(--sl-input-spacing-large);
+  }
+
+  .input--large .input__suffix ::slotted(*) {
+    padding-inline-end: var(--sl-input-spacing-large);
+  }
+
+  /*
+   * Pill modifier
+   */
+
+  .input--pill.input--small {
+    border-radius: var(--sl-input-height-small);
+  }
+
+  .input--pill.input--medium {
+    border-radius: var(--sl-input-height-medium);
+  }
+
+  .input--pill.input--large {
+    border-radius: var(--sl-input-height-large);
+  }
+
+  /*
+   * Clearable + Password Toggle
+   */
+
+  .input__clear,
+  .input__password-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: inherit;
+    color: var(--sl-input-icon-color);
+    border: none;
+    background: none;
+    padding: 0;
+    transition: var(--sl-transition-fast) color;
+    cursor: pointer;
+  }
+
+  .input__clear:hover,
+  .input__password-toggle:hover {
+    color: var(--sl-input-icon-color-hover);
+  }
+
+  .input__clear:focus,
+  .input__password-toggle:focus {
+    outline: none;
+  }
+
+  .input--empty .input__clear {
+    visibility: hidden;
+  }
+
+  /* Don't show the browser's password toggle in Edge */
+  ::-ms-reveal {
+    display: none;
+  }
+
+  /* Hide Firefox's clear button on date and time inputs */
+  .input--is-firefox input[type='date'],
+  .input--is-firefox input[type='time'] {
+    clip-path: inset(0 2em 0 0);
+  }
+
+  /* Hide the built-in number spinner */
+  .input--no-spin-buttons input[type='number']::-webkit-outer-spin-button,
+  .input--no-spin-buttons input[type='number']::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    display: none;
+  }
+
+  .input--no-spin-buttons input[type='number'] {
+    -moz-appearance: textfield;
+  }
+`;
+
+// src/components/input/input.ts
+var _a;
+var isChromium = (_a = navigator.userAgentData) == null ? void 0 : _a.brands.some((b) => b.brand.includes("Chromium"));
+var isFirefox = isChromium ? false : navigator.userAgent.includes("Firefox");
+var SlInput = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.formSubmitController = new FormSubmitController(this);
+    this.hasSlotController = new HasSlotController(this, "help-text", "label");
+    this.localize = new LocalizeController2(this);
+    this.hasFocus = false;
+    this.type = "text";
+    this.size = "medium";
+    this.value = "";
+    this.defaultValue = "";
+    this.filled = false;
+    this.pill = false;
+    this.label = "";
+    this.helpText = "";
+    this.clearable = false;
+    this.passwordToggle = false;
+    this.passwordVisible = false;
+    this.noSpinButtons = false;
+    this.disabled = false;
+    this.readonly = false;
+    this.required = false;
+    this.invalid = false;
+  }
+  get valueAsDate() {
+    var _a2, _b;
+    return (_b = (_a2 = this.input) == null ? void 0 : _a2.valueAsDate) != null ? _b : null;
+  }
+  set valueAsDate(newValue) {
+    const input = document.createElement("input");
+    input.type = "date";
+    input.valueAsDate = newValue;
+    this.value = input.value;
+  }
+  get valueAsNumber() {
+    var _a2, _b;
+    return (_b = (_a2 = this.input) == null ? void 0 : _a2.valueAsNumber) != null ? _b : parseFloat(this.value);
+  }
+  set valueAsNumber(newValue) {
+    const input = document.createElement("input");
+    input.type = "number";
+    input.valueAsNumber = newValue;
+    this.value = input.value;
+  }
+  firstUpdated() {
+    this.invalid = !this.input.checkValidity();
+  }
+  focus(options) {
+    this.input.focus(options);
+  }
+  blur() {
+    this.input.blur();
+  }
+  select() {
+    this.input.select();
+  }
+  setSelectionRange(selectionStart, selectionEnd, selectionDirection = "none") {
+    this.input.setSelectionRange(selectionStart, selectionEnd, selectionDirection);
+  }
+  setRangeText(replacement, start, end, selectMode = "preserve") {
+    this.input.setRangeText(replacement, start, end, selectMode);
+    if (this.value !== this.input.value) {
+      this.value = this.input.value;
+      this.emit("sl-input");
+      this.emit("sl-change");
+    }
+  }
+  reportValidity() {
+    return this.input.reportValidity();
+  }
+  setCustomValidity(message) {
+    this.input.setCustomValidity(message);
+    this.invalid = !this.input.checkValidity();
+  }
+  handleBlur() {
+    this.hasFocus = false;
+    this.emit("sl-blur");
+  }
+  handleChange() {
+    this.value = this.input.value;
+    this.emit("sl-change");
+  }
+  handleClearClick(event) {
+    this.value = "";
+    this.emit("sl-clear");
+    this.emit("sl-input");
+    this.emit("sl-change");
+    this.input.focus();
+    event.stopPropagation();
+  }
+  handleDisabledChange() {
+    this.input.disabled = this.disabled;
+    this.invalid = !this.input.checkValidity();
+  }
+  handleStepChange() {
+    this.input.step = String(this.step);
+    this.invalid = !this.input.checkValidity();
+  }
+  handleFocus() {
+    this.hasFocus = true;
+    this.emit("sl-focus");
+  }
+  handleInput() {
+    this.value = this.input.value;
+    this.emit("sl-input");
+  }
+  handleInvalid() {
+    this.invalid = true;
+  }
+  handleKeyDown(event) {
+    const hasModifier = event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+    if (event.key === "Enter" && !hasModifier) {
+      setTimeout(() => {
+        if (!event.defaultPrevented) {
+          this.formSubmitController.submit();
+        }
+      });
+    }
+  }
+  handlePasswordToggle() {
+    this.passwordVisible = !this.passwordVisible;
+  }
+  handleValueChange() {
+    this.invalid = !this.input.checkValidity();
+  }
+  render() {
+    const hasLabelSlot = this.hasSlotController.test("label");
+    const hasHelpTextSlot = this.hasSlotController.test("help-text");
+    const hasLabel = this.label ? true : !!hasLabelSlot;
+    const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
+    const hasClearIcon = this.clearable && !this.disabled && !this.readonly && (typeof this.value === "number" || this.value.length > 0);
+    return $`
+      <div
+        part="form-control"
+        class=${o$3({
+      "form-control": true,
+      "form-control--small": this.size === "small",
+      "form-control--medium": this.size === "medium",
+      "form-control--large": this.size === "large",
+      "form-control--has-label": hasLabel,
+      "form-control--has-help-text": hasHelpText
+    })}
+      >
+        <label
+          part="form-control-label"
+          class="form-control__label"
+          for="input"
+          aria-hidden=${hasLabel ? "false" : "true"}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <div
+            part="base"
+            class=${o$3({
+      input: true,
+      "input--small": this.size === "small",
+      "input--medium": this.size === "medium",
+      "input--large": this.size === "large",
+      "input--pill": this.pill,
+      "input--standard": !this.filled,
+      "input--filled": this.filled,
+      "input--disabled": this.disabled,
+      "input--focused": this.hasFocus,
+      "input--empty": !this.value,
+      "input--invalid": this.invalid,
+      "input--no-spin-buttons": this.noSpinButtons,
+      "input--is-firefox": isFirefox
+    })}
+          >
+            <span part="prefix" class="input__prefix">
+              <slot name="prefix"></slot>
+            </span>
+
+            <input
+              part="input"
+              id="input"
+              class="input__control"
+              type=${this.type === "password" && this.passwordVisible ? "text" : this.type}
+              name=${l$2(this.name)}
+              ?disabled=${this.disabled}
+              ?readonly=${this.readonly}
+              ?required=${this.required}
+              placeholder=${l$2(this.placeholder)}
+              minlength=${l$2(this.minlength)}
+              maxlength=${l$2(this.maxlength)}
+              min=${l$2(this.min)}
+              max=${l$2(this.max)}
+              step=${l$2(this.step)}
+              .value=${l$3(this.value)}
+              autocapitalize=${l$2(this.type === "password" ? "off" : this.autocapitalize)}
+              autocomplete=${l$2(this.type === "password" ? "off" : this.autocomplete)}
+              autocorrect=${l$2(this.type === "password" ? "off" : this.autocorrect)}
+              ?autofocus=${this.autofocus}
+              spellcheck=${l$2(this.spellcheck)}
+              pattern=${l$2(this.pattern)}
+              enterkeyhint=${l$2(this.enterkeyhint)}
+              inputmode=${l$2(this.inputmode)}
+              aria-describedby="help-text"
+              aria-invalid=${this.invalid ? "true" : "false"}
+              @change=${this.handleChange}
+              @input=${this.handleInput}
+              @invalid=${this.handleInvalid}
+              @keydown=${this.handleKeyDown}
+              @focus=${this.handleFocus}
+              @blur=${this.handleBlur}
+            />
+
+            ${hasClearIcon ? $`
+                  <button
+                    part="clear-button"
+                    class="input__clear"
+                    type="button"
+                    aria-label=${this.localize.term("clearEntry")}
+                    @click=${this.handleClearClick}
+                    tabindex="-1"
+                  >
+                    <slot name="clear-icon">
+                      <sl-icon name="x-circle-fill" library="system"></sl-icon>
+                    </slot>
+                  </button>
+                ` : ""}
+            ${this.passwordToggle && !this.disabled ? $`
+                  <button
+                    part="password-toggle-button"
+                    class="input__password-toggle"
+                    type="button"
+                    aria-label=${this.localize.term(this.passwordVisible ? "hidePassword" : "showPassword")}
+                    @click=${this.handlePasswordToggle}
+                    tabindex="-1"
+                  >
+                    ${this.passwordVisible ? $`
+                          <slot name="show-password-icon">
+                            <sl-icon name="eye-slash" library="system"></sl-icon>
+                          </slot>
+                        ` : $`
+                          <slot name="hide-password-icon">
+                            <sl-icon name="eye" library="system"></sl-icon>
+                          </slot>
+                        `}
+                  </button>
+                ` : ""}
+
+            <span part="suffix" class="input__suffix">
+              <slot name="suffix"></slot>
+            </span>
+          </div>
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${hasHelpText ? "false" : "true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `;
+  }
+};
+SlInput.styles = input_styles_default;
+__decorateClass([
+  i2$2(".input__control")
+], SlInput.prototype, "input", 2);
+__decorateClass([
+  t$1()
+], SlInput.prototype, "hasFocus", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlInput.prototype, "type", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlInput.prototype, "size", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "name", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "value", 2);
+__decorateClass([
+  defaultValue()
+], SlInput.prototype, "defaultValue", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlInput.prototype, "filled", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlInput.prototype, "pill", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "label", 2);
+__decorateClass([
+  e$1({ attribute: "help-text" })
+], SlInput.prototype, "helpText", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlInput.prototype, "clearable", 2);
+__decorateClass([
+  e$1({ attribute: "password-toggle", type: Boolean })
+], SlInput.prototype, "passwordToggle", 2);
+__decorateClass([
+  e$1({ attribute: "password-visible", type: Boolean })
+], SlInput.prototype, "passwordVisible", 2);
+__decorateClass([
+  e$1({ attribute: "no-spin-buttons", type: Boolean })
+], SlInput.prototype, "noSpinButtons", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "placeholder", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlInput.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlInput.prototype, "readonly", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlInput.prototype, "minlength", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlInput.prototype, "maxlength", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "min", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "max", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "step", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "pattern", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlInput.prototype, "required", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlInput.prototype, "invalid", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "autocapitalize", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "autocorrect", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "autocomplete", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlInput.prototype, "autofocus", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "enterkeyhint", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlInput.prototype, "spellcheck", 2);
+__decorateClass([
+  e$1()
+], SlInput.prototype, "inputmode", 2);
+__decorateClass([
+  watch("disabled", { waitUntilFirstUpdate: true })
+], SlInput.prototype, "handleDisabledChange", 1);
+__decorateClass([
+  watch("step", { waitUntilFirstUpdate: true })
+], SlInput.prototype, "handleStepChange", 1);
+__decorateClass([
+  watch("value", { waitUntilFirstUpdate: true })
+], SlInput.prototype, "handleValueChange", 1);
+SlInput = __decorateClass([
+  n$1("sl-input")
+], SlInput);
+
+// src/components/dropdown/dropdown.styles.ts
+var dropdown_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .dropdown::part(popup) {
+    z-index: var(--sl-z-index-dropdown);
+  }
+
+  .dropdown[data-current-placement^='top']::part(popup) {
+    transform-origin: bottom;
+  }
+
+  .dropdown[data-current-placement^='bottom']::part(popup) {
+    transform-origin: top;
+  }
+
+  .dropdown[data-current-placement^='left']::part(popup) {
+    transform-origin: right;
+  }
+
+  .dropdown[data-current-placement^='right']::part(popup) {
+    transform-origin: left;
+  }
+
+  .dropdown__trigger {
+    display: block;
+  }
+
+  .dropdown__panel {
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+    font-weight: var(--sl-font-weight-normal);
+    color: var(--color);
+    box-shadow: var(--sl-shadow-large);
+    pointer-events: none;
+  }
+
+  .dropdown--open .dropdown__panel {
+    pointer-events: all;
+  }
+
+  /* When users slot a menu, make sure it conforms to the popup's auto-size */
+  ::slotted(sl-menu) {
+    max-width: var(--auto-size-available-width) !important;
+    max-height: var(--auto-size-available-height) !important;
+  }
+`;
+
+// src/components/dropdown/dropdown.ts
+var SlDropdown = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.open = false;
+    this.placement = "bottom-start";
+    this.disabled = false;
+    this.stayOpenOnSelect = false;
+    this.distance = 0;
+    this.skidding = 0;
+    this.hoist = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.handleMenuItemActivate = this.handleMenuItemActivate.bind(this);
+    this.handlePanelSelect = this.handlePanelSelect.bind(this);
+    this.handleDocumentKeyDown = this.handleDocumentKeyDown.bind(this);
+    this.handleDocumentMouseDown = this.handleDocumentMouseDown.bind(this);
+    if (!this.containingElement) {
+      this.containingElement = this;
+    }
+  }
+  firstUpdated() {
+    this.panel.hidden = !this.open;
+    if (this.open) {
+      this.addOpenListeners();
+      this.popup.active = true;
+    }
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeOpenListeners();
+    this.hide();
+  }
+  focusOnTrigger() {
+    const slot = this.trigger.querySelector("slot");
+    const trigger = slot.assignedElements({ flatten: true })[0];
+    if (typeof (trigger == null ? void 0 : trigger.focus) === "function") {
+      trigger.focus();
+    }
+  }
+  getMenu() {
+    const slot = this.panel.querySelector("slot");
+    return slot.assignedElements({ flatten: true }).find((el) => el.tagName.toLowerCase() === "sl-menu");
+  }
+  handleDocumentKeyDown(event) {
+    var _a;
+    if (event.key === "Escape") {
+      this.hide();
+      this.focusOnTrigger();
+      return;
+    }
+    if (event.key === "Tab") {
+      if (this.open && ((_a = document.activeElement) == null ? void 0 : _a.tagName.toLowerCase()) === "sl-menu-item") {
+        event.preventDefault();
+        this.hide();
+        this.focusOnTrigger();
+        return;
+      }
+      setTimeout(() => {
+        var _a2, _b, _c;
+        const activeElement = ((_a2 = this.containingElement) == null ? void 0 : _a2.getRootNode()) instanceof ShadowRoot ? (_c = (_b = document.activeElement) == null ? void 0 : _b.shadowRoot) == null ? void 0 : _c.activeElement : document.activeElement;
+        if (!this.containingElement || (activeElement == null ? void 0 : activeElement.closest(this.containingElement.tagName.toLowerCase())) !== this.containingElement) {
+          this.hide();
+        }
+      });
+    }
+  }
+  handleDocumentMouseDown(event) {
+    const path = event.composedPath();
+    if (this.containingElement && !path.includes(this.containingElement)) {
+      this.hide();
+    }
+  }
+  handleMenuItemActivate(event) {
+    const item = event.target;
+    scrollIntoView(item, this.panel);
+  }
+  handlePanelSelect(event) {
+    const target = event.target;
+    if (!this.stayOpenOnSelect && target.tagName.toLowerCase() === "sl-menu") {
+      this.hide();
+      this.focusOnTrigger();
+    }
+  }
+  handleTriggerClick() {
+    if (this.open) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  }
+  handleTriggerKeyDown(event) {
+    if (event.key === "Escape") {
+      this.focusOnTrigger();
+      this.hide();
+      return;
+    }
+    if ([" ", "Enter"].includes(event.key)) {
+      event.preventDefault();
+      this.handleTriggerClick();
+      return;
+    }
+    const menu = this.getMenu();
+    if (menu) {
+      const menuItems = menu.defaultSlot.assignedElements({ flatten: true });
+      const firstMenuItem = menuItems[0];
+      const lastMenuItem = menuItems[menuItems.length - 1];
+      if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+        event.preventDefault();
+        if (!this.open) {
+          this.show();
+        }
+        if (menuItems.length > 0) {
+          requestAnimationFrame(() => {
+            if (event.key === "ArrowDown" || event.key === "Home") {
+              menu.setCurrentItem(firstMenuItem);
+              firstMenuItem.focus();
+            }
+            if (event.key === "ArrowUp" || event.key === "End") {
+              menu.setCurrentItem(lastMenuItem);
+              lastMenuItem.focus();
+            }
+          });
+        }
+      }
+      const ignoredKeys = ["Tab", "Shift", "Meta", "Ctrl", "Alt"];
+      if (this.open && !ignoredKeys.includes(event.key)) {
+        menu.typeToSelect(event);
+      }
+    }
+  }
+  handleTriggerKeyUp(event) {
+    if (event.key === " ") {
+      event.preventDefault();
+    }
+  }
+  handleTriggerSlotChange() {
+    this.updateAccessibleTrigger();
+  }
+  updateAccessibleTrigger() {
+    const slot = this.trigger.querySelector("slot");
+    const assignedElements = slot.assignedElements({ flatten: true });
+    const accessibleTrigger = assignedElements.find((el) => getTabbableBoundary(el).start);
+    let target;
+    if (accessibleTrigger) {
+      switch (accessibleTrigger.tagName.toLowerCase()) {
+        case "sl-button":
+        case "sl-icon-button":
+          target = accessibleTrigger.button;
+          break;
+        default:
+          target = accessibleTrigger;
+      }
+      target.setAttribute("aria-haspopup", "true");
+      target.setAttribute("aria-expanded", this.open ? "true" : "false");
+    }
+  }
+  async show() {
+    if (this.open) {
+      return void 0;
+    }
+    this.open = true;
+    return waitForEvent(this, "sl-after-show");
+  }
+  async hide() {
+    if (!this.open) {
+      return void 0;
+    }
+    this.open = false;
+    return waitForEvent(this, "sl-after-hide");
+  }
+  reposition() {
+    this.popup.reposition();
+  }
+  addOpenListeners() {
+    this.panel.addEventListener("sl-activate", this.handleMenuItemActivate);
+    this.panel.addEventListener("sl-select", this.handlePanelSelect);
+    document.addEventListener("keydown", this.handleDocumentKeyDown);
+    document.addEventListener("mousedown", this.handleDocumentMouseDown);
+  }
+  removeOpenListeners() {
+    this.panel.removeEventListener("sl-activate", this.handleMenuItemActivate);
+    this.panel.removeEventListener("sl-select", this.handlePanelSelect);
+    document.removeEventListener("keydown", this.handleDocumentKeyDown);
+    document.removeEventListener("mousedown", this.handleDocumentMouseDown);
+  }
+  async handleOpenChange() {
+    if (this.disabled) {
+      this.open = false;
+      return;
+    }
+    this.updateAccessibleTrigger();
+    if (this.open) {
+      this.emit("sl-show");
+      this.addOpenListeners();
+      await stopAnimations(this);
+      this.panel.hidden = false;
+      this.popup.active = true;
+      const { keyframes, options } = getAnimation(this, "dropdown.show", { dir: this.localize.dir() });
+      await animateTo(this.popup.popup, keyframes, options);
+      this.emit("sl-after-show");
+    } else {
+      this.emit("sl-hide");
+      this.removeOpenListeners();
+      await stopAnimations(this);
+      const { keyframes, options } = getAnimation(this, "dropdown.hide", { dir: this.localize.dir() });
+      await animateTo(this.popup.popup, keyframes, options);
+      this.panel.hidden = true;
+      this.popup.active = false;
+      this.emit("sl-after-hide");
+    }
+  }
+  render() {
+    return $`
+      <sl-popup
+        part="base"
+        id="dropdown"
+        placement=${this.placement}
+        distance=${this.distance}
+        skidding=${this.skidding}
+        strategy=${this.hoist ? "fixed" : "absolute"}
+        flip
+        shift
+        auto-size="vertical"
+        auto-size-padding="10"
+        class=${o$3({
+      dropdown: true,
+      "dropdown--open": this.open
+    })}
+      >
+        <span
+          slot="anchor"
+          part="trigger"
+          class="dropdown__trigger"
+          @click=${this.handleTriggerClick}
+          @keydown=${this.handleTriggerKeyDown}
+          @keyup=${this.handleTriggerKeyUp}
+        >
+          <slot name="trigger" @slotchange=${this.handleTriggerSlotChange}></slot>
+        </span>
+
+        <div
+          part="panel"
+          class="dropdown__panel"
+          aria-hidden=${this.open ? "false" : "true"}
+          aria-labelledby="dropdown"
+        >
+          <slot></slot>
+        </div>
+      </sl-popup>
+    `;
+  }
+};
+SlDropdown.styles = dropdown_styles_default;
+__decorateClass([
+  i2$2(".dropdown")
+], SlDropdown.prototype, "popup", 2);
+__decorateClass([
+  i2$2(".dropdown__trigger")
+], SlDropdown.prototype, "trigger", 2);
+__decorateClass([
+  i2$2(".dropdown__panel")
+], SlDropdown.prototype, "panel", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlDropdown.prototype, "open", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlDropdown.prototype, "placement", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlDropdown.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ attribute: "stay-open-on-select", type: Boolean, reflect: true })
+], SlDropdown.prototype, "stayOpenOnSelect", 2);
+__decorateClass([
+  e$1({ attribute: false })
+], SlDropdown.prototype, "containingElement", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlDropdown.prototype, "distance", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlDropdown.prototype, "skidding", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlDropdown.prototype, "hoist", 2);
+__decorateClass([
+  watch("open", { waitUntilFirstUpdate: true })
+], SlDropdown.prototype, "handleOpenChange", 1);
+SlDropdown = __decorateClass([
+  n$1("sl-dropdown")
+], SlDropdown);
+setDefaultAnimation("dropdown.show", {
+  keyframes: [
+    { opacity: 0, transform: "scale(0.9)" },
+    { opacity: 1, transform: "scale(1)" }
+  ],
+  options: { duration: 100, easing: "ease" }
+});
+setDefaultAnimation("dropdown.hide", {
+  keyframes: [
+    { opacity: 1, transform: "scale(1)" },
+    { opacity: 0, transform: "scale(0.9)" }
+  ],
+  options: { duration: 100, easing: "ease" }
+});
+
+// src/components/popup/popup.styles.ts
+var popup_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --arrow-color: var(--sl-color-neutral-1000);
+    --arrow-size: 6px;
+
+    /*
+     * These properties are computed to account for the arrow's dimensions after being rotated 45º. The constant
+     * 0.7071 is derived from sin(45), which is the diagonal size of the arrow's container after rotating.
+     */
+    --arrow-size-diagonal: calc(var(--arrow-size) * 0.7071);
+    --arrow-padding-offset: calc(var(--arrow-size-diagonal) - var(--arrow-size));
+
+    display: contents;
+  }
+
+  .popup {
+    position: absolute;
+    isolation: isolate;
+    max-width: var(--auto-size-available-width, none);
+    max-height: var(--auto-size-available-height, none);
+  }
+
+  .popup--fixed {
+    position: fixed;
+  }
+
+  .popup:not(.popup--active) {
+    display: none;
+  }
+
+  .popup__arrow {
+    position: absolute;
+    width: calc(var(--arrow-size-diagonal) * 2);
+    height: calc(var(--arrow-size-diagonal) * 2);
+    transform: rotate(45deg);
+    background: var(--arrow-color);
+    z-index: -1;
+  }
+`;
+
+// node_modules/@floating-ui/core/dist/floating-ui.core.browser.min.mjs
+function t(t2) {
+  return t2.split("-")[0];
+}
+function e2(t2) {
+  return t2.split("-")[1];
+}
+function n2(e3) {
+  return ["top", "bottom"].includes(t(e3)) ? "x" : "y";
+}
+function r(t2) {
+  return "y" === t2 ? "height" : "width";
+}
+function i2(i4, o4, a3) {
+  let { reference: l3, floating: s3 } = i4;
+  const c3 = l3.x + l3.width / 2 - s3.width / 2, f3 = l3.y + l3.height / 2 - s3.height / 2, u3 = n2(o4), m3 = r(u3), g3 = l3[m3] / 2 - s3[m3] / 2, d3 = "x" === u3;
+  let p3;
+  switch (t(o4)) {
+    case "top":
+      p3 = { x: c3, y: l3.y - s3.height };
+      break;
+    case "bottom":
+      p3 = { x: c3, y: l3.y + l3.height };
+      break;
+    case "right":
+      p3 = { x: l3.x + l3.width, y: f3 };
+      break;
+    case "left":
+      p3 = { x: l3.x - s3.width, y: f3 };
+      break;
+    default:
+      p3 = { x: l3.x, y: l3.y };
+  }
+  switch (e2(o4)) {
+    case "start":
+      p3[u3] -= g3 * (a3 && d3 ? -1 : 1);
+      break;
+    case "end":
+      p3[u3] += g3 * (a3 && d3 ? -1 : 1);
+  }
+  return p3;
+}
+var o2 = async (t2, e3, n4) => {
+  const { placement: r3 = "bottom", strategy: o4 = "absolute", middleware: a3 = [], platform: l3 } = n4, s3 = await (null == l3.isRTL ? void 0 : l3.isRTL(e3));
+  let c3 = await l3.getElementRects({ reference: t2, floating: e3, strategy: o4 }), { x: f3, y: u3 } = i2(c3, r3, s3), m3 = r3, g3 = {}, d3 = 0;
+  for (let n5 = 0; n5 < a3.length; n5++) {
+    const { name: p3, fn: h3 } = a3[n5], { x: y3, y: x3, data: w3, reset: v3 } = await h3({ x: f3, y: u3, initialPlacement: r3, placement: m3, strategy: o4, middlewareData: g3, rects: c3, platform: l3, elements: { reference: t2, floating: e3 } });
+    f3 = null != y3 ? y3 : f3, u3 = null != x3 ? x3 : u3, g3 = __spreadProps(__spreadValues({}, g3), { [p3]: __spreadValues(__spreadValues({}, g3[p3]), w3) }), v3 && d3 <= 50 && (d3++, "object" == typeof v3 && (v3.placement && (m3 = v3.placement), v3.rects && (c3 = true === v3.rects ? await l3.getElementRects({ reference: t2, floating: e3, strategy: o4 }) : v3.rects), { x: f3, y: u3 } = i2(c3, m3, s3)), n5 = -1);
+  }
+  return { x: f3, y: u3, placement: m3, strategy: o4, middlewareData: g3 };
+};
+function a(t2) {
+  return "number" != typeof t2 ? function(t3) {
+    return __spreadValues({ top: 0, right: 0, bottom: 0, left: 0 }, t3);
+  }(t2) : { top: t2, right: t2, bottom: t2, left: t2 };
+}
+function l(t2) {
+  return __spreadProps(__spreadValues({}, t2), { top: t2.y, left: t2.x, right: t2.x + t2.width, bottom: t2.y + t2.height });
+}
+async function s(t2, e3) {
+  var n4;
+  void 0 === e3 && (e3 = {});
+  const { x: r3, y: i4, platform: o4, rects: s3, elements: c3, strategy: f3 } = t2, { boundary: u3 = "clippingAncestors", rootBoundary: m3 = "viewport", elementContext: g3 = "floating", altBoundary: d3 = false, padding: p3 = 0 } = e3, h3 = a(p3), y3 = c3[d3 ? "floating" === g3 ? "reference" : "floating" : g3], x3 = l(await o4.getClippingRect({ element: null == (n4 = await (null == o4.isElement ? void 0 : o4.isElement(y3))) || n4 ? y3 : y3.contextElement || await (null == o4.getDocumentElement ? void 0 : o4.getDocumentElement(c3.floating)), boundary: u3, rootBoundary: m3, strategy: f3 })), w3 = l(o4.convertOffsetParentRelativeRectToViewportRelativeRect ? await o4.convertOffsetParentRelativeRectToViewportRelativeRect({ rect: "floating" === g3 ? __spreadProps(__spreadValues({}, s3.floating), { x: r3, y: i4 }) : s3.reference, offsetParent: await (null == o4.getOffsetParent ? void 0 : o4.getOffsetParent(c3.floating)), strategy: f3 }) : s3[g3]);
+  return { top: x3.top - w3.top + h3.top, bottom: w3.bottom - x3.bottom + h3.bottom, left: x3.left - w3.left + h3.left, right: w3.right - x3.right + h3.right };
+}
+var c = Math.min;
+var f = Math.max;
+function u(t2, e3, n4) {
+  return f(t2, c(e3, n4));
+}
+var m = (t2) => ({ name: "arrow", options: t2, async fn(i4) {
+  const { element: o4, padding: l3 = 0 } = null != t2 ? t2 : {}, { x: s3, y: c3, placement: f3, rects: m3, platform: g3 } = i4;
+  if (null == o4)
+    return {};
+  const d3 = a(l3), p3 = { x: s3, y: c3 }, h3 = n2(f3), y3 = e2(f3), x3 = r(h3), w3 = await g3.getDimensions(o4), v3 = "y" === h3 ? "top" : "left", b3 = "y" === h3 ? "bottom" : "right", R2 = m3.reference[x3] + m3.reference[h3] - p3[h3] - m3.floating[x3], A = p3[h3] - m3.reference[h3], P2 = await (null == g3.getOffsetParent ? void 0 : g3.getOffsetParent(o4));
+  let T3 = P2 ? "y" === h3 ? P2.clientHeight || 0 : P2.clientWidth || 0 : 0;
+  0 === T3 && (T3 = m3.floating[x3]);
+  const O2 = R2 / 2 - A / 2, L3 = d3[v3], D3 = T3 - w3[x3] - d3[b3], k2 = T3 / 2 - w3[x3] / 2 + O2, E3 = u(L3, k2, D3), C2 = ("start" === y3 ? d3[v3] : d3[b3]) > 0 && k2 !== E3 && m3.reference[x3] <= m3.floating[x3];
+  return { [h3]: p3[h3] - (C2 ? k2 < L3 ? L3 - k2 : D3 - k2 : 0), data: { [h3]: E3, centerOffset: k2 - E3 } };
+} });
+var g = { left: "right", right: "left", bottom: "top", top: "bottom" };
+function d(t2) {
+  return t2.replace(/left|right|bottom|top/g, (t3) => g[t3]);
+}
+function p(t2, i4, o4) {
+  void 0 === o4 && (o4 = false);
+  const a3 = e2(t2), l3 = n2(t2), s3 = r(l3);
+  let c3 = "x" === l3 ? a3 === (o4 ? "end" : "start") ? "right" : "left" : "start" === a3 ? "bottom" : "top";
+  return i4.reference[s3] > i4.floating[s3] && (c3 = d(c3)), { main: c3, cross: d(c3) };
+}
+var h = { start: "end", end: "start" };
+function y(t2) {
+  return t2.replace(/start|end/g, (t3) => h[t3]);
+}
+var x = ["top", "right", "bottom", "left"];
+x.reduce((t2, e3) => t2.concat(e3, e3 + "-start", e3 + "-end"), []);
+var b = function(e3) {
+  return void 0 === e3 && (e3 = {}), { name: "flip", options: e3, async fn(n4) {
+    var r3;
+    const { placement: i4, middlewareData: o4, rects: a3, initialPlacement: l3, platform: c3, elements: f3 } = n4, _a = e3, { mainAxis: u3 = true, crossAxis: m3 = true, fallbackPlacements: g3, fallbackStrategy: h3 = "bestFit", flipAlignment: x3 = true } = _a, w3 = __objRest(_a, ["mainAxis", "crossAxis", "fallbackPlacements", "fallbackStrategy", "flipAlignment"]), v3 = t(i4), b3 = g3 || (v3 === l3 || !x3 ? [d(l3)] : function(t2) {
+      const e4 = d(t2);
+      return [y(t2), e4, y(e4)];
+    }(l3)), R2 = [l3, ...b3], A = await s(n4, w3), P2 = [];
+    let T3 = (null == (r3 = o4.flip) ? void 0 : r3.overflows) || [];
+    if (u3 && P2.push(A[v3]), m3) {
+      const { main: t2, cross: e4 } = p(i4, a3, await (null == c3.isRTL ? void 0 : c3.isRTL(f3.floating)));
+      P2.push(A[t2], A[e4]);
+    }
+    if (T3 = [...T3, { placement: i4, overflows: P2 }], !P2.every((t2) => t2 <= 0)) {
+      var O2, L3;
+      const t2 = (null != (O2 = null == (L3 = o4.flip) ? void 0 : L3.index) ? O2 : 0) + 1, e4 = R2[t2];
+      if (e4)
+        return { data: { index: t2, overflows: T3 }, reset: { placement: e4 } };
+      let n5 = "bottom";
+      switch (h3) {
+        case "bestFit": {
+          var D3;
+          const t3 = null == (D3 = T3.map((t4) => [t4, t4.overflows.filter((t5) => t5 > 0).reduce((t5, e5) => t5 + e5, 0)]).sort((t4, e5) => t4[1] - e5[1])[0]) ? void 0 : D3[0].placement;
+          t3 && (n5 = t3);
+          break;
+        }
+        case "initialPlacement":
+          n5 = l3;
+      }
+      if (i4 !== n5)
+        return { reset: { placement: n5 } };
+    }
+    return {};
+  } };
+};
+var T = function(r3) {
+  return void 0 === r3 && (r3 = 0), { name: "offset", options: r3, async fn(i4) {
+    const { x: o4, y: a3 } = i4, l3 = await async function(r4, i5) {
+      const { placement: o5, platform: a4, elements: l4 } = r4, s3 = await (null == a4.isRTL ? void 0 : a4.isRTL(l4.floating)), c3 = t(o5), f3 = e2(o5), u3 = "x" === n2(o5), m3 = ["left", "top"].includes(c3) ? -1 : 1, g3 = s3 && u3 ? -1 : 1, d3 = "function" == typeof i5 ? i5(r4) : i5;
+      let { mainAxis: p3, crossAxis: h3, alignmentAxis: y3 } = "number" == typeof d3 ? { mainAxis: d3, crossAxis: 0, alignmentAxis: null } : __spreadValues({ mainAxis: 0, crossAxis: 0, alignmentAxis: null }, d3);
+      return f3 && "number" == typeof y3 && (h3 = "end" === f3 ? -1 * y3 : y3), u3 ? { x: h3 * g3, y: p3 * m3 } : { x: p3 * m3, y: h3 * g3 };
+    }(i4, r3);
+    return { x: o4 + l3.x, y: a3 + l3.y, data: l3 };
+  } };
+};
+function O(t2) {
+  return "x" === t2 ? "y" : "x";
+}
+var L = function(e3) {
+  return void 0 === e3 && (e3 = {}), { name: "shift", options: e3, async fn(r3) {
+    const { x: i4, y: o4, placement: a3 } = r3, _a = e3, { mainAxis: l3 = true, crossAxis: c3 = false, limiter: f3 = { fn: (t2) => {
+      let { x: e4, y: n4 } = t2;
+      return { x: e4, y: n4 };
+    } } } = _a, m3 = __objRest(_a, ["mainAxis", "crossAxis", "limiter"]), g3 = { x: i4, y: o4 }, d3 = await s(r3, m3), p3 = n2(t(a3)), h3 = O(p3);
+    let y3 = g3[p3], x3 = g3[h3];
+    if (l3) {
+      const t2 = "y" === p3 ? "bottom" : "right";
+      y3 = u(y3 + d3["y" === p3 ? "top" : "left"], y3, y3 - d3[t2]);
+    }
+    if (c3) {
+      const t2 = "y" === h3 ? "bottom" : "right";
+      x3 = u(x3 + d3["y" === h3 ? "top" : "left"], x3, x3 - d3[t2]);
+    }
+    const w3 = f3.fn(__spreadProps(__spreadValues({}, r3), { [p3]: y3, [h3]: x3 }));
+    return __spreadProps(__spreadValues({}, w3), { data: { x: w3.x - i4, y: w3.y - o4 } });
+  } };
+};
+var k = function(n4) {
+  return void 0 === n4 && (n4 = {}), { name: "size", options: n4, async fn(r3) {
+    const { placement: i4, rects: o4, platform: a3, elements: l3 } = r3, _a = n4, { apply: c3 = () => {
+    } } = _a, u3 = __objRest(_a, ["apply"]), m3 = await s(r3, u3), g3 = t(i4), d3 = e2(i4);
+    let p3, h3;
+    "top" === g3 || "bottom" === g3 ? (p3 = g3, h3 = d3 === (await (null == a3.isRTL ? void 0 : a3.isRTL(l3.floating)) ? "start" : "end") ? "left" : "right") : (h3 = g3, p3 = "end" === d3 ? "top" : "bottom");
+    const y3 = f(m3.left, 0), x3 = f(m3.right, 0), w3 = f(m3.top, 0), v3 = f(m3.bottom, 0), b3 = { availableHeight: o4.floating.height - (["left", "right"].includes(i4) ? 2 * (0 !== w3 || 0 !== v3 ? w3 + v3 : f(m3.top, m3.bottom)) : m3[p3]), availableWidth: o4.floating.width - (["top", "bottom"].includes(i4) ? 2 * (0 !== y3 || 0 !== x3 ? y3 + x3 : f(m3.left, m3.right)) : m3[h3]) };
+    await c3(__spreadValues(__spreadValues({}, r3), b3));
+    const R2 = await a3.getDimensions(l3.floating);
+    return o4.floating.width !== R2.width || o4.floating.height !== R2.height ? { reset: { rects: true } } : {};
+  } };
+};
+
+// node_modules/@floating-ui/dom/dist/floating-ui.dom.browser.min.mjs
+function n3(t2) {
+  return t2 && t2.document && t2.location && t2.alert && t2.setInterval;
+}
+function o3(t2) {
+  if (null == t2)
+    return window;
+  if (!n3(t2)) {
+    const e3 = t2.ownerDocument;
+    return e3 && e3.defaultView || window;
+  }
+  return t2;
+}
+function i3(t2) {
+  return o3(t2).getComputedStyle(t2);
+}
+function r2(t2) {
+  return n3(t2) ? "" : t2 ? (t2.nodeName || "").toLowerCase() : "";
+}
+function l2() {
+  const t2 = navigator.userAgentData;
+  return null != t2 && t2.brands ? t2.brands.map((t3) => t3.brand + "/" + t3.version).join(" ") : navigator.userAgent;
+}
+function c2(t2) {
+  return t2 instanceof o3(t2).HTMLElement;
+}
+function f2(t2) {
+  return t2 instanceof o3(t2).Element;
+}
+function s2(t2) {
+  if ("undefined" == typeof ShadowRoot)
+    return false;
+  return t2 instanceof o3(t2).ShadowRoot || t2 instanceof ShadowRoot;
+}
+function u2(t2) {
+  const { overflow: e3, overflowX: n4, overflowY: o4 } = i3(t2);
+  return /auto|scroll|overlay|hidden/.test(e3 + o4 + n4);
+}
+function d2(t2) {
+  return ["table", "td", "th"].includes(r2(t2));
+}
+function h2(t2) {
+  const e3 = /firefox/i.test(l2()), n4 = i3(t2);
+  return "none" !== n4.transform || "none" !== n4.perspective || "paint" === n4.contain || ["transform", "perspective"].includes(n4.willChange) || e3 && "filter" === n4.willChange || e3 && !!n4.filter && "none" !== n4.filter;
+}
+function a2() {
+  return !/^((?!chrome|android).)*safari/i.test(l2());
+}
+var g2 = Math.min;
+var p2 = Math.max;
+var m2 = Math.round;
+function w2(t2, e3, n4) {
+  var i4, r3, l3, s3;
+  void 0 === e3 && (e3 = false), void 0 === n4 && (n4 = false);
+  const u3 = t2.getBoundingClientRect();
+  let d3 = 1, h3 = 1;
+  e3 && c2(t2) && (d3 = t2.offsetWidth > 0 && m2(u3.width) / t2.offsetWidth || 1, h3 = t2.offsetHeight > 0 && m2(u3.height) / t2.offsetHeight || 1);
+  const g3 = f2(t2) ? o3(t2) : window, p3 = !a2() && n4, w3 = (u3.left + (p3 && null != (i4 = null == (r3 = g3.visualViewport) ? void 0 : r3.offsetLeft) ? i4 : 0)) / d3, v3 = (u3.top + (p3 && null != (l3 = null == (s3 = g3.visualViewport) ? void 0 : s3.offsetTop) ? l3 : 0)) / h3, y3 = u3.width / d3, x3 = u3.height / h3;
+  return { width: y3, height: x3, top: v3, right: w3 + y3, bottom: v3 + x3, left: w3, x: w3, y: v3 };
+}
+function v2(t2) {
+  return (e3 = t2, (e3 instanceof o3(e3).Node ? t2.ownerDocument : t2.document) || window.document).documentElement;
+  var e3;
+}
+function y2(t2) {
+  return f2(t2) ? { scrollLeft: t2.scrollLeft, scrollTop: t2.scrollTop } : { scrollLeft: t2.pageXOffset, scrollTop: t2.pageYOffset };
+}
+function x2(t2) {
+  return w2(v2(t2)).left + y2(t2).scrollLeft;
+}
+function b2(t2, e3, n4) {
+  const o4 = c2(e3), i4 = v2(e3), l3 = w2(t2, o4 && function(t3) {
+    const e4 = w2(t3);
+    return m2(e4.width) !== t3.offsetWidth || m2(e4.height) !== t3.offsetHeight;
+  }(e3), "fixed" === n4);
+  let f3 = { scrollLeft: 0, scrollTop: 0 };
+  const s3 = { x: 0, y: 0 };
+  if (o4 || !o4 && "fixed" !== n4)
+    if (("body" !== r2(e3) || u2(i4)) && (f3 = y2(e3)), c2(e3)) {
+      const t3 = w2(e3, true);
+      s3.x = t3.x + e3.clientLeft, s3.y = t3.y + e3.clientTop;
+    } else
+      i4 && (s3.x = x2(i4));
+  return { x: l3.left + f3.scrollLeft - s3.x, y: l3.top + f3.scrollTop - s3.y, width: l3.width, height: l3.height };
+}
+function L2(t2) {
+  return "html" === r2(t2) ? t2 : t2.assignedSlot || t2.parentNode || (s2(t2) ? t2.host : null) || v2(t2);
+}
+function R(t2) {
+  return c2(t2) && "fixed" !== getComputedStyle(t2).position ? t2.offsetParent : null;
+}
+function T2(t2) {
+  const e3 = o3(t2);
+  let n4 = R(t2);
+  for (; n4 && d2(n4) && "static" === getComputedStyle(n4).position; )
+    n4 = R(n4);
+  return n4 && ("html" === r2(n4) || "body" === r2(n4) && "static" === getComputedStyle(n4).position && !h2(n4)) ? e3 : n4 || function(t3) {
+    let e4 = L2(t3);
+    for (s2(e4) && (e4 = e4.host); c2(e4) && !["html", "body"].includes(r2(e4)); ) {
+      if (h2(e4))
+        return e4;
+      e4 = e4.parentNode;
+    }
+    return null;
+  }(t2) || e3;
+}
+function W(t2) {
+  if (c2(t2))
+    return { width: t2.offsetWidth, height: t2.offsetHeight };
+  const e3 = w2(t2);
+  return { width: e3.width, height: e3.height };
+}
+function E2(t2) {
+  const e3 = L2(t2);
+  return ["html", "body", "#document"].includes(r2(e3)) ? t2.ownerDocument.body : c2(e3) && u2(e3) ? e3 : E2(e3);
+}
+function H(t2, e3) {
+  var n4;
+  void 0 === e3 && (e3 = []);
+  const i4 = E2(t2), r3 = i4 === (null == (n4 = t2.ownerDocument) ? void 0 : n4.body), l3 = o3(i4), c3 = r3 ? [l3].concat(l3.visualViewport || [], u2(i4) ? i4 : []) : i4, f3 = e3.concat(c3);
+  return r3 ? f3 : f3.concat(H(c3));
+}
+function C(e3, n4, r3) {
+  return "viewport" === n4 ? l(function(t2, e4) {
+    const n5 = o3(t2), i4 = v2(t2), r4 = n5.visualViewport;
+    let l3 = i4.clientWidth, c3 = i4.clientHeight, f3 = 0, s3 = 0;
+    if (r4) {
+      l3 = r4.width, c3 = r4.height;
+      const t3 = a2();
+      (t3 || !t3 && "fixed" === e4) && (f3 = r4.offsetLeft, s3 = r4.offsetTop);
+    }
+    return { width: l3, height: c3, x: f3, y: s3 };
+  }(e3, r3)) : f2(n4) ? function(t2, e4) {
+    const n5 = w2(t2, false, "fixed" === e4), o4 = n5.top + t2.clientTop, i4 = n5.left + t2.clientLeft;
+    return { top: o4, left: i4, x: i4, y: o4, right: i4 + t2.clientWidth, bottom: o4 + t2.clientHeight, width: t2.clientWidth, height: t2.clientHeight };
+  }(n4, r3) : l(function(t2) {
+    var e4;
+    const n5 = v2(t2), o4 = y2(t2), r4 = null == (e4 = t2.ownerDocument) ? void 0 : e4.body, l3 = p2(n5.scrollWidth, n5.clientWidth, r4 ? r4.scrollWidth : 0, r4 ? r4.clientWidth : 0), c3 = p2(n5.scrollHeight, n5.clientHeight, r4 ? r4.scrollHeight : 0, r4 ? r4.clientHeight : 0);
+    let f3 = -o4.scrollLeft + x2(t2);
+    const s3 = -o4.scrollTop;
+    return "rtl" === i3(r4 || n5).direction && (f3 += p2(n5.clientWidth, r4 ? r4.clientWidth : 0) - l3), { width: l3, height: c3, x: f3, y: s3 };
+  }(v2(e3)));
+}
+function S(t2) {
+  const e3 = H(t2), n4 = ["absolute", "fixed"].includes(i3(t2).position) && c2(t2) ? T2(t2) : t2;
+  return f2(n4) ? e3.filter((t3) => f2(t3) && function(t4, e4) {
+    const n5 = null == e4.getRootNode ? void 0 : e4.getRootNode();
+    if (t4.contains(e4))
+      return true;
+    if (n5 && s2(n5)) {
+      let n6 = e4;
+      do {
+        if (n6 && t4 === n6)
+          return true;
+        n6 = n6.parentNode || n6.host;
+      } while (n6);
+    }
+    return false;
+  }(t3, n4) && "body" !== r2(t3)) : [];
+}
+var D2 = { getClippingRect: function(t2) {
+  let { element: e3, boundary: n4, rootBoundary: o4, strategy: i4 } = t2;
+  const r3 = [..."clippingAncestors" === n4 ? S(e3) : [].concat(n4), o4], l3 = r3[0], c3 = r3.reduce((t3, n5) => {
+    const o5 = C(e3, n5, i4);
+    return t3.top = p2(o5.top, t3.top), t3.right = g2(o5.right, t3.right), t3.bottom = g2(o5.bottom, t3.bottom), t3.left = p2(o5.left, t3.left), t3;
+  }, C(e3, l3, i4));
+  return { width: c3.right - c3.left, height: c3.bottom - c3.top, x: c3.left, y: c3.top };
+}, convertOffsetParentRelativeRectToViewportRelativeRect: function(t2) {
+  let { rect: e3, offsetParent: n4, strategy: o4 } = t2;
+  const i4 = c2(n4), l3 = v2(n4);
+  if (n4 === l3)
+    return e3;
+  let f3 = { scrollLeft: 0, scrollTop: 0 };
+  const s3 = { x: 0, y: 0 };
+  if ((i4 || !i4 && "fixed" !== o4) && (("body" !== r2(n4) || u2(l3)) && (f3 = y2(n4)), c2(n4))) {
+    const t3 = w2(n4, true);
+    s3.x = t3.x + n4.clientLeft, s3.y = t3.y + n4.clientTop;
+  }
+  return __spreadProps(__spreadValues({}, e3), { x: e3.x - f3.scrollLeft + s3.x, y: e3.y - f3.scrollTop + s3.y });
+}, isElement: f2, getDimensions: W, getOffsetParent: T2, getDocumentElement: v2, getElementRects: (t2) => {
+  let { reference: e3, floating: n4, strategy: o4 } = t2;
+  return { reference: b2(e3, T2(n4), o4), floating: __spreadProps(__spreadValues({}, W(n4)), { x: 0, y: 0 }) };
+}, getClientRects: (t2) => Array.from(t2.getClientRects()), isRTL: (t2) => "rtl" === i3(t2).direction };
+function N(t2, e3, n4, o4) {
+  void 0 === o4 && (o4 = {});
+  const { ancestorScroll: i4 = true, ancestorResize: r3 = true, elementResize: l3 = true, animationFrame: c3 = false } = o4, s3 = i4 && !c3, u3 = r3 && !c3, d3 = s3 || u3 ? [...f2(t2) ? H(t2) : [], ...H(e3)] : [];
+  d3.forEach((t3) => {
+    s3 && t3.addEventListener("scroll", n4, { passive: true }), u3 && t3.addEventListener("resize", n4);
+  });
+  let h3, a3 = null;
+  if (l3) {
+    let o5 = true;
+    a3 = new ResizeObserver(() => {
+      o5 || n4(), o5 = false;
+    }), f2(t2) && !c3 && a3.observe(t2), a3.observe(e3);
+  }
+  let g3 = c3 ? w2(t2) : null;
+  return c3 && function e4() {
+    const o5 = w2(t2);
+    !g3 || o5.x === g3.x && o5.y === g3.y && o5.width === g3.width && o5.height === g3.height || n4();
+    g3 = o5, h3 = requestAnimationFrame(e4);
+  }(), n4(), () => {
+    var t3;
+    d3.forEach((t4) => {
+      s3 && t4.removeEventListener("scroll", n4), u3 && t4.removeEventListener("resize", n4);
+    }), null == (t3 = a3) || t3.disconnect(), a3 = null, c3 && cancelAnimationFrame(h3);
+  };
+}
+var z = (t2, n4, o4) => o2(t2, n4, __spreadValues({ platform: D2 }, o4));
+
+// src/components/popup/popup.ts
+var SlPopup = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.active = false;
+    this.placement = "top";
+    this.strategy = "absolute";
+    this.distance = 0;
+    this.skidding = 0;
+    this.arrow = false;
+    this.arrowPlacement = "anchor";
+    this.arrowPadding = 10;
+    this.flip = false;
+    this.flipFallbackPlacements = "";
+    this.flipFallbackStrategy = "initial";
+    this.flipPadding = 0;
+    this.shift = false;
+    this.shiftPadding = 0;
+    this.autoSizePadding = 0;
+  }
+  async connectedCallback() {
+    super.connectedCallback();
+    await this.updateComplete;
+    this.start();
+  }
+  disconnectedCallback() {
+    this.stop();
+  }
+  async handleAnchorChange() {
+    await this.stop();
+    if (this.anchor && typeof this.anchor === "string") {
+      const root = this.getRootNode();
+      this.anchorEl = root.getElementById(this.anchor);
+    } else if (this.anchor instanceof HTMLElement) {
+      this.anchorEl = this.anchor;
+    } else {
+      this.anchorEl = this.querySelector('[slot="anchor"]');
+    }
+    if (this.anchorEl instanceof HTMLSlotElement) {
+      this.anchorEl = this.anchorEl.assignedElements({ flatten: true })[0];
+    }
+    if (!this.anchorEl) {
+      throw new Error(
+        "Invalid anchor element: no anchor could be found using the anchor slot or the anchor attribute."
+      );
+    }
+    this.start();
+  }
+  start() {
+    if (!this.anchorEl) {
+      return;
+    }
+    this.cleanup = N(this.anchorEl, this.popup, () => {
+      this.reposition();
+    });
+  }
+  async stop() {
+    return new Promise((resolve) => {
+      if (this.cleanup) {
+        this.cleanup();
+        this.cleanup = void 0;
+        this.removeAttribute("data-current-placement");
+        this.style.removeProperty("--auto-size-available-width");
+        this.style.removeProperty("--auto-size-available-height");
+        requestAnimationFrame(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+  async updated(changedProps) {
+    super.updated(changedProps);
+    if (changedProps.has("active")) {
+      if (this.active) {
+        this.start();
+      } else {
+        this.stop();
+      }
+    }
+    if (changedProps.has("anchor")) {
+      this.handleAnchorChange();
+    }
+    if (this.active) {
+      await this.updateComplete;
+      this.reposition();
+    }
+  }
+  reposition() {
+    if (!this.active || !this.anchorEl) {
+      return;
+    }
+    const middleware = [
+      T({ mainAxis: this.distance, crossAxis: this.skidding })
+    ];
+    if (this.sync) {
+      middleware.push(
+        k({
+          apply: ({ rects }) => {
+            const syncWidth = this.sync === "width" || this.sync === "both";
+            const syncHeight = this.sync === "height" || this.sync === "both";
+            this.popup.style.width = syncWidth ? `${rects.reference.width}px` : "";
+            this.popup.style.height = syncHeight ? `${rects.reference.height}px` : "";
+          }
+        })
+      );
+    } else {
+      this.popup.style.width = "";
+      this.popup.style.height = "";
+    }
+    if (this.flip) {
+      middleware.push(
+        b({
+          boundary: this.flipBoundary,
+          fallbackPlacements: this.flipFallbackPlacements,
+          fallbackStrategy: this.flipFallbackStrategy === "best-fit" ? "bestFit" : "initialPlacement",
+          padding: this.flipPadding
+        })
+      );
+    }
+    if (this.shift) {
+      middleware.push(
+        L({
+          boundary: this.shiftBoundary,
+          padding: this.shiftPadding
+        })
+      );
+    }
+    if (this.autoSize) {
+      middleware.push(
+        k({
+          boundary: this.autoSizeBoundary,
+          padding: this.autoSizePadding,
+          apply: ({ availableWidth, availableHeight }) => {
+            if (this.autoSize === "vertical" || this.autoSize === "both") {
+              this.style.setProperty("--auto-size-available-height", `${availableHeight}px`);
+            } else {
+              this.style.removeProperty("--auto-size-available-height");
+            }
+            if (this.autoSize === "horizontal" || this.autoSize === "both") {
+              this.style.setProperty("--auto-size-available-width", `${availableWidth}px`);
+            } else {
+              this.style.removeProperty("--auto-size-available-width");
+            }
+          }
+        })
+      );
+    } else {
+      this.style.removeProperty("--auto-size-available-width");
+      this.style.removeProperty("--auto-size-available-height");
+    }
+    if (this.arrow) {
+      middleware.push(
+        m({
+          element: this.arrowEl,
+          padding: this.arrowPadding
+        })
+      );
+    }
+    z(this.anchorEl, this.popup, {
+      placement: this.placement,
+      middleware,
+      strategy: this.strategy
+    }).then(({ x: x3, y: y3, middlewareData, placement }) => {
+      const isRtl = getComputedStyle(this).direction === "rtl";
+      const staticSide = { top: "bottom", right: "left", bottom: "top", left: "right" }[placement.split("-")[0]];
+      this.setAttribute("data-current-placement", placement);
+      Object.assign(this.popup.style, {
+        left: `${x3}px`,
+        top: `${y3}px`
+      });
+      if (this.arrow) {
+        const arrowX = middlewareData.arrow.x;
+        const arrowY = middlewareData.arrow.y;
+        let top = "";
+        let right = "";
+        let bottom = "";
+        let left = "";
+        if (this.arrowPlacement === "start") {
+          const value = typeof arrowX === "number" ? `calc(${this.arrowPadding}px - var(--arrow-padding-offset))` : "";
+          top = typeof arrowY === "number" ? `calc(${this.arrowPadding}px - var(--arrow-padding-offset))` : "";
+          right = isRtl ? value : "";
+          left = isRtl ? "" : value;
+        } else if (this.arrowPlacement === "end") {
+          const value = typeof arrowX === "number" ? `calc(${this.arrowPadding}px - var(--arrow-padding-offset))` : "";
+          right = isRtl ? "" : value;
+          left = isRtl ? value : "";
+          bottom = typeof arrowY === "number" ? `calc(${this.arrowPadding}px - var(--arrow-padding-offset))` : "";
+        } else if (this.arrowPlacement === "center") {
+          left = typeof arrowX === "number" ? `calc(50% - var(--arrow-size-diagonal))` : "";
+          top = typeof arrowY === "number" ? `calc(50% - var(--arrow-size-diagonal))` : "";
+        } else {
+          left = typeof arrowX === "number" ? `${arrowX}px` : "";
+          top = typeof arrowY === "number" ? `${arrowY}px` : "";
+        }
+        Object.assign(this.arrowEl.style, {
+          top,
+          right,
+          bottom,
+          left,
+          [staticSide]: "calc(var(--arrow-size-diagonal) * -1)"
+        });
+      }
+    });
+    this.emit("sl-reposition");
+  }
+  render() {
+    return $`
+      <slot name="anchor" @slotchange=${this.handleAnchorChange}></slot>
+
+      <div
+        part="popup"
+        class=${o$3({
+      popup: true,
+      "popup--active": this.active,
+      "popup--fixed": this.strategy === "fixed",
+      "popup--has-arrow": this.arrow
+    })}
+      >
+        <slot></slot>
+        ${this.arrow ? $`<div part="arrow" class="popup__arrow" role="presentation"></div>` : ""}
+      </div>
+    `;
+  }
+};
+SlPopup.styles = popup_styles_default;
+__decorateClass([
+  i2$2(".popup")
+], SlPopup.prototype, "popup", 2);
+__decorateClass([
+  i2$2(".popup__arrow")
+], SlPopup.prototype, "arrowEl", 2);
+__decorateClass([
+  e$1()
+], SlPopup.prototype, "anchor", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlPopup.prototype, "active", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlPopup.prototype, "placement", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlPopup.prototype, "strategy", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlPopup.prototype, "distance", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlPopup.prototype, "skidding", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlPopup.prototype, "arrow", 2);
+__decorateClass([
+  e$1({ attribute: "arrow-placement" })
+], SlPopup.prototype, "arrowPlacement", 2);
+__decorateClass([
+  e$1({ attribute: "arrow-padding", type: Number })
+], SlPopup.prototype, "arrowPadding", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlPopup.prototype, "flip", 2);
+__decorateClass([
+  e$1({
+    attribute: "flip-fallback-placements",
+    converter: {
+      fromAttribute: (value) => {
+        return value.split(" ").map((p3) => p3.trim()).filter((p3) => p3 !== "");
+      },
+      toAttribute: (value) => {
+        return value.join(" ");
+      }
+    }
+  })
+], SlPopup.prototype, "flipFallbackPlacements", 2);
+__decorateClass([
+  e$1({ attribute: "flip-fallback-strategy" })
+], SlPopup.prototype, "flipFallbackStrategy", 2);
+__decorateClass([
+  e$1({ type: Object })
+], SlPopup.prototype, "flipBoundary", 2);
+__decorateClass([
+  e$1({ attribute: "flip-padding", type: Number })
+], SlPopup.prototype, "flipPadding", 2);
+__decorateClass([
+  e$1({ type: Boolean })
+], SlPopup.prototype, "shift", 2);
+__decorateClass([
+  e$1({ type: Object })
+], SlPopup.prototype, "shiftBoundary", 2);
+__decorateClass([
+  e$1({ attribute: "shift-padding", type: Number })
+], SlPopup.prototype, "shiftPadding", 2);
+__decorateClass([
+  e$1({ attribute: "auto-size" })
+], SlPopup.prototype, "autoSize", 2);
+__decorateClass([
+  e$1()
+], SlPopup.prototype, "sync", 2);
+__decorateClass([
+  e$1({ type: Object })
+], SlPopup.prototype, "autoSizeBoundary", 2);
+__decorateClass([
+  e$1({ attribute: "auto-size-padding", type: Number })
+], SlPopup.prototype, "autoSizePadding", 2);
+SlPopup = __decorateClass([
+  n$1("sl-popup")
+], SlPopup);
+
+// src/components/details/details.styles.ts
+var details_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .details {
+    border: solid 1px var(--sl-color-neutral-200);
+    border-radius: var(--sl-border-radius-medium);
+    background-color: var(--sl-color-neutral-0);
+    overflow-anchor: none;
+  }
+
+  .details--disabled {
+    opacity: 0.5;
+  }
+
+  .details__header {
+    display: flex;
+    align-items: center;
+    border-radius: inherit;
+    padding: var(--sl-spacing-medium);
+    user-select: none;
+    cursor: pointer;
+  }
+
+  .details__header:focus {
+    outline: none;
+  }
+
+  .details__header:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: calc(1px + var(--sl-focus-ring-offset));
+  }
+
+  .details--disabled .details__header {
+    cursor: not-allowed;
+  }
+
+  .details--disabled .details__header:focus-visible {
+    outline: none;
+    box-shadow: none;
+  }
+
+  .details__summary {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .details__summary-icon {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    transition: var(--sl-transition-medium) transform ease;
+  }
+
+  .details--open .details__summary-icon {
+    transform: rotate(90deg);
+  }
+
+  .details__body {
+    overflow: hidden;
+  }
+
+  .details__content {
+    padding: var(--sl-spacing-medium);
+  }
+`;
+
+// src/components/details/details.ts
+var SlDetails = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.open = false;
+    this.disabled = false;
+  }
+  firstUpdated() {
+    this.body.hidden = !this.open;
+    this.body.style.height = this.open ? "auto" : "0";
+  }
+  async show() {
+    if (this.open || this.disabled) {
+      return void 0;
+    }
+    this.open = true;
+    return waitForEvent(this, "sl-after-show");
+  }
+  async hide() {
+    if (!this.open || this.disabled) {
+      return void 0;
+    }
+    this.open = false;
+    return waitForEvent(this, "sl-after-hide");
+  }
+  handleSummaryClick() {
+    if (!this.disabled) {
+      if (this.open) {
+        this.hide();
+      } else {
+        this.show();
+      }
+      this.header.focus();
+    }
+  }
+  handleSummaryKeyDown(event) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      if (this.open) {
+        this.hide();
+      } else {
+        this.show();
+      }
+    }
+    if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+      event.preventDefault();
+      this.hide();
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+      event.preventDefault();
+      this.show();
+    }
+  }
+  async handleOpenChange() {
+    if (this.open) {
+      this.emit("sl-show");
+      await stopAnimations(this.body);
+      this.body.hidden = false;
+      const { keyframes, options } = getAnimation(this, "details.show", { dir: this.localize.dir() });
+      await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
+      this.body.style.height = "auto";
+      this.emit("sl-after-show");
+    } else {
+      this.emit("sl-hide");
+      await stopAnimations(this.body);
+      const { keyframes, options } = getAnimation(this, "details.hide", { dir: this.localize.dir() });
+      await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
+      this.body.hidden = true;
+      this.body.style.height = "auto";
+      this.emit("sl-after-hide");
+    }
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      details: true,
+      "details--open": this.open,
+      "details--disabled": this.disabled
+    })}
+      >
+        <header
+          part="header"
+          id="header"
+          class="details__header"
+          role="button"
+          aria-expanded=${this.open ? "true" : "false"}
+          aria-controls="content"
+          aria-disabled=${this.disabled ? "true" : "false"}
+          tabindex=${this.disabled ? "-1" : "0"}
+          @click=${this.handleSummaryClick}
+          @keydown=${this.handleSummaryKeyDown}
+        >
+          <div part="summary" class="details__summary">
+            <slot name="summary">${this.summary}</slot>
+          </div>
+
+          <span part="summary-icon" class="details__summary-icon">
+            <sl-icon name="chevron-right" library="system"></sl-icon>
+          </span>
+        </header>
+
+        <div class="details__body">
+          <div part="content" id="content" class="details__content" role="region" aria-labelledby="header">
+            <slot></slot>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+};
+SlDetails.styles = details_styles_default;
+__decorateClass([
+  i2$2(".details")
+], SlDetails.prototype, "details", 2);
+__decorateClass([
+  i2$2(".details__header")
+], SlDetails.prototype, "header", 2);
+__decorateClass([
+  i2$2(".details__body")
+], SlDetails.prototype, "body", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlDetails.prototype, "open", 2);
+__decorateClass([
+  e$1()
+], SlDetails.prototype, "summary", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlDetails.prototype, "disabled", 2);
+__decorateClass([
+  watch("open", { waitUntilFirstUpdate: true })
+], SlDetails.prototype, "handleOpenChange", 1);
+SlDetails = __decorateClass([
+  n$1("sl-details")
+], SlDetails);
+setDefaultAnimation("details.show", {
+  keyframes: [
+    { height: "0", opacity: "0" },
+    { height: "auto", opacity: "1" }
+  ],
+  options: { duration: 250, easing: "linear" }
+});
+setDefaultAnimation("details.hide", {
+  keyframes: [
+    { height: "auto", opacity: "1" },
+    { height: "0", opacity: "0" }
+  ],
+  options: { duration: 250, easing: "linear" }
+});
+
+// src/components/dialog/dialog.styles.ts
+var dialog_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --width: 31rem;
+    --header-spacing: var(--sl-spacing-large);
+    --body-spacing: var(--sl-spacing-large);
+    --footer-spacing: var(--sl-spacing-large);
+
+    display: contents;
+  }
+
+  .dialog {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: var(--sl-z-index-dialog);
+  }
+
+  .dialog__panel {
+    display: flex;
+    flex-direction: column;
+    z-index: 2;
+    width: var(--width);
+    max-width: calc(100% - var(--sl-spacing-2x-large));
+    max-height: calc(100% - var(--sl-spacing-2x-large));
+    background-color: var(--sl-panel-background-color);
+    border-radius: var(--sl-border-radius-medium);
+    box-shadow: var(--sl-shadow-x-large);
+  }
+
+  .dialog__panel:focus {
+    outline: none;
+  }
+
+  /* Ensure there's enough vertical padding for phones that don't update vh when chrome appears (e.g. iPhone) */
+  @media screen and (max-width: 420px) {
+    .dialog__panel {
+      max-height: 80vh;
+    }
+  }
+
+  .dialog--open .dialog__panel {
+    display: flex;
+    opacity: 1;
+    transform: none;
+  }
+
+  .dialog__header {
+    flex: 0 0 auto;
+    display: flex;
+  }
+
+  .dialog__title {
+    flex: 1 1 auto;
+    font: inherit;
+    font-size: var(--sl-font-size-large);
+    line-height: var(--sl-line-height-dense);
+    padding: var(--header-spacing);
+    margin: 0;
+  }
+
+  .dialog__close {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    font-size: var(--sl-font-size-x-large);
+    padding: 0 var(--header-spacing);
+  }
+
+  .dialog__body {
+    flex: 1 1 auto;
+    padding: var(--body-spacing);
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .dialog__footer {
+    flex: 0 0 auto;
+    text-align: right;
+    padding: var(--footer-spacing);
+  }
+
+  .dialog__footer ::slotted(sl-button:not(:first-of-type)) {
+    margin-inline-start: var(--sl-spacing-x-small);
+  }
+
+  .dialog:not(.dialog--has-footer) .dialog__footer {
+    display: none;
+  }
+
+  .dialog__overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: var(--sl-overlay-background-color);
+  }
+`;
+
+// src/components/dialog/dialog.ts
+var SlDialog = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.hasSlotController = new HasSlotController(this, "footer");
+    this.localize = new LocalizeController2(this);
+    this.open = false;
+    this.label = "";
+    this.noHeader = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.modal = new Modal(this);
+  }
+  firstUpdated() {
+    this.dialog.hidden = !this.open;
+    if (this.open) {
+      this.modal.activate();
+      lockBodyScrolling(this);
+    }
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    unlockBodyScrolling(this);
+  }
+  async show() {
+    if (this.open) {
+      return void 0;
+    }
+    this.open = true;
+    return waitForEvent(this, "sl-after-show");
+  }
+  async hide() {
+    if (!this.open) {
+      return void 0;
+    }
+    this.open = false;
+    return waitForEvent(this, "sl-after-hide");
+  }
+  requestClose(source) {
+    const slRequestClose = this.emit("sl-request-close", {
+      cancelable: true,
+      detail: { source }
+    });
+    if (slRequestClose.defaultPrevented) {
+      const animation = getAnimation(this, "dialog.denyClose", { dir: this.localize.dir() });
+      animateTo(this.panel, animation.keyframes, animation.options);
+      return;
+    }
+    this.hide();
+  }
+  handleKeyDown(event) {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      this.requestClose("keyboard");
+    }
+  }
+  async handleOpenChange() {
+    if (this.open) {
+      this.emit("sl-show");
+      this.originalTrigger = document.activeElement;
+      this.modal.activate();
+      lockBodyScrolling(this);
+      const autoFocusTarget = this.querySelector("[autofocus]");
+      if (autoFocusTarget) {
+        autoFocusTarget.removeAttribute("autofocus");
+      }
+      await Promise.all([stopAnimations(this.dialog), stopAnimations(this.overlay)]);
+      this.dialog.hidden = false;
+      requestAnimationFrame(() => {
+        const slInitialFocus = this.emit("sl-initial-focus", { cancelable: true });
+        if (!slInitialFocus.defaultPrevented) {
+          if (autoFocusTarget) {
+            autoFocusTarget.focus({ preventScroll: true });
+          } else {
+            this.panel.focus({ preventScroll: true });
+          }
+        }
+        if (autoFocusTarget) {
+          autoFocusTarget.setAttribute("autofocus", "");
+        }
+      });
+      const panelAnimation = getAnimation(this, "dialog.show", { dir: this.localize.dir() });
+      const overlayAnimation = getAnimation(this, "dialog.overlay.show", { dir: this.localize.dir() });
+      await Promise.all([
+        animateTo(this.panel, panelAnimation.keyframes, panelAnimation.options),
+        animateTo(this.overlay, overlayAnimation.keyframes, overlayAnimation.options)
+      ]);
+      this.emit("sl-after-show");
+    } else {
+      this.emit("sl-hide");
+      this.modal.deactivate();
+      await Promise.all([stopAnimations(this.dialog), stopAnimations(this.overlay)]);
+      const panelAnimation = getAnimation(this, "dialog.hide", { dir: this.localize.dir() });
+      const overlayAnimation = getAnimation(this, "dialog.overlay.hide", { dir: this.localize.dir() });
+      await Promise.all([
+        animateTo(this.overlay, overlayAnimation.keyframes, overlayAnimation.options).then(() => {
+          this.overlay.hidden = true;
+        }),
+        animateTo(this.panel, panelAnimation.keyframes, panelAnimation.options).then(() => {
+          this.panel.hidden = true;
+        })
+      ]);
+      this.dialog.hidden = true;
+      this.overlay.hidden = false;
+      this.panel.hidden = false;
+      unlockBodyScrolling(this);
+      const trigger = this.originalTrigger;
+      if (typeof (trigger == null ? void 0 : trigger.focus) === "function") {
+        setTimeout(() => trigger.focus());
+      }
+      this.emit("sl-after-hide");
+    }
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      dialog: true,
+      "dialog--open": this.open,
+      "dialog--has-footer": this.hasSlotController.test("footer")
+    })}
+        @keydown=${this.handleKeyDown}
+      >
+        <div part="overlay" class="dialog__overlay" @click=${() => this.requestClose("overlay")} tabindex="-1"></div>
+
+        <div
+          part="panel"
+          class="dialog__panel"
+          role="dialog"
+          aria-modal="true"
+          aria-hidden=${this.open ? "false" : "true"}
+          aria-label=${l$2(this.noHeader ? this.label : void 0)}
+          aria-labelledby=${l$2(!this.noHeader ? "title" : void 0)}
+          tabindex="0"
+        >
+          ${!this.noHeader ? $`
+                <header part="header" class="dialog__header">
+                  <h2 part="title" class="dialog__title" id="title">
+                    <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(65279)} </slot>
+                  </h2>
+                  <sl-icon-button
+                    part="close-button"
+                    exportparts="base:close-button__base"
+                    class="dialog__close"
+                    name="x"
+                    label=${this.localize.term("close")}
+                    library="system"
+                    @click="${() => this.requestClose("close-button")}"
+                  ></sl-icon-button>
+                </header>
+              ` : ""}
+
+          <div part="body" class="dialog__body">
+            <slot></slot>
+          </div>
+
+          <footer part="footer" class="dialog__footer">
+            <slot name="footer"></slot>
+          </footer>
+        </div>
+      </div>
+    `;
+  }
+};
+SlDialog.styles = dialog_styles_default;
+__decorateClass([
+  i2$2(".dialog")
+], SlDialog.prototype, "dialog", 2);
+__decorateClass([
+  i2$2(".dialog__panel")
+], SlDialog.prototype, "panel", 2);
+__decorateClass([
+  i2$2(".dialog__overlay")
+], SlDialog.prototype, "overlay", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlDialog.prototype, "open", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlDialog.prototype, "label", 2);
+__decorateClass([
+  e$1({ attribute: "no-header", type: Boolean, reflect: true })
+], SlDialog.prototype, "noHeader", 2);
+__decorateClass([
+  watch("open", { waitUntilFirstUpdate: true })
+], SlDialog.prototype, "handleOpenChange", 1);
+SlDialog = __decorateClass([
+  n$1("sl-dialog")
+], SlDialog);
+setDefaultAnimation("dialog.show", {
+  keyframes: [
+    { opacity: 0, transform: "scale(0.8)" },
+    { opacity: 1, transform: "scale(1)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("dialog.hide", {
+  keyframes: [
+    { opacity: 1, transform: "scale(1)" },
+    { opacity: 0, transform: "scale(0.8)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("dialog.denyClose", {
+  keyframes: [{ transform: "scale(1)" }, { transform: "scale(1.02)" }, { transform: "scale(1)" }],
+  options: { duration: 250 }
+});
+setDefaultAnimation("dialog.overlay.show", {
+  keyframes: [{ opacity: 0 }, { opacity: 1 }],
+  options: { duration: 250 }
+});
+setDefaultAnimation("dialog.overlay.hide", {
+  keyframes: [{ opacity: 1 }, { opacity: 0 }],
+  options: { duration: 250 }
+});
+
+// src/components/divider/divider.styles.ts
+var divider_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --color: var(--sl-panel-border-color);
+    --width: var(--sl-panel-border-width);
+    --spacing: var(--sl-spacing-medium);
+  }
+
+  :host(:not([vertical])) {
+    display: block;
+    border-top: solid var(--width) var(--color);
+    margin: var(--spacing) 0;
+  }
+
+  :host([vertical]) {
+    display: inline-block;
+    height: 100%;
+    border-left: solid var(--width) var(--color);
+    margin: 0 var(--spacing);
+  }
+`;
+
+// src/components/divider/divider.ts
+var SlDivider = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.vertical = false;
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute("role", "separator");
+  }
+  handleVerticalChange() {
+    this.setAttribute("aria-orientation", this.vertical ? "vertical" : "horizontal");
+  }
+};
+SlDivider.styles = divider_styles_default;
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlDivider.prototype, "vertical", 2);
+__decorateClass([
+  watch("vertical")
+], SlDivider.prototype, "handleVerticalChange", 1);
+SlDivider = __decorateClass([
+  n$1("sl-divider")
+], SlDivider);
+
+// src/components/button/button.ts
+var SlButton = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.formSubmitController = new FormSubmitController(this, {
+      form: (input) => {
+        if (input.hasAttribute("form")) {
+          const doc = input.getRootNode();
+          const formId = input.getAttribute("form");
+          return doc.getElementById(formId);
+        }
+        return input.closest("form");
+      }
+    });
+    this.hasSlotController = new HasSlotController(this, "[default]", "prefix", "suffix");
+    this.localize = new LocalizeController2(this);
+    this.hasFocus = false;
+    this.variant = "default";
+    this.size = "medium";
+    this.caret = false;
+    this.disabled = false;
+    this.loading = false;
+    this.outline = false;
+    this.pill = false;
+    this.circle = false;
+    this.type = "button";
+  }
+  click() {
+    this.button.click();
+  }
+  focus(options) {
+    this.button.focus(options);
+  }
+  blur() {
+    this.button.blur();
+  }
+  handleBlur() {
+    this.hasFocus = false;
+    this.emit("sl-blur");
+  }
+  handleFocus() {
+    this.hasFocus = true;
+    this.emit("sl-focus");
+  }
+  handleClick(event) {
+    if (this.disabled || this.loading) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    if (this.type === "submit") {
+      this.formSubmitController.submit(this);
+    }
+    if (this.type === "reset") {
+      this.formSubmitController.reset(this);
+    }
+  }
+  render() {
+    const isLink = this.href ? true : false;
+    const tag = isLink ? l$1`a` : l$1`button`;
+    return n`
+      <${tag}
+        part="base"
+        class=${o$3({
+      button: true,
+      "button--default": this.variant === "default",
+      "button--primary": this.variant === "primary",
+      "button--success": this.variant === "success",
+      "button--neutral": this.variant === "neutral",
+      "button--warning": this.variant === "warning",
+      "button--danger": this.variant === "danger",
+      "button--text": this.variant === "text",
+      "button--small": this.size === "small",
+      "button--medium": this.size === "medium",
+      "button--large": this.size === "large",
+      "button--caret": this.caret,
+      "button--circle": this.circle,
+      "button--disabled": this.disabled,
+      "button--focused": this.hasFocus,
+      "button--loading": this.loading,
+      "button--standard": !this.outline,
+      "button--outline": this.outline,
+      "button--pill": this.pill,
+      "button--rtl": this.localize.dir() === "rtl",
+      "button--has-label": this.hasSlotController.test("[default]"),
+      "button--has-prefix": this.hasSlotController.test("prefix"),
+      "button--has-suffix": this.hasSlotController.test("suffix")
+    })}
+        ?disabled=${l$2(isLink ? void 0 : this.disabled)}
+        type=${l$2(isLink ? void 0 : this.type)}
+        name=${l$2(isLink ? void 0 : this.name)}
+        value=${l$2(isLink ? void 0 : this.value)}
+        href=${l$2(isLink ? this.href : void 0)}
+        target=${l$2(isLink ? this.target : void 0)}
+        download=${l$2(isLink ? this.download : void 0)}
+        rel=${l$2(isLink && this.target ? "noreferrer noopener" : void 0)}
+        role=${l$2(isLink ? void 0 : "button")}
+        aria-disabled=${this.disabled ? "true" : "false"}
+        tabindex=${this.disabled ? "-1" : "0"}
+        @blur=${this.handleBlur}
+        @focus=${this.handleFocus}
+        @click=${this.handleClick}
+      >
+        <span part="prefix" class="button__prefix">
+          <slot name="prefix"></slot>
+        </span>
+        <span part="label" class="button__label">
+          <slot></slot>
+        </span>
+        <span part="suffix" class="button__suffix">
+          <slot name="suffix"></slot>
+        </span>
+        ${this.caret ? n`
+                <span part="caret" class="button__caret">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <polyline points="6 9 12 15 18 9"></polyline>
+                  </svg>
+                </span>
+              ` : ""}
+        ${this.loading ? n`<sl-spinner></sl-spinner>` : ""}
+      </${tag}>
+    `;
+  }
+};
+SlButton.styles = button_styles_default;
+__decorateClass([
+  i2$2(".button")
+], SlButton.prototype, "button", 2);
+__decorateClass([
+  t$1()
+], SlButton.prototype, "hasFocus", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlButton.prototype, "variant", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlButton.prototype, "size", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlButton.prototype, "caret", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlButton.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlButton.prototype, "loading", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlButton.prototype, "outline", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlButton.prototype, "pill", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlButton.prototype, "circle", 2);
+__decorateClass([
+  e$1()
+], SlButton.prototype, "type", 2);
+__decorateClass([
+  e$1()
+], SlButton.prototype, "name", 2);
+__decorateClass([
+  e$1()
+], SlButton.prototype, "value", 2);
+__decorateClass([
+  e$1()
+], SlButton.prototype, "href", 2);
+__decorateClass([
+  e$1()
+], SlButton.prototype, "target", 2);
+__decorateClass([
+  e$1()
+], SlButton.prototype, "download", 2);
+__decorateClass([
+  e$1()
+], SlButton.prototype, "form", 2);
+__decorateClass([
+  e$1({ attribute: "formaction" })
+], SlButton.prototype, "formAction", 2);
+__decorateClass([
+  e$1({ attribute: "formmethod" })
+], SlButton.prototype, "formMethod", 2);
+__decorateClass([
+  e$1({ attribute: "formnovalidate", type: Boolean })
+], SlButton.prototype, "formNoValidate", 2);
+__decorateClass([
+  e$1({ attribute: "formtarget" })
+], SlButton.prototype, "formTarget", 2);
+SlButton = __decorateClass([
+  n$1("sl-button")
+], SlButton);
+
+// src/components/spinner/spinner.styles.ts
+var spinner_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --track-width: 2px;
+    --track-color: rgb(128 128 128 / 25%);
+    --indicator-color: var(--sl-color-primary-600);
+    --speed: 2s;
+
+    display: inline-flex;
+    width: 1em;
+    height: 1em;
+  }
+
+  .spinner {
+    flex: 1 1 auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .spinner__track,
+  .spinner__indicator {
+    fill: none;
+    stroke-width: var(--track-width);
+    r: calc(0.5em - var(--track-width) / 2);
+    cx: 0.5em;
+    cy: 0.5em;
+    transform-origin: 50% 50%;
+  }
+
+  .spinner__track {
+    stroke: var(--track-color);
+    transform-origin: 0% 0%;
+    mix-blend-mode: multiply;
+  }
+
+  .spinner__indicator {
+    stroke: var(--indicator-color);
+    stroke-linecap: round;
+    stroke-dasharray: 150% 75%;
+    animation: spin var(--speed) linear infinite;
+  }
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+      stroke-dasharray: 0.01em, 2.75em;
+    }
+
+    50% {
+      transform: rotate(450deg);
+      stroke-dasharray: 1.375em, 1.375em;
+    }
+
+    100% {
+      transform: rotate(1080deg);
+      stroke-dasharray: 0.01em, 2.75em;
+    }
+  }
+`;
+
+// src/components/spinner/spinner.ts
+var SlSpinner = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+  }
+  render() {
+    return $`
+      <svg part="base" class="spinner" role="progressbar" aria-valuetext=${this.localize.term("loading")}>
+        <circle class="spinner__track"></circle>
+        <circle class="spinner__indicator"></circle>
+      </svg>
+    `;
+  }
+};
+SlSpinner.styles = spinner_styles_default;
+SlSpinner = __decorateClass([
+  n$1("sl-spinner")
+], SlSpinner);
+
+// src/components/animation/animation.styles.ts
+var animation_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: contents;
+  }
+`;
+
+// node_modules/@shoelace-style/animations/dist/index.js
+var dist_exports = {};
+__export(dist_exports, {
+  backInDown: () => backInDown,
+  backInLeft: () => backInLeft,
+  backInRight: () => backInRight,
+  backInUp: () => backInUp,
+  backOutDown: () => backOutDown,
+  backOutLeft: () => backOutLeft,
+  backOutRight: () => backOutRight,
+  backOutUp: () => backOutUp,
+  bounce: () => bounce,
+  bounceIn: () => bounceIn,
+  bounceInDown: () => bounceInDown,
+  bounceInLeft: () => bounceInLeft,
+  bounceInRight: () => bounceInRight,
+  bounceInUp: () => bounceInUp,
+  bounceOut: () => bounceOut,
+  bounceOutDown: () => bounceOutDown,
+  bounceOutLeft: () => bounceOutLeft,
+  bounceOutRight: () => bounceOutRight,
+  bounceOutUp: () => bounceOutUp,
+  easings: () => easings,
+  fadeIn: () => fadeIn,
+  fadeInBottomLeft: () => fadeInBottomLeft,
+  fadeInBottomRight: () => fadeInBottomRight,
+  fadeInDown: () => fadeInDown,
+  fadeInDownBig: () => fadeInDownBig,
+  fadeInLeft: () => fadeInLeft,
+  fadeInLeftBig: () => fadeInLeftBig,
+  fadeInRight: () => fadeInRight,
+  fadeInRightBig: () => fadeInRightBig,
+  fadeInTopLeft: () => fadeInTopLeft,
+  fadeInTopRight: () => fadeInTopRight,
+  fadeInUp: () => fadeInUp,
+  fadeInUpBig: () => fadeInUpBig,
+  fadeOut: () => fadeOut,
+  fadeOutBottomLeft: () => fadeOutBottomLeft,
+  fadeOutBottomRight: () => fadeOutBottomRight,
+  fadeOutDown: () => fadeOutDown,
+  fadeOutDownBig: () => fadeOutDownBig,
+  fadeOutLeft: () => fadeOutLeft,
+  fadeOutLeftBig: () => fadeOutLeftBig,
+  fadeOutRight: () => fadeOutRight,
+  fadeOutRightBig: () => fadeOutRightBig,
+  fadeOutTopLeft: () => fadeOutTopLeft,
+  fadeOutTopRight: () => fadeOutTopRight,
+  fadeOutUp: () => fadeOutUp,
+  fadeOutUpBig: () => fadeOutUpBig,
+  flash: () => flash,
+  flip: () => flip,
+  flipInX: () => flipInX,
+  flipInY: () => flipInY,
+  flipOutX: () => flipOutX,
+  flipOutY: () => flipOutY,
+  headShake: () => headShake,
+  heartBeat: () => heartBeat,
+  hinge: () => hinge,
+  jackInTheBox: () => jackInTheBox,
+  jello: () => jello,
+  lightSpeedInLeft: () => lightSpeedInLeft,
+  lightSpeedInRight: () => lightSpeedInRight,
+  lightSpeedOutLeft: () => lightSpeedOutLeft,
+  lightSpeedOutRight: () => lightSpeedOutRight,
+  pulse: () => pulse,
+  rollIn: () => rollIn,
+  rollOut: () => rollOut,
+  rotateIn: () => rotateIn,
+  rotateInDownLeft: () => rotateInDownLeft,
+  rotateInDownRight: () => rotateInDownRight,
+  rotateInUpLeft: () => rotateInUpLeft,
+  rotateInUpRight: () => rotateInUpRight,
+  rotateOut: () => rotateOut,
+  rotateOutDownLeft: () => rotateOutDownLeft,
+  rotateOutDownRight: () => rotateOutDownRight,
+  rotateOutUpLeft: () => rotateOutUpLeft,
+  rotateOutUpRight: () => rotateOutUpRight,
+  rubberBand: () => rubberBand,
+  shake: () => shake,
+  shakeX: () => shakeX,
+  shakeY: () => shakeY,
+  slideInDown: () => slideInDown,
+  slideInLeft: () => slideInLeft,
+  slideInRight: () => slideInRight,
+  slideInUp: () => slideInUp,
+  slideOutDown: () => slideOutDown,
+  slideOutLeft: () => slideOutLeft,
+  slideOutRight: () => slideOutRight,
+  slideOutUp: () => slideOutUp,
+  swing: () => swing,
+  tada: () => tada,
+  wobble: () => wobble,
+  zoomIn: () => zoomIn,
+  zoomInDown: () => zoomInDown,
+  zoomInLeft: () => zoomInLeft,
+  zoomInRight: () => zoomInRight,
+  zoomInUp: () => zoomInUp,
+  zoomOut: () => zoomOut,
+  zoomOutDown: () => zoomOutDown,
+  zoomOutLeft: () => zoomOutLeft,
+  zoomOutRight: () => zoomOutRight,
+  zoomOutUp: () => zoomOutUp
+});
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/bounce.js
+var bounce = [
+  { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)", transform: "translate3d(0, 0, 0)" },
+  { offset: 0.2, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)", transform: "translate3d(0, 0, 0)" },
+  { offset: 0.4, easing: "cubic-bezier(0.755, 0.05, 0.855, 0.06)", transform: "translate3d(0, -30px, 0) scaleY(1.1)" },
+  { offset: 0.43, easing: "cubic-bezier(0.755, 0.05, 0.855, 0.06)", transform: "translate3d(0, -30px, 0) scaleY(1.1)" },
+  { offset: 0.53, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)", transform: "translate3d(0, 0, 0)" },
+  { offset: 0.7, easing: "cubic-bezier(0.755, 0.05, 0.855, 0.06)", transform: "translate3d(0, -15px, 0) scaleY(1.05)" },
+  {
+    offset: 0.8,
+    "transition-timing-function": "cubic-bezier(0.215, 0.61, 0.355, 1)",
+    transform: "translate3d(0, 0, 0) scaleY(0.95)"
+  },
+  { offset: 0.9, transform: "translate3d(0, -4px, 0) scaleY(1.02)" },
+  { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/flash.js
+var flash = [
+  { offset: 0, opacity: "1" },
+  { offset: 0.25, opacity: "0" },
+  { offset: 0.5, opacity: "1" },
+  { offset: 0.75, opacity: "0" },
+  { offset: 1, opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/headShake.js
+var headShake = [
+  { offset: 0, transform: "translateX(0)" },
+  { offset: 0.065, transform: "translateX(-6px) rotateY(-9deg)" },
+  { offset: 0.185, transform: "translateX(5px) rotateY(7deg)" },
+  { offset: 0.315, transform: "translateX(-3px) rotateY(-5deg)" },
+  { offset: 0.435, transform: "translateX(2px) rotateY(3deg)" },
+  { offset: 0.5, transform: "translateX(0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/heartBeat.js
+var heartBeat = [
+  { offset: 0, transform: "scale(1)" },
+  { offset: 0.14, transform: "scale(1.3)" },
+  { offset: 0.28, transform: "scale(1)" },
+  { offset: 0.42, transform: "scale(1.3)" },
+  { offset: 0.7, transform: "scale(1)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/jello.js
+var jello = [
+  { offset: 0, transform: "translate3d(0, 0, 0)" },
+  { offset: 0.111, transform: "translate3d(0, 0, 0)" },
+  { offset: 0.222, transform: "skewX(-12.5deg) skewY(-12.5deg)" },
+  { offset: 0.33299999999999996, transform: "skewX(6.25deg) skewY(6.25deg)" },
+  { offset: 0.444, transform: "skewX(-3.125deg) skewY(-3.125deg)" },
+  { offset: 0.555, transform: "skewX(1.5625deg) skewY(1.5625deg)" },
+  { offset: 0.6659999999999999, transform: "skewX(-0.78125deg) skewY(-0.78125deg)" },
+  { offset: 0.777, transform: "skewX(0.390625deg) skewY(0.390625deg)" },
+  { offset: 0.888, transform: "skewX(-0.1953125deg) skewY(-0.1953125deg)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/pulse.js
+var pulse = [
+  { offset: 0, transform: "scale3d(1, 1, 1)" },
+  { offset: 0.5, transform: "scale3d(1.05, 1.05, 1.05)" },
+  { offset: 1, transform: "scale3d(1, 1, 1)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/rubberBand.js
+var rubberBand = [
+  { offset: 0, transform: "scale3d(1, 1, 1)" },
+  { offset: 0.3, transform: "scale3d(1.25, 0.75, 1)" },
+  { offset: 0.4, transform: "scale3d(0.75, 1.25, 1)" },
+  { offset: 0.5, transform: "scale3d(1.15, 0.85, 1)" },
+  { offset: 0.65, transform: "scale3d(0.95, 1.05, 1)" },
+  { offset: 0.75, transform: "scale3d(1.05, 0.95, 1)" },
+  { offset: 1, transform: "scale3d(1, 1, 1)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/shake.js
+var shake = [
+  { offset: 0, transform: "translate3d(0, 0, 0)" },
+  { offset: 0.1, transform: "translate3d(-10px, 0, 0)" },
+  { offset: 0.2, transform: "translate3d(10px, 0, 0)" },
+  { offset: 0.3, transform: "translate3d(-10px, 0, 0)" },
+  { offset: 0.4, transform: "translate3d(10px, 0, 0)" },
+  { offset: 0.5, transform: "translate3d(-10px, 0, 0)" },
+  { offset: 0.6, transform: "translate3d(10px, 0, 0)" },
+  { offset: 0.7, transform: "translate3d(-10px, 0, 0)" },
+  { offset: 0.8, transform: "translate3d(10px, 0, 0)" },
+  { offset: 0.9, transform: "translate3d(-10px, 0, 0)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/shakeX.js
+var shakeX = [
+  { offset: 0, transform: "translate3d(0, 0, 0)" },
+  { offset: 0.1, transform: "translate3d(-10px, 0, 0)" },
+  { offset: 0.2, transform: "translate3d(10px, 0, 0)" },
+  { offset: 0.3, transform: "translate3d(-10px, 0, 0)" },
+  { offset: 0.4, transform: "translate3d(10px, 0, 0)" },
+  { offset: 0.5, transform: "translate3d(-10px, 0, 0)" },
+  { offset: 0.6, transform: "translate3d(10px, 0, 0)" },
+  { offset: 0.7, transform: "translate3d(-10px, 0, 0)" },
+  { offset: 0.8, transform: "translate3d(10px, 0, 0)" },
+  { offset: 0.9, transform: "translate3d(-10px, 0, 0)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/shakeY.js
+var shakeY = [
+  { offset: 0, transform: "translate3d(0, 0, 0)" },
+  { offset: 0.1, transform: "translate3d(0, -10px, 0)" },
+  { offset: 0.2, transform: "translate3d(0, 10px, 0)" },
+  { offset: 0.3, transform: "translate3d(0, -10px, 0)" },
+  { offset: 0.4, transform: "translate3d(0, 10px, 0)" },
+  { offset: 0.5, transform: "translate3d(0, -10px, 0)" },
+  { offset: 0.6, transform: "translate3d(0, 10px, 0)" },
+  { offset: 0.7, transform: "translate3d(0, -10px, 0)" },
+  { offset: 0.8, transform: "translate3d(0, 10px, 0)" },
+  { offset: 0.9, transform: "translate3d(0, -10px, 0)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/swing.js
+var swing = [
+  { offset: 0.2, transform: "rotate3d(0, 0, 1, 15deg)" },
+  { offset: 0.4, transform: "rotate3d(0, 0, 1, -10deg)" },
+  { offset: 0.6, transform: "rotate3d(0, 0, 1, 5deg)" },
+  { offset: 0.8, transform: "rotate3d(0, 0, 1, -5deg)" },
+  { offset: 1, transform: "rotate3d(0, 0, 1, 0deg)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/tada.js
+var tada = [
+  { offset: 0, transform: "scale3d(1, 1, 1)" },
+  { offset: 0.1, transform: "scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)" },
+  { offset: 0.2, transform: "scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)" },
+  { offset: 0.3, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)" },
+  { offset: 0.4, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)" },
+  { offset: 0.5, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)" },
+  { offset: 0.6, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)" },
+  { offset: 0.7, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)" },
+  { offset: 0.8, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)" },
+  { offset: 0.9, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)" },
+  { offset: 1, transform: "scale3d(1, 1, 1)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/attention_seekers/wobble.js
+var wobble = [
+  { offset: 0, transform: "translate3d(0, 0, 0)" },
+  { offset: 0.15, transform: "translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg)" },
+  { offset: 0.3, transform: "translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg)" },
+  { offset: 0.45, transform: "translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg)" },
+  { offset: 0.6, transform: "translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg)" },
+  { offset: 0.75, transform: "translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/back_entrances/backInDown.js
+var backInDown = [
+  { offset: 0, transform: "translateY(-1200px) scale(0.7)", opacity: "0.7" },
+  { offset: 0.8, transform: "translateY(0px) scale(0.7)", opacity: "0.7" },
+  { offset: 1, transform: "scale(1)", opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/back_entrances/backInLeft.js
+var backInLeft = [
+  { offset: 0, transform: "translateX(-2000px) scale(0.7)", opacity: "0.7" },
+  { offset: 0.8, transform: "translateX(0px) scale(0.7)", opacity: "0.7" },
+  { offset: 1, transform: "scale(1)", opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/back_entrances/backInRight.js
+var backInRight = [
+  { offset: 0, transform: "translateX(2000px) scale(0.7)", opacity: "0.7" },
+  { offset: 0.8, transform: "translateX(0px) scale(0.7)", opacity: "0.7" },
+  { offset: 1, transform: "scale(1)", opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/back_entrances/backInUp.js
+var backInUp = [
+  { offset: 0, transform: "translateY(1200px) scale(0.7)", opacity: "0.7" },
+  { offset: 0.8, transform: "translateY(0px) scale(0.7)", opacity: "0.7" },
+  { offset: 1, transform: "scale(1)", opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/back_exits/backOutDown.js
+var backOutDown = [
+  { offset: 0, transform: "scale(1)", opacity: "1" },
+  { offset: 0.2, transform: "translateY(0px) scale(0.7)", opacity: "0.7" },
+  { offset: 1, transform: "translateY(700px) scale(0.7)", opacity: "0.7" }
+];
+
+// node_modules/@shoelace-style/animations/dist/back_exits/backOutLeft.js
+var backOutLeft = [
+  { offset: 0, transform: "scale(1)", opacity: "1" },
+  { offset: 0.2, transform: "translateX(0px) scale(0.7)", opacity: "0.7" },
+  { offset: 1, transform: "translateX(-2000px) scale(0.7)", opacity: "0.7" }
+];
+
+// node_modules/@shoelace-style/animations/dist/back_exits/backOutRight.js
+var backOutRight = [
+  { offset: 0, transform: "scale(1)", opacity: "1" },
+  { offset: 0.2, transform: "translateX(0px) scale(0.7)", opacity: "0.7" },
+  { offset: 1, transform: "translateX(2000px) scale(0.7)", opacity: "0.7" }
+];
+
+// node_modules/@shoelace-style/animations/dist/back_exits/backOutUp.js
+var backOutUp = [
+  { offset: 0, transform: "scale(1)", opacity: "1" },
+  { offset: 0.2, transform: "translateY(0px) scale(0.7)", opacity: "0.7" },
+  { offset: 1, transform: "translateY(-700px) scale(0.7)", opacity: "0.7" }
+];
+
+// node_modules/@shoelace-style/animations/dist/bouncing_entrances/bounceIn.js
+var bounceIn = [
+  { offset: 0, opacity: "0", transform: "scale3d(0.3, 0.3, 0.3)" },
+  { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.2, transform: "scale3d(1.1, 1.1, 1.1)" },
+  { offset: 0.2, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.4, transform: "scale3d(0.9, 0.9, 0.9)" },
+  { offset: 0.4, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.6, opacity: "1", transform: "scale3d(1.03, 1.03, 1.03)" },
+  { offset: 0.6, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.8, transform: "scale3d(0.97, 0.97, 0.97)" },
+  { offset: 0.8, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 1, opacity: "1", transform: "scale3d(1, 1, 1)" },
+  { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/bouncing_entrances/bounceInDown.js
+var bounceInDown = [
+  { offset: 0, opacity: "0", transform: "translate3d(0, -3000px, 0) scaleY(3)" },
+  { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.6, opacity: "1", transform: "translate3d(0, 25px, 0) scaleY(0.9)" },
+  { offset: 0.6, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.75, transform: "translate3d(0, -10px, 0) scaleY(0.95)" },
+  { offset: 0.75, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.9, transform: "translate3d(0, 5px, 0) scaleY(0.985)" },
+  { offset: 0.9, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" },
+  { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/bouncing_entrances/bounceInLeft.js
+var bounceInLeft = [
+  { offset: 0, opacity: "0", transform: "translate3d(-3000px, 0, 0) scaleX(3)" },
+  { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.6, opacity: "1", transform: "translate3d(25px, 0, 0) scaleX(1)" },
+  { offset: 0.6, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.75, transform: "translate3d(-10px, 0, 0) scaleX(0.98)" },
+  { offset: 0.75, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.9, transform: "translate3d(5px, 0, 0) scaleX(0.995)" },
+  { offset: 0.9, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" },
+  { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/bouncing_entrances/bounceInRight.js
+var bounceInRight = [
+  { offset: 0, opacity: "0", transform: "translate3d(3000px, 0, 0) scaleX(3)" },
+  { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.6, opacity: "1", transform: "translate3d(-25px, 0, 0) scaleX(1)" },
+  { offset: 0.6, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.75, transform: "translate3d(10px, 0, 0) scaleX(0.98)" },
+  { offset: 0.75, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.9, transform: "translate3d(-5px, 0, 0) scaleX(0.995)" },
+  { offset: 0.9, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" },
+  { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/bouncing_entrances/bounceInUp.js
+var bounceInUp = [
+  { offset: 0, opacity: "0", transform: "translate3d(0, 3000px, 0) scaleY(5)" },
+  { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.6, opacity: "1", transform: "translate3d(0, -20px, 0) scaleY(0.9)" },
+  { offset: 0.6, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.75, transform: "translate3d(0, 10px, 0) scaleY(0.95)" },
+  { offset: 0.75, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 0.9, transform: "translate3d(0, -5px, 0) scaleY(0.985)" },
+  { offset: 0.9, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" },
+  { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/bouncing_exits/bounceOut.js
+var bounceOut = [
+  { offset: 0.2, transform: "scale3d(0.9, 0.9, 0.9)" },
+  { offset: 0.5, opacity: "1", transform: "scale3d(1.1, 1.1, 1.1)" },
+  { offset: 0.55, opacity: "1", transform: "scale3d(1.1, 1.1, 1.1)" },
+  { offset: 1, opacity: "0", transform: "scale3d(0.3, 0.3, 0.3)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/bouncing_exits/bounceOutDown.js
+var bounceOutDown = [
+  { offset: 0.2, transform: "translate3d(0, 10px, 0) scaleY(0.985)" },
+  { offset: 0.4, opacity: "1", transform: "translate3d(0, -20px, 0) scaleY(0.9)" },
+  { offset: 0.45, opacity: "1", transform: "translate3d(0, -20px, 0) scaleY(0.9)" },
+  { offset: 1, opacity: "0", transform: "translate3d(0, 2000px, 0) scaleY(3)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/bouncing_exits/bounceOutLeft.js
+var bounceOutLeft = [
+  { offset: 0.2, opacity: "1", transform: "translate3d(20px, 0, 0) scaleX(0.9)" },
+  { offset: 1, opacity: "0", transform: "translate3d(-2000px, 0, 0) scaleX(2)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/bouncing_exits/bounceOutRight.js
+var bounceOutRight = [
+  { offset: 0.2, opacity: "1", transform: "translate3d(-20px, 0, 0) scaleX(0.9)" },
+  { offset: 1, opacity: "0", transform: "translate3d(2000px, 0, 0) scaleX(2)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/bouncing_exits/bounceOutUp.js
+var bounceOutUp = [
+  { offset: 0.2, transform: "translate3d(0, -10px, 0) scaleY(0.985)" },
+  { offset: 0.4, opacity: "1", transform: "translate3d(0, 20px, 0) scaleY(0.9)" },
+  { offset: 0.45, opacity: "1", transform: "translate3d(0, 20px, 0) scaleY(0.9)" },
+  { offset: 1, opacity: "0", transform: "translate3d(0, -2000px, 0) scaleY(3)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeIn.js
+var fadeIn = [
+  { offset: 0, opacity: "0" },
+  { offset: 1, opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInBottomLeft.js
+var fadeInBottomLeft = [
+  { offset: 0, opacity: "0", transform: "translate3d(-100%, 100%, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInBottomRight.js
+var fadeInBottomRight = [
+  { offset: 0, opacity: "0", transform: "translate3d(100%, 100%, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInDown.js
+var fadeInDown = [
+  { offset: 0, opacity: "0", transform: "translate3d(0, -100%, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInDownBig.js
+var fadeInDownBig = [
+  { offset: 0, opacity: "0", transform: "translate3d(0, -2000px, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInLeft.js
+var fadeInLeft = [
+  { offset: 0, opacity: "0", transform: "translate3d(-100%, 0, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInLeftBig.js
+var fadeInLeftBig = [
+  { offset: 0, opacity: "0", transform: "translate3d(-2000px, 0, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInRight.js
+var fadeInRight = [
+  { offset: 0, opacity: "0", transform: "translate3d(100%, 0, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInRightBig.js
+var fadeInRightBig = [
+  { offset: 0, opacity: "0", transform: "translate3d(2000px, 0, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInTopLeft.js
+var fadeInTopLeft = [
+  { offset: 0, opacity: "0", transform: "translate3d(-100%, -100%, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInTopRight.js
+var fadeInTopRight = [
+  { offset: 0, opacity: "0", transform: "translate3d(100%, -100%, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInUp.js
+var fadeInUp = [
+  { offset: 0, opacity: "0", transform: "translate3d(0, 100%, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInUpBig.js
+var fadeInUpBig = [
+  { offset: 0, opacity: "0", transform: "translate3d(0, 2000px, 0)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOut.js
+var fadeOut = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutBottomLeft.js
+var fadeOutBottomLeft = [
+  { offset: 0, opacity: "1", transform: "translate3d(0, 0, 0)" },
+  { offset: 1, opacity: "0", transform: "translate3d(-100%, 100%, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutBottomRight.js
+var fadeOutBottomRight = [
+  { offset: 0, opacity: "1", transform: "translate3d(0, 0, 0)" },
+  { offset: 1, opacity: "0", transform: "translate3d(100%, 100%, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutDown.js
+var fadeOutDown = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, opacity: "0", transform: "translate3d(0, 100%, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutDownBig.js
+var fadeOutDownBig = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, opacity: "0", transform: "translate3d(0, 2000px, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutLeft.js
+var fadeOutLeft = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, opacity: "0", transform: "translate3d(-100%, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutLeftBig.js
+var fadeOutLeftBig = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, opacity: "0", transform: "translate3d(-2000px, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutRight.js
+var fadeOutRight = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, opacity: "0", transform: "translate3d(100%, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutRightBig.js
+var fadeOutRightBig = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, opacity: "0", transform: "translate3d(2000px, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutTopLeft.js
+var fadeOutTopLeft = [
+  { offset: 0, opacity: "1", transform: "translate3d(0, 0, 0)" },
+  { offset: 1, opacity: "0", transform: "translate3d(-100%, -100%, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutTopRight.js
+var fadeOutTopRight = [
+  { offset: 0, opacity: "1", transform: "translate3d(0, 0, 0)" },
+  { offset: 1, opacity: "0", transform: "translate3d(100%, -100%, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutUp.js
+var fadeOutUp = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, opacity: "0", transform: "translate3d(0, -100%, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutUpBig.js
+var fadeOutUpBig = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, opacity: "0", transform: "translate3d(0, -2000px, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/flippers/flip.js
+var flip = [
+  {
+    offset: 0,
+    transform: "perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, -360deg)",
+    easing: "ease-out"
+  },
+  {
+    offset: 0.4,
+    transform: "perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px)\n      rotate3d(0, 1, 0, -190deg)",
+    easing: "ease-out"
+  },
+  {
+    offset: 0.5,
+    transform: "perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px)\n      rotate3d(0, 1, 0, -170deg)",
+    easing: "ease-in"
+  },
+  {
+    offset: 0.8,
+    transform: "perspective(400px) scale3d(0.95, 0.95, 0.95) translate3d(0, 0, 0)\n      rotate3d(0, 1, 0, 0deg)",
+    easing: "ease-in"
+  },
+  {
+    offset: 1,
+    transform: "perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)",
+    easing: "ease-in"
+  }
+];
+
+// node_modules/@shoelace-style/animations/dist/flippers/flipInX.js
+var flipInX = [
+  { offset: 0, transform: "perspective(400px) rotate3d(1, 0, 0, 90deg)", easing: "ease-in", opacity: "0" },
+  { offset: 0.4, transform: "perspective(400px) rotate3d(1, 0, 0, -20deg)", easing: "ease-in" },
+  { offset: 0.6, transform: "perspective(400px) rotate3d(1, 0, 0, 10deg)", opacity: "1" },
+  { offset: 0.8, transform: "perspective(400px) rotate3d(1, 0, 0, -5deg)" },
+  { offset: 1, transform: "perspective(400px)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/flippers/flipInY.js
+var flipInY = [
+  { offset: 0, transform: "perspective(400px) rotate3d(0, 1, 0, 90deg)", easing: "ease-in", opacity: "0" },
+  { offset: 0.4, transform: "perspective(400px) rotate3d(0, 1, 0, -20deg)", easing: "ease-in" },
+  { offset: 0.6, transform: "perspective(400px) rotate3d(0, 1, 0, 10deg)", opacity: "1" },
+  { offset: 0.8, transform: "perspective(400px) rotate3d(0, 1, 0, -5deg)" },
+  { offset: 1, transform: "perspective(400px)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/flippers/flipOutX.js
+var flipOutX = [
+  { offset: 0, transform: "perspective(400px)" },
+  { offset: 0.3, transform: "perspective(400px) rotate3d(1, 0, 0, -20deg)", opacity: "1" },
+  { offset: 1, transform: "perspective(400px) rotate3d(1, 0, 0, 90deg)", opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/flippers/flipOutY.js
+var flipOutY = [
+  { offset: 0, transform: "perspective(400px)" },
+  { offset: 0.3, transform: "perspective(400px) rotate3d(0, 1, 0, -15deg)", opacity: "1" },
+  { offset: 1, transform: "perspective(400px) rotate3d(0, 1, 0, 90deg)", opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/lightspeed/lightSpeedInLeft.js
+var lightSpeedInLeft = [
+  { offset: 0, transform: "translate3d(-100%, 0, 0) skewX(30deg)", opacity: "0" },
+  { offset: 0.6, transform: "skewX(-20deg)", opacity: "1" },
+  { offset: 0.8, transform: "skewX(5deg)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/lightspeed/lightSpeedInRight.js
+var lightSpeedInRight = [
+  { offset: 0, transform: "translate3d(100%, 0, 0) skewX(-30deg)", opacity: "0" },
+  { offset: 0.6, transform: "skewX(20deg)", opacity: "1" },
+  { offset: 0.8, transform: "skewX(-5deg)" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/lightspeed/lightSpeedOutLeft.js
+var lightSpeedOutLeft = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, transform: "translate3d(-100%, 0, 0) skewX(-30deg)", opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/lightspeed/lightSpeedOutRight.js
+var lightSpeedOutRight = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, transform: "translate3d(100%, 0, 0) skewX(30deg)", opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/rotating_entrances/rotateIn.js
+var rotateIn = [
+  { offset: 0, transform: "rotate3d(0, 0, 1, -200deg)", opacity: "0" },
+  { offset: 1, transform: "translate3d(0, 0, 0)", opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/rotating_entrances/rotateInDownLeft.js
+var rotateInDownLeft = [
+  { offset: 0, transform: "rotate3d(0, 0, 1, -45deg)", opacity: "0" },
+  { offset: 1, transform: "translate3d(0, 0, 0)", opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/rotating_entrances/rotateInDownRight.js
+var rotateInDownRight = [
+  { offset: 0, transform: "rotate3d(0, 0, 1, 45deg)", opacity: "0" },
+  { offset: 1, transform: "translate3d(0, 0, 0)", opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/rotating_entrances/rotateInUpLeft.js
+var rotateInUpLeft = [
+  { offset: 0, transform: "rotate3d(0, 0, 1, 45deg)", opacity: "0" },
+  { offset: 1, transform: "translate3d(0, 0, 0)", opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/rotating_entrances/rotateInUpRight.js
+var rotateInUpRight = [
+  { offset: 0, transform: "rotate3d(0, 0, 1, -90deg)", opacity: "0" },
+  { offset: 1, transform: "translate3d(0, 0, 0)", opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/rotating_exits/rotateOut.js
+var rotateOut = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, transform: "rotate3d(0, 0, 1, 200deg)", opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/rotating_exits/rotateOutDownLeft.js
+var rotateOutDownLeft = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, transform: "rotate3d(0, 0, 1, 45deg)", opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/rotating_exits/rotateOutDownRight.js
+var rotateOutDownRight = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, transform: "rotate3d(0, 0, 1, -45deg)", opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/rotating_exits/rotateOutUpLeft.js
+var rotateOutUpLeft = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, transform: "rotate3d(0, 0, 1, -45deg)", opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/rotating_exits/rotateOutUpRight.js
+var rotateOutUpRight = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, transform: "rotate3d(0, 0, 1, 90deg)", opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/sliding_entrances/slideInDown.js
+var slideInDown = [
+  { offset: 0, transform: "translate3d(0, -100%, 0)", visibility: "visible" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/sliding_entrances/slideInLeft.js
+var slideInLeft = [
+  { offset: 0, transform: "translate3d(-100%, 0, 0)", visibility: "visible" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/sliding_entrances/slideInRight.js
+var slideInRight = [
+  { offset: 0, transform: "translate3d(100%, 0, 0)", visibility: "visible" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/sliding_entrances/slideInUp.js
+var slideInUp = [
+  { offset: 0, transform: "translate3d(0, 100%, 0)", visibility: "visible" },
+  { offset: 1, transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/sliding_exits/slideOutDown.js
+var slideOutDown = [
+  { offset: 0, transform: "translate3d(0, 0, 0)" },
+  { offset: 1, visibility: "hidden", transform: "translate3d(0, 100%, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/sliding_exits/slideOutLeft.js
+var slideOutLeft = [
+  { offset: 0, transform: "translate3d(0, 0, 0)" },
+  { offset: 1, visibility: "hidden", transform: "translate3d(-100%, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/sliding_exits/slideOutRight.js
+var slideOutRight = [
+  { offset: 0, transform: "translate3d(0, 0, 0)" },
+  { offset: 1, visibility: "hidden", transform: "translate3d(100%, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/sliding_exits/slideOutUp.js
+var slideOutUp = [
+  { offset: 0, transform: "translate3d(0, 0, 0)" },
+  { offset: 1, visibility: "hidden", transform: "translate3d(0, -100%, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/specials/hinge.js
+var hinge = [
+  { offset: 0, easing: "ease-in-out" },
+  { offset: 0.2, transform: "rotate3d(0, 0, 1, 80deg)", easing: "ease-in-out" },
+  { offset: 0.4, transform: "rotate3d(0, 0, 1, 60deg)", easing: "ease-in-out", opacity: "1" },
+  { offset: 0.6, transform: "rotate3d(0, 0, 1, 80deg)", easing: "ease-in-out" },
+  { offset: 0.8, transform: "rotate3d(0, 0, 1, 60deg)", easing: "ease-in-out", opacity: "1" },
+  { offset: 1, transform: "translate3d(0, 700px, 0)", opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/specials/jackInTheBox.js
+var jackInTheBox = [
+  { offset: 0, opacity: "0", transform: "scale(0.1) rotate(30deg)", "transform-origin": "center bottom" },
+  { offset: 0.5, transform: "rotate(-10deg)" },
+  { offset: 0.7, transform: "rotate(3deg)" },
+  { offset: 1, opacity: "1", transform: "scale(1)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/specials/rollIn.js
+var rollIn = [
+  { offset: 0, opacity: "0", transform: "translate3d(-100%, 0, 0) rotate3d(0, 0, 1, -120deg)" },
+  { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/specials/rollOut.js
+var rollOut = [
+  { offset: 0, opacity: "1" },
+  { offset: 1, opacity: "0", transform: "translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/zooming_entrances/zoomIn.js
+var zoomIn = [
+  { offset: 0, opacity: "0", transform: "scale3d(0.3, 0.3, 0.3)" },
+  { offset: 0.5, opacity: "1" }
+];
+
+// node_modules/@shoelace-style/animations/dist/zooming_entrances/zoomInDown.js
+var zoomInDown = [
+  {
+    offset: 0,
+    opacity: "0",
+    transform: "scale3d(0.1, 0.1, 0.1) translate3d(0, -1000px, 0)",
+    easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+  },
+  {
+    offset: 0.6,
+    opacity: "1",
+    transform: "scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)",
+    easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+  }
+];
+
+// node_modules/@shoelace-style/animations/dist/zooming_entrances/zoomInLeft.js
+var zoomInLeft = [
+  {
+    offset: 0,
+    opacity: "0",
+    transform: "scale3d(0.1, 0.1, 0.1) translate3d(-1000px, 0, 0)",
+    easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+  },
+  {
+    offset: 0.6,
+    opacity: "1",
+    transform: "scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0)",
+    easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+  }
+];
+
+// node_modules/@shoelace-style/animations/dist/zooming_entrances/zoomInRight.js
+var zoomInRight = [
+  {
+    offset: 0,
+    opacity: "0",
+    transform: "scale3d(0.1, 0.1, 0.1) translate3d(1000px, 0, 0)",
+    easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+  },
+  {
+    offset: 0.6,
+    opacity: "1",
+    transform: "scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0)",
+    easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+  }
+];
+
+// node_modules/@shoelace-style/animations/dist/zooming_entrances/zoomInUp.js
+var zoomInUp = [
+  {
+    offset: 0,
+    opacity: "0",
+    transform: "scale3d(0.1, 0.1, 0.1) translate3d(0, 1000px, 0)",
+    easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+  },
+  {
+    offset: 0.6,
+    opacity: "1",
+    transform: "scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)",
+    easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+  }
+];
+
+// node_modules/@shoelace-style/animations/dist/zooming_exits/zoomOut.js
+var zoomOut = [
+  { offset: 0, opacity: "1" },
+  { offset: 0.5, opacity: "0", transform: "scale3d(0.3, 0.3, 0.3)" },
+  { offset: 1, opacity: "0" }
+];
+
+// node_modules/@shoelace-style/animations/dist/zooming_exits/zoomOutDown.js
+var zoomOutDown = [
+  {
+    offset: 0.4,
+    opacity: "1",
+    transform: "scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)",
+    easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+  },
+  {
+    offset: 1,
+    opacity: "0",
+    transform: "scale3d(0.1, 0.1, 0.1) translate3d(0, 2000px, 0)",
+    easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+  }
+];
+
+// node_modules/@shoelace-style/animations/dist/zooming_exits/zoomOutLeft.js
+var zoomOutLeft = [
+  { offset: 0.4, opacity: "1", transform: "scale3d(0.475, 0.475, 0.475) translate3d(42px, 0, 0)" },
+  { offset: 1, opacity: "0", transform: "scale(0.1) translate3d(-2000px, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/zooming_exits/zoomOutRight.js
+var zoomOutRight = [
+  { offset: 0.4, opacity: "1", transform: "scale3d(0.475, 0.475, 0.475) translate3d(-42px, 0, 0)" },
+  { offset: 1, opacity: "0", transform: "scale(0.1) translate3d(2000px, 0, 0)" }
+];
+
+// node_modules/@shoelace-style/animations/dist/zooming_exits/zoomOutUp.js
+var zoomOutUp = [
+  {
+    offset: 0.4,
+    opacity: "1",
+    transform: "scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)",
+    easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+  },
+  {
+    offset: 1,
+    opacity: "0",
+    transform: "scale3d(0.1, 0.1, 0.1) translate3d(0, -2000px, 0)",
+    easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+  }
+];
+
+// node_modules/@shoelace-style/animations/dist/easings/easings.js
+var easings = {
+  linear: "linear",
+  ease: "ease",
+  easeIn: "ease-in",
+  easeOut: "ease-out",
+  easeInOut: "ease-in-out",
+  easeInSine: "cubic-bezier(0.47, 0, 0.745, 0.715)",
+  easeOutSine: "cubic-bezier(0.39, 0.575, 0.565, 1)",
+  easeInOutSine: "cubic-bezier(0.445, 0.05, 0.55, 0.95)",
+  easeInQuad: "cubic-bezier(0.55, 0.085, 0.68, 0.53)",
+  easeOutQuad: "cubic-bezier(0.25, 0.46, 0.45, 0.94)",
+  easeInOutQuad: "cubic-bezier(0.455, 0.03, 0.515, 0.955)",
+  easeInCubic: "cubic-bezier(0.55, 0.055, 0.675, 0.19)",
+  easeOutCubic: "cubic-bezier(0.215, 0.61, 0.355, 1)",
+  easeInOutCubic: "cubic-bezier(0.645, 0.045, 0.355, 1)",
+  easeInQuart: "cubic-bezier(0.895, 0.03, 0.685, 0.22)",
+  easeOutQuart: "cubic-bezier(0.165, 0.84, 0.44, 1)",
+  easeInOutQuart: "cubic-bezier(0.77, 0, 0.175, 1)",
+  easeInQuint: "cubic-bezier(0.755, 0.05, 0.855, 0.06)",
+  easeOutQuint: "cubic-bezier(0.23, 1, 0.32, 1)",
+  easeInOutQuint: "cubic-bezier(0.86, 0, 0.07, 1)",
+  easeInExpo: "cubic-bezier(0.95, 0.05, 0.795, 0.035)",
+  easeOutExpo: "cubic-bezier(0.19, 1, 0.22, 1)",
+  easeInOutExpo: "cubic-bezier(1, 0, 0, 1)",
+  easeInCirc: "cubic-bezier(0.6, 0.04, 0.98, 0.335)",
+  easeOutCirc: "cubic-bezier(0.075, 0.82, 0.165, 1)",
+  easeInOutCirc: "cubic-bezier(0.785, 0.135, 0.15, 0.86)",
+  easeInBack: "cubic-bezier(0.6, -0.28, 0.735, 0.045)",
+  easeOutBack: "cubic-bezier(0.175, 0.885, 0.32, 1.275)",
+  easeInOutBack: "cubic-bezier(0.68, -0.55, 0.265, 1.55)"
+};
+
+// src/components/animation/animation.ts
+var SlAnimation = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.hasStarted = false;
+    this.name = "none";
+    this.play = false;
+    this.delay = 0;
+    this.direction = "normal";
+    this.duration = 1e3;
+    this.easing = "linear";
+    this.endDelay = 0;
+    this.fill = "auto";
+    this.iterations = Infinity;
+    this.iterationStart = 0;
+    this.playbackRate = 1;
+  }
+  get currentTime() {
+    var _a, _b;
+    return (_b = (_a = this.animation) == null ? void 0 : _a.currentTime) != null ? _b : 0;
+  }
+  set currentTime(time) {
+    if (this.animation) {
+      this.animation.currentTime = time;
+    }
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.createAnimation();
+    this.handleAnimationCancel = this.handleAnimationCancel.bind(this);
+    this.handleAnimationFinish = this.handleAnimationFinish.bind(this);
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.destroyAnimation();
+  }
+  handleAnimationChange() {
+    if (!this.hasUpdated) {
+      return;
+    }
+    this.createAnimation();
+  }
+  handleAnimationFinish() {
+    this.play = false;
+    this.hasStarted = false;
+    this.emit("sl-finish");
+  }
+  handleAnimationCancel() {
+    this.play = false;
+    this.hasStarted = false;
+    this.emit("sl-cancel");
+  }
+  handlePlayChange() {
+    if (this.animation) {
+      if (this.play && !this.hasStarted) {
+        this.hasStarted = true;
+        this.emit("sl-start");
+      }
+      if (this.play) {
+        this.animation.play();
+      } else {
+        this.animation.pause();
+      }
+      return true;
+    }
+    return false;
+  }
+  handlePlaybackRateChange() {
+    if (this.animation) {
+      this.animation.playbackRate = this.playbackRate;
+    }
+  }
+  handleSlotChange() {
+    this.destroyAnimation();
+    this.createAnimation();
+  }
+  async createAnimation() {
+    var _a, _b;
+    const easing = (_a = dist_exports.easings[this.easing]) != null ? _a : this.easing;
+    const keyframes = (_b = this.keyframes) != null ? _b : dist_exports[this.name];
+    const slot = await this.defaultSlot;
+    const element = slot.assignedElements()[0];
+    if (!element || !keyframes) {
+      return false;
+    }
+    this.destroyAnimation();
+    this.animation = element.animate(keyframes, {
+      delay: this.delay,
+      direction: this.direction,
+      duration: this.duration,
+      easing,
+      endDelay: this.endDelay,
+      fill: this.fill,
+      iterationStart: this.iterationStart,
+      iterations: this.iterations
+    });
+    this.animation.playbackRate = this.playbackRate;
+    this.animation.addEventListener("cancel", this.handleAnimationCancel);
+    this.animation.addEventListener("finish", this.handleAnimationFinish);
+    if (this.play) {
+      this.hasStarted = true;
+      this.emit("sl-start");
+    } else {
+      this.animation.pause();
+    }
+    return true;
+  }
+  destroyAnimation() {
+    if (this.animation) {
+      this.animation.cancel();
+      this.animation.removeEventListener("cancel", this.handleAnimationCancel);
+      this.animation.removeEventListener("finish", this.handleAnimationFinish);
+      this.hasStarted = false;
+    }
+  }
+  cancel() {
+    var _a;
+    (_a = this.animation) == null ? void 0 : _a.cancel();
+  }
+  finish() {
+    var _a;
+    (_a = this.animation) == null ? void 0 : _a.finish();
+  }
+  render() {
+    return $` <slot @slotchange=${this.handleSlotChange}></slot> `;
+  }
+};
+SlAnimation.styles = animation_styles_default;
+__decorateClass([
+  e2$1("slot")
+], SlAnimation.prototype, "defaultSlot", 2);
+__decorateClass([
+  e$1()
+], SlAnimation.prototype, "name", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlAnimation.prototype, "play", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlAnimation.prototype, "delay", 2);
+__decorateClass([
+  e$1()
+], SlAnimation.prototype, "direction", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlAnimation.prototype, "duration", 2);
+__decorateClass([
+  e$1()
+], SlAnimation.prototype, "easing", 2);
+__decorateClass([
+  e$1({ attribute: "end-delay", type: Number })
+], SlAnimation.prototype, "endDelay", 2);
+__decorateClass([
+  e$1()
+], SlAnimation.prototype, "fill", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlAnimation.prototype, "iterations", 2);
+__decorateClass([
+  e$1({ attribute: "iteration-start", type: Number })
+], SlAnimation.prototype, "iterationStart", 2);
+__decorateClass([
+  e$1({ attribute: false })
+], SlAnimation.prototype, "keyframes", 2);
+__decorateClass([
+  e$1({ attribute: "playback-rate", type: Number })
+], SlAnimation.prototype, "playbackRate", 2);
+__decorateClass([
+  watch("name"),
+  watch("delay"),
+  watch("direction"),
+  watch("duration"),
+  watch("easing"),
+  watch("endDelay"),
+  watch("fill"),
+  watch("iterations"),
+  watch("iterationsStart"),
+  watch("keyframes")
+], SlAnimation.prototype, "handleAnimationChange", 1);
+__decorateClass([
+  watch("play")
+], SlAnimation.prototype, "handlePlayChange", 1);
+__decorateClass([
+  watch("playbackRate")
+], SlAnimation.prototype, "handlePlaybackRateChange", 1);
+SlAnimation = __decorateClass([
+  n$1("sl-animation")
+], SlAnimation);
+
+// src/components/card/card.styles.ts
+var card_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --border-color: var(--sl-color-neutral-200);
+    --border-radius: var(--sl-border-radius-medium);
+    --border-width: 1px;
+    --padding: var(--sl-spacing-large);
+
+    display: inline-block;
+  }
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--sl-panel-background-color);
+    box-shadow: var(--sl-shadow-x-small);
+    border: solid var(--border-width) var(--border-color);
+    border-radius: var(--border-radius);
+  }
+
+  .card__image {
+    border-top-left-radius: var(--border-radius);
+    border-top-right-radius: var(--border-radius);
+    margin: calc(-1 * var(--border-width));
+    overflow: hidden;
+  }
+
+  .card__image ::slotted(img) {
+    display: block;
+    width: 100%;
+  }
+
+  .card:not(.card--has-image) .card__image {
+    display: none;
+  }
+
+  .card__header {
+    border-bottom: solid var(--border-width) var(--border-color);
+    padding: calc(var(--padding) / 2) var(--padding);
+  }
+
+  .card:not(.card--has-header) .card__header {
+    display: none;
+  }
+
+  .card__body {
+    padding: var(--padding);
+  }
+
+  .card--has-footer .card__footer {
+    border-top: solid var(--border-width) var(--border-color);
+    padding: var(--padding);
+  }
+
+  .card:not(.card--has-footer) .card__footer {
+    display: none;
+  }
+`;
+
+// src/components/card/card.ts
+var SlCard = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.hasSlotController = new HasSlotController(this, "footer", "header", "image");
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      card: true,
+      "card--has-footer": this.hasSlotController.test("footer"),
+      "card--has-image": this.hasSlotController.test("image"),
+      "card--has-header": this.hasSlotController.test("header")
+    })}
+      >
+        <div part="image" class="card__image">
+          <slot name="image"></slot>
+        </div>
+
+        <div part="header" class="card__header">
+          <slot name="header"></slot>
+        </div>
+
+        <div part="body" class="card__body">
+          <slot></slot>
+        </div>
+
+        <div part="footer" class="card__footer">
+          <slot name="footer"></slot>
+        </div>
+      </div>
+    `;
+  }
+};
+SlCard.styles = card_styles_default;
+SlCard = __decorateClass([
+  n$1("sl-card")
+], SlCard);
+
+// src/components/checkbox/checkbox.styles.ts
+var checkbox_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .checkbox {
+    display: inline-flex;
+    align-items: top;
+    font-family: var(--sl-input-font-family);
+    font-size: var(--sl-input-font-size-medium);
+    font-weight: var(--sl-input-font-weight);
+    color: var(--sl-input-color);
+    vertical-align: middle;
+    cursor: pointer;
+  }
+
+  .checkbox__control {
+    flex: 0 0 auto;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--sl-toggle-size);
+    height: var(--sl-toggle-size);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+    border-radius: 2px;
+    background-color: var(--sl-input-background-color);
+    color: var(--sl-color-neutral-0);
+    transition: var(--sl-transition-fast) border-color, var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) color, var(--sl-transition-fast) box-shadow;
+  }
+
+  .checkbox__input {
+    position: absolute;
+    opacity: 0;
+    padding: 0;
+    margin: 0;
+    pointer-events: none;
+  }
+
+  .checkbox__control .checkbox__icon {
+    display: inline-flex;
+    width: var(--sl-toggle-size);
+    height: var(--sl-toggle-size);
+  }
+
+  .checkbox__control .checkbox__icon svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* Hover */
+  .checkbox:not(.checkbox--checked):not(.checkbox--disabled) .checkbox__control:hover {
+    border-color: var(--sl-input-border-color-hover);
+    background-color: var(--sl-input-background-color-hover);
+  }
+
+  /* Focus */
+  .checkbox:not(.checkbox--checked):not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Checked/indeterminate */
+  .checkbox--checked .checkbox__control,
+  .checkbox--indeterminate .checkbox__control {
+    border-color: var(--sl-color-primary-600);
+    background-color: var(--sl-color-primary-600);
+  }
+
+  /* Checked/indeterminate + hover */
+  .checkbox.checkbox--checked:not(.checkbox--disabled) .checkbox__control:hover,
+  .checkbox.checkbox--indeterminate:not(.checkbox--disabled) .checkbox__control:hover {
+    border-color: var(--sl-color-primary-500);
+    background-color: var(--sl-color-primary-500);
+  }
+
+  /* Checked/indeterminate + focus */
+  .checkbox.checkbox--checked:not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control,
+  .checkbox.checkbox--indeterminate:not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Disabled */
+  .checkbox--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .checkbox__label {
+    color: var(--sl-input-label-color);
+    line-height: var(--sl-toggle-size);
+    margin-inline-start: 0.5em;
+    user-select: none;
+  }
+
+  :host([required]) .checkbox__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+`;
+
+// src/components/checkbox/checkbox.ts
+var SlCheckbox = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.formSubmitController = new FormSubmitController(this, {
+      value: (control) => control.checked ? control.value || "on" : void 0,
+      defaultValue: (control) => control.defaultChecked,
+      setValue: (control, checked) => control.checked = checked
+    });
+    this.hasFocus = false;
+    this.disabled = false;
+    this.required = false;
+    this.checked = false;
+    this.indeterminate = false;
+    this.invalid = false;
+    this.defaultChecked = false;
+  }
+  firstUpdated() {
+    this.invalid = !this.input.checkValidity();
+  }
+  click() {
+    this.input.click();
+  }
+  focus(options) {
+    this.input.focus(options);
+  }
+  blur() {
+    this.input.blur();
+  }
+  reportValidity() {
+    return this.input.reportValidity();
+  }
+  setCustomValidity(message) {
+    this.input.setCustomValidity(message);
+    this.invalid = !this.input.checkValidity();
+  }
+  handleClick() {
+    this.checked = !this.checked;
+    this.indeterminate = false;
+    this.emit("sl-change");
+  }
+  handleBlur() {
+    this.hasFocus = false;
+    this.emit("sl-blur");
+  }
+  handleDisabledChange() {
+    this.input.disabled = this.disabled;
+    this.invalid = !this.input.checkValidity();
+  }
+  handleFocus() {
+    this.hasFocus = true;
+    this.emit("sl-focus");
+  }
+  handleStateChange() {
+    this.invalid = !this.input.checkValidity();
+  }
+  render() {
+    return $`
+      <label
+        part="base"
+        class=${o$3({
+      checkbox: true,
+      "checkbox--checked": this.checked,
+      "checkbox--disabled": this.disabled,
+      "checkbox--focused": this.hasFocus,
+      "checkbox--indeterminate": this.indeterminate
+    })}
+      >
+        <input
+          class="checkbox__input"
+          type="checkbox"
+          name=${l$2(this.name)}
+          value=${l$2(this.value)}
+          .indeterminate=${l$3(this.indeterminate)}
+          .checked=${l$3(this.checked)}
+          .disabled=${this.disabled}
+          .required=${this.required}
+          aria-checked=${this.checked ? "true" : "false"}
+          @click=${this.handleClick}
+          @blur=${this.handleBlur}
+          @focus=${this.handleFocus}
+        />
+
+        <span part="control" class="checkbox__control">
+          ${this.checked ? $`
+                <svg part="checked-icon" class="checkbox__icon" viewBox="0 0 16 16">
+                  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+                    <g stroke="currentColor" stroke-width="2">
+                      <g transform="translate(3.428571, 3.428571)">
+                        <path d="M0,5.71428571 L3.42857143,9.14285714"></path>
+                        <path d="M9.14285714,0 L3.42857143,9.14285714"></path>
+                      </g>
+                    </g>
+                  </g>
+                </svg>
+              ` : ""}
+          ${!this.checked && this.indeterminate ? $`
+                <svg part="indeterminate-icon" class="checkbox__icon" viewBox="0 0 16 16">
+                  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+                    <g stroke="currentColor" stroke-width="2">
+                      <g transform="translate(2.285714, 6.857143)">
+                        <path d="M10.2857143,1.14285714 L1.14285714,1.14285714"></path>
+                      </g>
+                    </g>
+                  </g>
+                </svg>
+              ` : ""}
+        </span>
+
+        <span part="label" class="checkbox__label">
+          <slot></slot>
+        </span>
+      </label>
+    `;
+  }
+};
+SlCheckbox.styles = checkbox_styles_default;
+__decorateClass([
+  i2$2('input[type="checkbox"]')
+], SlCheckbox.prototype, "input", 2);
+__decorateClass([
+  t$1()
+], SlCheckbox.prototype, "hasFocus", 2);
+__decorateClass([
+  e$1()
+], SlCheckbox.prototype, "name", 2);
+__decorateClass([
+  e$1()
+], SlCheckbox.prototype, "value", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlCheckbox.prototype, "disabled", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlCheckbox.prototype, "required", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlCheckbox.prototype, "checked", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlCheckbox.prototype, "indeterminate", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlCheckbox.prototype, "invalid", 2);
+__decorateClass([
+  defaultValue("checked")
+], SlCheckbox.prototype, "defaultChecked", 2);
+__decorateClass([
+  watch("disabled", { waitUntilFirstUpdate: true })
+], SlCheckbox.prototype, "handleDisabledChange", 1);
+__decorateClass([
+  watch("checked", { waitUntilFirstUpdate: true }),
+  watch("indeterminate", { waitUntilFirstUpdate: true })
+], SlCheckbox.prototype, "handleStateChange", 1);
+SlCheckbox = __decorateClass([
+  n$1("sl-checkbox")
+], SlCheckbox);
+
+// src/components/badge/badge.styles.ts
+var badge_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-flex;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--sl-font-size-x-small);
+    font-weight: var(--sl-font-weight-semibold);
+    letter-spacing: var(--sl-letter-spacing-normal);
+    line-height: 1;
+    border-radius: var(--sl-border-radius-small);
+    border: solid 1px var(--sl-color-neutral-0);
+    white-space: nowrap;
+    padding: 3px 6px;
+    user-select: none;
+    cursor: inherit;
+  }
+
+  /* Variant modifiers */
+  .badge--primary {
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .badge--success {
+    background-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .badge--neutral {
+    background-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .badge--warning {
+    background-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .badge--danger {
+    background-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Pill modifier */
+  .badge--pill {
+    border-radius: var(--sl-border-radius-pill);
+  }
+
+  /* Pulse modifier */
+  .badge--pulse {
+    animation: pulse 1.5s infinite;
+  }
+
+  .badge--pulse.badge--primary {
+    --pulse-color: var(--sl-color-primary-600);
+  }
+
+  .badge--pulse.badge--success {
+    --pulse-color: var(--sl-color-success-600);
+  }
+
+  .badge--pulse.badge--neutral {
+    --pulse-color: var(--sl-color-neutral-600);
+  }
+
+  .badge--pulse.badge--warning {
+    --pulse-color: var(--sl-color-warning-600);
+  }
+
+  .badge--pulse.badge--danger {
+    --pulse-color: var(--sl-color-danger-600);
+  }
+
+  @keyframes pulse {
+    0% {
+      box-shadow: 0 0 0 0 var(--pulse-color);
+    }
+    70% {
+      box-shadow: 0 0 0 0.5rem transparent;
+    }
+    100% {
+      box-shadow: 0 0 0 0 transparent;
+    }
+  }
+`;
+
+// src/components/badge/badge.ts
+var SlBadge = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.variant = "primary";
+    this.pill = false;
+    this.pulse = false;
+  }
+  render() {
+    return $`
+      <span
+        part="base"
+        class=${o$3({
+      badge: true,
+      "badge--primary": this.variant === "primary",
+      "badge--success": this.variant === "success",
+      "badge--neutral": this.variant === "neutral",
+      "badge--warning": this.variant === "warning",
+      "badge--danger": this.variant === "danger",
+      "badge--pill": this.pill,
+      "badge--pulse": this.pulse
+    })}
+        role="status"
+      >
+        <slot></slot>
+      </span>
+    `;
+  }
+};
+SlBadge.styles = badge_styles_default;
+__decorateClass([
+  e$1({ reflect: true })
+], SlBadge.prototype, "variant", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlBadge.prototype, "pill", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlBadge.prototype, "pulse", 2);
+SlBadge = __decorateClass([
+  n$1("sl-badge")
+], SlBadge);
+
+// src/components/breadcrumb/breadcrumb.styles.ts
+var breadcrumb_styles_default = r$2`
+  ${component_styles_default}
+
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+`;
+
+// src/components/breadcrumb/breadcrumb.ts
+var SlBreadcrumb = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.localize = new LocalizeController2(this);
+    this.separatorDir = this.localize.dir();
+    this.label = "Breadcrumb";
+  }
+  getSeparator() {
+    const separator = this.separatorSlot.assignedElements({ flatten: true })[0];
+    const clone = separator.cloneNode(true);
+    [clone, ...clone.querySelectorAll("[id]")].forEach((el) => el.removeAttribute("id"));
+    clone.setAttribute("data-default", "");
+    clone.slot = "separator";
+    return clone;
+  }
+  handleSlotChange() {
+    const items = [...this.defaultSlot.assignedElements({ flatten: true })].filter(
+      (item) => item.tagName.toLowerCase() === "sl-breadcrumb-item"
+    );
+    items.forEach((item, index) => {
+      const separator = item.querySelector('[slot="separator"]');
+      if (separator === null) {
+        item.append(this.getSeparator());
+      } else if (separator.hasAttribute("data-default")) {
+        separator.replaceWith(this.getSeparator());
+      } else ;
+      if (index === items.length - 1) {
+        item.setAttribute("aria-current", "page");
+      } else {
+        item.removeAttribute("aria-current");
+      }
+    });
+  }
+  render() {
+    if (this.separatorDir !== this.localize.dir()) {
+      this.separatorDir = this.localize.dir();
+      this.updateComplete.then(() => this.handleSlotChange());
+    }
+    return $`
+      <nav part="base" class="breadcrumb" aria-label=${this.label}>
+        <slot @slotchange=${this.handleSlotChange}></slot>
+      </nav>
+
+      <slot name="separator" hidden aria-hidden="true">
+        <sl-icon name=${this.localize.dir() === "rtl" ? "chevron-left" : "chevron-right"} library="system"></sl-icon>
+      </slot>
+    `;
+  }
+};
+SlBreadcrumb.styles = breadcrumb_styles_default;
+__decorateClass([
+  i2$2("slot")
+], SlBreadcrumb.prototype, "defaultSlot", 2);
+__decorateClass([
+  i2$2('slot[name="separator"]')
+], SlBreadcrumb.prototype, "separatorSlot", 2);
+__decorateClass([
+  e$1()
+], SlBreadcrumb.prototype, "label", 2);
+SlBreadcrumb = __decorateClass([
+  n$1("sl-breadcrumb")
+], SlBreadcrumb);
+
+// src/components/breadcrumb-item/breadcrumb-item.styles.ts
+var breadcrumb_item_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-flex;
+  }
+
+  .breadcrumb-item {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-small);
+    font-weight: var(--sl-font-weight-semibold);
+    color: var(--sl-color-neutral-600);
+    line-height: var(--sl-line-height-normal);
+    white-space: nowrap;
+  }
+
+  .breadcrumb-item__label {
+    display: inline-block;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    text-decoration: none;
+    color: inherit;
+    background: none;
+    border: none;
+    border-radius: var(--sl-border-radius-medium);
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    transition: var(--sl-transition-fast) --color;
+  }
+
+  :host(:not(:last-of-type)) .breadcrumb-item__label {
+    color: var(--sl-color-primary-600);
+  }
+
+  :host(:not(:last-of-type)) .breadcrumb-item__label:hover {
+    color: var(--sl-color-primary-500);
+  }
+
+  :host(:not(:last-of-type)) .breadcrumb-item__label:active {
+    color: var(--sl-color-primary-600);
+  }
+
+  .breadcrumb-item__label:focus {
+    outline: none;
+  }
+
+  .breadcrumb-item__label:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .breadcrumb-item__prefix,
+  .breadcrumb-item__suffix {
+    display: none;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .breadcrumb-item--has-prefix .breadcrumb-item__prefix {
+    display: inline-flex;
+    margin-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .breadcrumb-item--has-suffix .breadcrumb-item__suffix {
+    display: inline-flex;
+    margin-inline-start: var(--sl-spacing-x-small);
+  }
+
+  :host(:last-of-type) .breadcrumb-item__separator {
+    display: none;
+  }
+
+  .breadcrumb-item__separator {
+    display: inline-flex;
+    align-items: center;
+    margin: 0 var(--sl-spacing-x-small);
+    user-select: none;
+  }
+`;
+
+// src/components/breadcrumb-item/breadcrumb-item.ts
+var SlBreadcrumbItem = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.hasSlotController = new HasSlotController(this, "prefix", "suffix");
+    this.rel = "noreferrer noopener";
+  }
+  render() {
+    const isLink = this.href ? true : false;
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      "breadcrumb-item": true,
+      "breadcrumb-item--has-prefix": this.hasSlotController.test("prefix"),
+      "breadcrumb-item--has-suffix": this.hasSlotController.test("suffix")
+    })}
+      >
+        <span part="prefix" class="breadcrumb-item__prefix">
+          <slot name="prefix"></slot>
+        </span>
+
+        ${isLink ? $`
+              <a
+                part="label"
+                class="breadcrumb-item__label breadcrumb-item__label--link"
+                href="${this.href}"
+                target="${l$2(this.target ? this.target : void 0)}"
+                rel=${l$2(this.target ? this.rel : void 0)}
+              >
+                <slot></slot>
+              </a>
+            ` : $`
+              <button part="label" type="button" class="breadcrumb-item__label breadcrumb-item__label--button">
+                <slot></slot>
+              </button>
+            `}
+
+        <span part="suffix" class="breadcrumb-item__suffix">
+          <slot name="suffix"></slot>
+        </span>
+
+        <span part="separator" class="breadcrumb-item__separator" aria-hidden="true">
+          <slot name="separator"></slot>
+        </span>
+      </div>
+    `;
+  }
+};
+SlBreadcrumbItem.styles = breadcrumb_item_styles_default;
+__decorateClass([
+  e$1()
+], SlBreadcrumbItem.prototype, "href", 2);
+__decorateClass([
+  e$1()
+], SlBreadcrumbItem.prototype, "target", 2);
+__decorateClass([
+  e$1()
+], SlBreadcrumbItem.prototype, "rel", 2);
+SlBreadcrumbItem = __decorateClass([
+  n$1("sl-breadcrumb-item")
+], SlBreadcrumbItem);
+
+// src/components/button-group/button-group.styles.ts
+var button_group_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .button-group {
+    display: flex;
+    flex-wrap: nowrap;
+  }
+`;
+
+// src/components/button-group/button-group.ts
+var SlButtonGroup = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.disableRole = false;
+    this.label = "";
+  }
+  handleFocus(event) {
+    const button = findButton(event.target);
+    button == null ? void 0 : button.classList.add("sl-button-group__button--focus");
+  }
+  handleBlur(event) {
+    const button = findButton(event.target);
+    button == null ? void 0 : button.classList.remove("sl-button-group__button--focus");
+  }
+  handleMouseOver(event) {
+    const button = findButton(event.target);
+    button == null ? void 0 : button.classList.add("sl-button-group__button--hover");
+  }
+  handleMouseOut(event) {
+    const button = findButton(event.target);
+    button == null ? void 0 : button.classList.remove("sl-button-group__button--hover");
+  }
+  handleSlotChange() {
+    const slottedElements = [...this.defaultSlot.assignedElements({ flatten: true })];
+    slottedElements.forEach((el) => {
+      const index = slottedElements.indexOf(el);
+      const button = findButton(el);
+      if (button !== null) {
+        button.classList.add("sl-button-group__button");
+        button.classList.toggle("sl-button-group__button--first", index === 0);
+        button.classList.toggle("sl-button-group__button--inner", index > 0 && index < slottedElements.length - 1);
+        button.classList.toggle("sl-button-group__button--last", index === slottedElements.length - 1);
+        button.classList.toggle("sl-button-group__button--radio", button.tagName.toLowerCase() === "sl-radio-button");
+      }
+    });
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class="button-group"
+        role="${this.disableRole ? "presentation" : "group"}"
+        aria-label=${this.label}
+        @focusout=${this.handleBlur}
+        @focusin=${this.handleFocus}
+        @mouseover=${this.handleMouseOver}
+        @mouseout=${this.handleMouseOut}
+      >
+        <slot @slotchange=${this.handleSlotChange} role="none"></slot>
+      </div>
+    `;
+  }
+};
+SlButtonGroup.styles = button_group_styles_default;
+__decorateClass([
+  i2$2("slot")
+], SlButtonGroup.prototype, "defaultSlot", 2);
+__decorateClass([
+  t$1()
+], SlButtonGroup.prototype, "disableRole", 2);
+__decorateClass([
+  e$1()
+], SlButtonGroup.prototype, "label", 2);
+SlButtonGroup = __decorateClass([
+  n$1("sl-button-group")
+], SlButtonGroup);
+function findButton(el) {
+  const children = ["sl-button", "sl-radio-button"];
+  return children.includes(el.tagName.toLowerCase()) ? el : el.querySelector(children.join(","));
+}
+
+// src/components/alert/alert.styles.ts
+var alert_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: contents;
+
+    /* For better DX, we'll reset the margin here so the base part can inherit it */
+    margin: 0;
+  }
+
+  .alert {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    background-color: var(--sl-panel-background-color);
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+    border-top-width: calc(var(--sl-panel-border-width) * 3);
+    border-radius: var(--sl-border-radius-medium);
+    box-shadow: var(--box-shadow);
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-small);
+    font-weight: var(--sl-font-weight-normal);
+    line-height: 1.6;
+    color: var(--sl-color-neutral-700);
+    margin: inherit;
+  }
+
+  .alert:not(.alert--has-icon) .alert__icon,
+  .alert:not(.alert--closable) .alert__close-button {
+    display: none;
+  }
+
+  .alert__icon {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    font-size: var(--sl-font-size-large);
+    padding-inline-start: var(--sl-spacing-large);
+  }
+
+  .alert--primary {
+    border-top-color: var(--sl-color-primary-600);
+  }
+
+  .alert--primary .alert__icon {
+    color: var(--sl-color-primary-600);
+  }
+
+  .alert--success {
+    border-top-color: var(--sl-color-success-600);
+  }
+
+  .alert--success .alert__icon {
+    color: var(--sl-color-success-600);
+  }
+
+  .alert--neutral {
+    border-top-color: var(--sl-color-neutral-600);
+  }
+
+  .alert--neutral .alert__icon {
+    color: var(--sl-color-neutral-600);
+  }
+
+  .alert--warning {
+    border-top-color: var(--sl-color-warning-600);
+  }
+
+  .alert--warning .alert__icon {
+    color: var(--sl-color-warning-600);
+  }
+
+  .alert--danger {
+    border-top-color: var(--sl-color-danger-600);
+  }
+
+  .alert--danger .alert__icon {
+    color: var(--sl-color-danger-600);
+  }
+
+  .alert__message {
+    flex: 1 1 auto;
+    padding: var(--sl-spacing-large);
+    overflow: hidden;
+  }
+
+  .alert__close-button {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    font-size: var(--sl-font-size-large);
+    padding-inline-end: var(--sl-spacing-medium);
+  }
+`;
+
+// src/components/alert/alert.ts
+var toastStack = Object.assign(document.createElement("div"), { className: "sl-toast-stack" });
+var SlAlert = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.hasSlotController = new HasSlotController(this, "icon", "suffix");
+    this.localize = new LocalizeController2(this);
+    this.open = false;
+    this.closable = false;
+    this.variant = "primary";
+    this.duration = Infinity;
+  }
+  firstUpdated() {
+    this.base.hidden = !this.open;
+  }
+  async show() {
+    if (this.open) {
+      return void 0;
+    }
+    this.open = true;
+    return waitForEvent(this, "sl-after-show");
+  }
+  async hide() {
+    if (!this.open) {
+      return void 0;
+    }
+    this.open = false;
+    return waitForEvent(this, "sl-after-hide");
+  }
+  async toast() {
+    return new Promise((resolve) => {
+      if (toastStack.parentElement === null) {
+        document.body.append(toastStack);
+      }
+      toastStack.appendChild(this);
+      requestAnimationFrame(() => {
+        this.clientWidth;
+        this.show();
+      });
+      this.addEventListener(
+        "sl-after-hide",
+        () => {
+          toastStack.removeChild(this);
+          resolve();
+          if (toastStack.querySelector("sl-alert") === null) {
+            toastStack.remove();
+          }
+        },
+        { once: true }
+      );
+    });
+  }
+  restartAutoHide() {
+    clearTimeout(this.autoHideTimeout);
+    if (this.open && this.duration < Infinity) {
+      this.autoHideTimeout = window.setTimeout(() => this.hide(), this.duration);
+    }
+  }
+  handleCloseClick() {
+    this.hide();
+  }
+  handleMouseMove() {
+    this.restartAutoHide();
+  }
+  async handleOpenChange() {
+    if (this.open) {
+      this.emit("sl-show");
+      if (this.duration < Infinity) {
+        this.restartAutoHide();
+      }
+      await stopAnimations(this.base);
+      this.base.hidden = false;
+      const { keyframes, options } = getAnimation(this, "alert.show", { dir: this.localize.dir() });
+      await animateTo(this.base, keyframes, options);
+      this.emit("sl-after-show");
+    } else {
+      this.emit("sl-hide");
+      clearTimeout(this.autoHideTimeout);
+      await stopAnimations(this.base);
+      const { keyframes, options } = getAnimation(this, "alert.hide", { dir: this.localize.dir() });
+      await animateTo(this.base, keyframes, options);
+      this.base.hidden = true;
+      this.emit("sl-after-hide");
+    }
+  }
+  handleDurationChange() {
+    this.restartAutoHide();
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      alert: true,
+      "alert--open": this.open,
+      "alert--closable": this.closable,
+      "alert--has-icon": this.hasSlotController.test("icon"),
+      "alert--primary": this.variant === "primary",
+      "alert--success": this.variant === "success",
+      "alert--neutral": this.variant === "neutral",
+      "alert--warning": this.variant === "warning",
+      "alert--danger": this.variant === "danger"
+    })}
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+        aria-hidden=${this.open ? "false" : "true"}
+        @mousemove=${this.handleMouseMove}
+      >
+        <span part="icon" class="alert__icon">
+          <slot name="icon"></slot>
+        </span>
+
+        <span part="message" class="alert__message">
+          <slot></slot>
+        </span>
+
+        ${this.closable ? $`
+              <sl-icon-button
+                part="close-button"
+                exportparts="base:close-button__base"
+                class="alert__close-button"
+                name="x"
+                library="system"
+                @click=${this.handleCloseClick}
+              ></sl-icon-button>
+            ` : ""}
+      </div>
+    `;
+  }
+};
+SlAlert.styles = alert_styles_default;
+__decorateClass([
+  i2$2('[part="base"]')
+], SlAlert.prototype, "base", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlAlert.prototype, "open", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlAlert.prototype, "closable", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlAlert.prototype, "variant", 2);
+__decorateClass([
+  e$1({ type: Number })
+], SlAlert.prototype, "duration", 2);
+__decorateClass([
+  watch("open", { waitUntilFirstUpdate: true })
+], SlAlert.prototype, "handleOpenChange", 1);
+__decorateClass([
+  watch("duration")
+], SlAlert.prototype, "handleDurationChange", 1);
+SlAlert = __decorateClass([
+  n$1("sl-alert")
+], SlAlert);
+setDefaultAnimation("alert.show", {
+  keyframes: [
+    { opacity: 0, transform: "scale(0.8)" },
+    { opacity: 1, transform: "scale(1)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+setDefaultAnimation("alert.hide", {
+  keyframes: [
+    { opacity: 1, transform: "scale(1)" },
+    { opacity: 0, transform: "scale(0.8)" }
+  ],
+  options: { duration: 250, easing: "ease" }
+});
+
+// src/components/icon-button/icon-button.styles.ts
+var icon_button_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .icon-button {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    background: none;
+    border: none;
+    border-radius: var(--sl-border-radius-medium);
+    font-size: inherit;
+    color: var(--sl-color-neutral-600);
+    padding: var(--sl-spacing-x-small);
+    cursor: pointer;
+    transition: var(--sl-transition-medium) color;
+    -webkit-appearance: none;
+  }
+
+  .icon-button:hover:not(.icon-button--disabled),
+  .icon-button:focus:not(.icon-button--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  .icon-button:active:not(.icon-button--disabled) {
+    color: var(--sl-color-primary-700);
+  }
+
+  .icon-button:focus {
+    outline: none;
+  }
+
+  .icon-button--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .icon-button:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .icon-button__icon {
+    pointer-events: none;
+  }
+`;
+
+// src/components/icon-button/icon-button.ts
+var SlIconButton = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.hasFocus = false;
+    this.label = "";
+    this.disabled = false;
+  }
+  click() {
+    this.button.click();
+  }
+  focus(options) {
+    this.button.focus(options);
+  }
+  blur() {
+    this.button.blur();
+  }
+  handleBlur() {
+    this.hasFocus = false;
+    this.emit("sl-blur");
+  }
+  handleFocus() {
+    this.hasFocus = true;
+    this.emit("sl-focus");
+  }
+  handleClick(event) {
+    if (this.disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+  render() {
+    const isLink = this.href ? true : false;
+    const tag = isLink ? l$1`a` : l$1`button`;
+    return n`
+      <${tag}
+        part="base"
+        class=${o$3({
+      "icon-button": true,
+      "icon-button--disabled": !isLink && this.disabled,
+      "icon-button--focused": this.hasFocus
+    })}
+        ?disabled=${l$2(isLink ? void 0 : this.disabled)}
+        type=${l$2(isLink ? void 0 : "button")}
+        href=${l$2(isLink ? this.href : void 0)}
+        target=${l$2(isLink ? this.target : void 0)}
+        download=${l$2(isLink ? this.download : void 0)}
+        rel=${l$2(isLink && this.target ? "noreferrer noopener" : void 0)}
+        role=${l$2(isLink ? void 0 : "button")}
+        aria-disabled=${this.disabled ? "true" : "false"}
+        aria-label="${this.label}"
+        tabindex=${this.disabled ? "-1" : "0"}
+        @blur=${this.handleBlur}
+        @focus=${this.handleFocus}
+        @click=${this.handleClick}
+      >
+        <sl-icon
+          class="icon-button__icon"
+          name=${l$2(this.name)}
+          library=${l$2(this.library)}
+          src=${l$2(this.src)}
+          aria-hidden="true"
+        ></sl-icon>
+      </${tag}>
+    `;
+  }
+};
+SlIconButton.styles = icon_button_styles_default;
+__decorateClass([
+  t$1()
+], SlIconButton.prototype, "hasFocus", 2);
+__decorateClass([
+  i2$2(".icon-button")
+], SlIconButton.prototype, "button", 2);
+__decorateClass([
+  e$1()
+], SlIconButton.prototype, "name", 2);
+__decorateClass([
+  e$1()
+], SlIconButton.prototype, "library", 2);
+__decorateClass([
+  e$1()
+], SlIconButton.prototype, "src", 2);
+__decorateClass([
+  e$1()
+], SlIconButton.prototype, "href", 2);
+__decorateClass([
+  e$1()
+], SlIconButton.prototype, "target", 2);
+__decorateClass([
+  e$1()
+], SlIconButton.prototype, "download", 2);
+__decorateClass([
+  e$1()
+], SlIconButton.prototype, "label", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlIconButton.prototype, "disabled", 2);
+SlIconButton = __decorateClass([
+  n$1("sl-icon-button")
+], SlIconButton);
+
+// src/components/animated-image/animated-image.styles.ts
+var animated_image_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --control-box-size: 3rem;
+    --icon-size: calc(var(--control-box-size) * 0.625);
+    display: inline-flex;
+    position: relative;
+    cursor: pointer;
+  }
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  img[aria-hidden='true'] {
+    display: none;
+  }
+
+  .animated-image__control-box {
+    display: flex;
+    position: absolute;
+    align-items: center;
+    justify-content: center;
+    top: calc(50% - var(--control-box-size) / 2);
+    right: calc(50% - var(--control-box-size) / 2);
+    width: var(--control-box-size);
+    height: var(--control-box-size);
+    font-size: var(--icon-size);
+    background: none;
+    border: solid 2px currentColor;
+    background-color: rgb(0 0 0 /50%);
+    border-radius: var(--sl-border-radius-circle);
+    color: white;
+    pointer-events: none;
+    transition: var(--sl-transition-fast) opacity;
+  }
+
+  :host([play]:hover) .animated-image__control-box {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  :host([play]:not(:hover)) .animated-image__control-box {
+    opacity: 0;
+  }
+`;
+
+// src/components/animated-image/animated-image.ts
+var SlAnimatedImage = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.isLoaded = false;
+  }
+  handleClick() {
+    this.play = !this.play;
+  }
+  handleLoad() {
+    const canvas = document.createElement("canvas");
+    const { width, height } = this.animatedImage;
+    canvas.width = width;
+    canvas.height = height;
+    canvas.getContext("2d").drawImage(this.animatedImage, 0, 0, width, height);
+    this.frozenFrame = canvas.toDataURL("image/gif");
+    if (!this.isLoaded) {
+      this.emit("sl-load");
+      this.isLoaded = true;
+    }
+  }
+  handleError() {
+    this.emit("sl-error");
+  }
+  handlePlayChange() {
+    if (this.play) {
+      this.animatedImage.src = "";
+      this.animatedImage.src = this.src;
+    }
+  }
+  handleSrcChange() {
+    this.isLoaded = false;
+  }
+  render() {
+    return $`
+      <div class="animated-image">
+        <img
+          class="animated-image__animated"
+          src=${this.src}
+          alt=${this.alt}
+          crossorigin="anonymous"
+          aria-hidden=${this.play ? "false" : "true"}
+          @click=${this.handleClick}
+          @load=${this.handleLoad}
+          @error=${this.handleError}
+        />
+
+        ${this.isLoaded ? $`
+              <img
+                class="animated-image__frozen"
+                src=${this.frozenFrame}
+                alt=${this.alt}
+                aria-hidden=${this.play ? "true" : "false"}
+                @click=${this.handleClick}
+              />
+
+              <div part="control-box" class="animated-image__control-box">
+                ${this.play ? $`<sl-icon part="pause-icon" name="pause-fill" library="system"></sl-icon>` : $`<sl-icon part="play-icon" name="play-fill" library="system"></sl-icon>`}
+              </div>
+            ` : ""}
+      </div>
+    `;
+  }
+};
+SlAnimatedImage.styles = animated_image_styles_default;
+__decorateClass([
+  t$1()
+], SlAnimatedImage.prototype, "frozenFrame", 2);
+__decorateClass([
+  t$1()
+], SlAnimatedImage.prototype, "isLoaded", 2);
+__decorateClass([
+  i2$2(".animated-image__animated")
+], SlAnimatedImage.prototype, "animatedImage", 2);
+__decorateClass([
+  e$1()
+], SlAnimatedImage.prototype, "src", 2);
+__decorateClass([
+  e$1()
+], SlAnimatedImage.prototype, "alt", 2);
+__decorateClass([
+  e$1({ type: Boolean, reflect: true })
+], SlAnimatedImage.prototype, "play", 2);
+__decorateClass([
+  watch("play", { waitUntilFirstUpdate: true })
+], SlAnimatedImage.prototype, "handlePlayChange", 1);
+__decorateClass([
+  watch("src")
+], SlAnimatedImage.prototype, "handleSrcChange", 1);
+SlAnimatedImage = __decorateClass([
+  n$1("sl-animated-image")
+], SlAnimatedImage);
+
+// src/components/avatar/avatar.styles.ts
+var avatar_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+
+    --size: 3rem;
+  }
+
+  .avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    width: var(--size);
+    height: var(--size);
+    background-color: var(--sl-color-neutral-400);
+    font-family: var(--sl-font-sans);
+    font-size: calc(var(--size) * 0.5);
+    font-weight: var(--sl-font-weight-normal);
+    color: var(--sl-color-neutral-0);
+    user-select: none;
+    vertical-align: middle;
+  }
+
+  .avatar--circle,
+  .avatar--circle .avatar__image {
+    border-radius: var(--sl-border-radius-circle);
+  }
+
+  .avatar--rounded,
+  .avatar--rounded .avatar__image {
+    border-radius: var(--sl-border-radius-medium);
+  }
+
+  .avatar--square {
+    border-radius: 0;
+  }
+
+  .avatar__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .avatar__initials {
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .avatar__image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    overflow: hidden;
+  }
+`;
+
+// src/components/avatar/avatar.ts
+var SlAvatar = class extends ShoelaceElement {
+  constructor() {
+    super(...arguments);
+    this.hasError = false;
+    this.image = "";
+    this.label = "";
+    this.initials = "";
+    this.shape = "circle";
+  }
+  handleImageChange() {
+    this.hasError = false;
+  }
+  render() {
+    return $`
+      <div
+        part="base"
+        class=${o$3({
+      avatar: true,
+      "avatar--circle": this.shape === "circle",
+      "avatar--rounded": this.shape === "rounded",
+      "avatar--square": this.shape === "square"
+    })}
+        role="img"
+        aria-label=${this.label}
+      >
+        ${this.initials ? $` <div part="initials" class="avatar__initials">${this.initials}</div> ` : $`
+              <div part="icon" class="avatar__icon" aria-hidden="true">
+                <slot name="icon">
+                  <sl-icon name="person-fill" library="system"></sl-icon>
+                </slot>
+              </div>
+            `}
+        ${this.image && !this.hasError ? $`
+              <img
+                part="image"
+                class="avatar__image"
+                src="${this.image}"
+                alt=""
+                @error="${() => this.hasError = true}"
+              />
+            ` : ""}
+      </div>
+    `;
+  }
+};
+SlAvatar.styles = avatar_styles_default;
+__decorateClass([
+  t$1()
+], SlAvatar.prototype, "hasError", 2);
+__decorateClass([
+  e$1()
+], SlAvatar.prototype, "image", 2);
+__decorateClass([
+  e$1()
+], SlAvatar.prototype, "label", 2);
+__decorateClass([
+  e$1()
+], SlAvatar.prototype, "initials", 2);
+__decorateClass([
+  e$1({ reflect: true })
+], SlAvatar.prototype, "shape", 2);
+__decorateClass([
+  watch("image")
+], SlAvatar.prototype, "handleImageChange", 1);
+SlAvatar = __decorateClass([
+  n$1("sl-avatar")
+], SlAvatar);
+
 /*
 Stimulus 3.1.0
 Copyright © 2022 Basecamp, LLC

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,511 +1,18858 @@
 (function (global, factory) {
-    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
-    typeof define === 'function' && define.amd ? define(['exports'], factory) :
-    (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.TeamsharesUI = {}));
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.TeamsharesUI = {}));
 })(this, (function (exports) { 'use strict';
 
-    /*
-    Stimulus 3.1.0
-    Copyright © 2022 Basecamp, LLC
-     */
+  // node_modules/@lit/reactive-element/css-tag.js
+  var t$3 = window.ShadowRoot && (void 0 === window.ShadyCSS || window.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype;
+  var e$3 = Symbol();
+  var n$2 = /* @__PURE__ */ new Map();
+  var s$3 = class {
+    constructor(t3, n5) {
+      if (this._$cssResult$ = true, n5 !== e$3)
+        throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+      this.cssText = t3;
+    }
+    get styleSheet() {
+      let e4 = n$2.get(this.cssText);
+      return t$3 && void 0 === e4 && (n$2.set(this.cssText, e4 = new CSSStyleSheet()), e4.replaceSync(this.cssText)), e4;
+    }
+    toString() {
+      return this.cssText;
+    }
+  };
+  var o$4 = (t3) => new s$3("string" == typeof t3 ? t3 : t3 + "", e$3);
+  var r$2 = (t3, ...n5) => {
+    const o5 = 1 === t3.length ? t3[0] : n5.reduce((e4, n6, s5) => e4 + ((t4) => {
+      if (true === t4._$cssResult$)
+        return t4.cssText;
+      if ("number" == typeof t4)
+        return t4;
+      throw Error("Value passed to 'css' function must be a 'css' function result: " + t4 + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
+    })(n6) + t3[s5 + 1], t3[0]);
+    return new s$3(o5, e$3);
+  };
+  var i$2 = (e4, n5) => {
+    t$3 ? e4.adoptedStyleSheets = n5.map((t3) => t3 instanceof CSSStyleSheet ? t3 : t3.styleSheet) : n5.forEach((t3) => {
+      const n6 = document.createElement("style"), s5 = window.litNonce;
+      void 0 !== s5 && n6.setAttribute("nonce", s5), n6.textContent = t3.cssText, e4.appendChild(n6);
+    });
+  };
+  var S$1 = t$3 ? (t3) => t3 : (t3) => t3 instanceof CSSStyleSheet ? ((t4) => {
+    let e4 = "";
+    for (const n5 of t4.cssRules)
+      e4 += n5.cssText;
+    return o$4(e4);
+  })(t3) : t3;
 
-    function camelize(value) {
-        return value.replace(/(?:[_-])([a-z0-9])/g, (_, char) => char.toUpperCase());
+  // node_modules/@lit/reactive-element/reactive-element.js
+  var s2$1;
+  var e2$2 = window.trustedTypes;
+  var r2$1 = e2$2 ? e2$2.emptyScript : "";
+  var h$1 = window.reactiveElementPolyfillSupport;
+  var o2$2 = { toAttribute(t3, i3) {
+    switch (i3) {
+      case Boolean:
+        t3 = t3 ? r2$1 : null;
+        break;
+      case Object:
+      case Array:
+        t3 = null == t3 ? t3 : JSON.stringify(t3);
     }
-    function capitalize(value) {
-        return value.charAt(0).toUpperCase() + value.slice(1);
-    }
-    function dasherize(value) {
-        return value.replace(/([A-Z])/g, (_, char) => `-${char.toLowerCase()}`);
-    }
-
-    function readInheritableStaticArrayValues(constructor, propertyName) {
-        const ancestors = getAncestorsForConstructor(constructor);
-        return Array.from(ancestors.reduce((values, constructor) => {
-            getOwnStaticArrayValues(constructor, propertyName).forEach(name => values.add(name));
-            return values;
-        }, new Set));
-    }
-    function readInheritableStaticObjectPairs(constructor, propertyName) {
-        const ancestors = getAncestorsForConstructor(constructor);
-        return ancestors.reduce((pairs, constructor) => {
-            pairs.push(...getOwnStaticObjectPairs(constructor, propertyName));
-            return pairs;
-        }, []);
-    }
-    function getAncestorsForConstructor(constructor) {
-        const ancestors = [];
-        while (constructor) {
-            ancestors.push(constructor);
-            constructor = Object.getPrototypeOf(constructor);
-        }
-        return ancestors.reverse();
-    }
-    function getOwnStaticArrayValues(constructor, propertyName) {
-        const definition = constructor[propertyName];
-        return Array.isArray(definition) ? definition : [];
-    }
-    function getOwnStaticObjectPairs(constructor, propertyName) {
-        const definition = constructor[propertyName];
-        return definition ? Object.keys(definition).map(key => [key, definition[key]]) : [];
-    }
-    (() => {
-        function extendWithReflect(constructor) {
-            function extended() {
-                return Reflect.construct(constructor, arguments, new.target);
-            }
-            extended.prototype = Object.create(constructor.prototype, {
-                constructor: { value: extended }
-            });
-            Reflect.setPrototypeOf(extended, constructor);
-            return extended;
-        }
-        function testReflectExtension() {
-            const a = function () { this.a.call(this); };
-            const b = extendWithReflect(a);
-            b.prototype.a = function () { };
-            return new b;
-        }
+    return t3;
+  }, fromAttribute(t3, i3) {
+    let s5 = t3;
+    switch (i3) {
+      case Boolean:
+        s5 = null !== t3;
+        break;
+      case Number:
+        s5 = null === t3 ? null : Number(t3);
+        break;
+      case Object:
+      case Array:
         try {
-            testReflectExtension();
-            return extendWithReflect;
-        }
-        catch (error) {
-            return (constructor) => class extended extends constructor {
-            };
-        }
-    })();
-
-    function ClassPropertiesBlessing(constructor) {
-        const classes = readInheritableStaticArrayValues(constructor, "classes");
-        return classes.reduce((properties, classDefinition) => {
-            return Object.assign(properties, propertiesForClassDefinition(classDefinition));
-        }, {});
-    }
-    function propertiesForClassDefinition(key) {
-        return {
-            [`${key}Class`]: {
-                get() {
-                    const { classes } = this;
-                    if (classes.has(key)) {
-                        return classes.get(key);
-                    }
-                    else {
-                        const attribute = classes.getAttributeName(key);
-                        throw new Error(`Missing attribute "${attribute}"`);
-                    }
-                }
-            },
-            [`${key}Classes`]: {
-                get() {
-                    return this.classes.getAll(key);
-                }
-            },
-            [`has${capitalize(key)}Class`]: {
-                get() {
-                    return this.classes.has(key);
-                }
-            }
-        };
-    }
-
-    function TargetPropertiesBlessing(constructor) {
-        const targets = readInheritableStaticArrayValues(constructor, "targets");
-        return targets.reduce((properties, targetDefinition) => {
-            return Object.assign(properties, propertiesForTargetDefinition(targetDefinition));
-        }, {});
-    }
-    function propertiesForTargetDefinition(name) {
-        return {
-            [`${name}Target`]: {
-                get() {
-                    const target = this.targets.find(name);
-                    if (target) {
-                        return target;
-                    }
-                    else {
-                        throw new Error(`Missing target element "${name}" for "${this.identifier}" controller`);
-                    }
-                }
-            },
-            [`${name}Targets`]: {
-                get() {
-                    return this.targets.findAll(name);
-                }
-            },
-            [`has${capitalize(name)}Target`]: {
-                get() {
-                    return this.targets.has(name);
-                }
-            }
-        };
-    }
-
-    function ValuePropertiesBlessing(constructor) {
-        const valueDefinitionPairs = readInheritableStaticObjectPairs(constructor, "values");
-        const propertyDescriptorMap = {
-            valueDescriptorMap: {
-                get() {
-                    return valueDefinitionPairs.reduce((result, valueDefinitionPair) => {
-                        const valueDescriptor = parseValueDefinitionPair(valueDefinitionPair, this.identifier);
-                        const attributeName = this.data.getAttributeNameForKey(valueDescriptor.key);
-                        return Object.assign(result, { [attributeName]: valueDescriptor });
-                    }, {});
-                }
-            }
-        };
-        return valueDefinitionPairs.reduce((properties, valueDefinitionPair) => {
-            return Object.assign(properties, propertiesForValueDefinitionPair(valueDefinitionPair));
-        }, propertyDescriptorMap);
-    }
-    function propertiesForValueDefinitionPair(valueDefinitionPair, controller) {
-        const definition = parseValueDefinitionPair(valueDefinitionPair, controller);
-        const { key, name, reader: read, writer: write } = definition;
-        return {
-            [name]: {
-                get() {
-                    const value = this.data.get(key);
-                    if (value !== null) {
-                        return read(value);
-                    }
-                    else {
-                        return definition.defaultValue;
-                    }
-                },
-                set(value) {
-                    if (value === undefined) {
-                        this.data.delete(key);
-                    }
-                    else {
-                        this.data.set(key, write(value));
-                    }
-                }
-            },
-            [`has${capitalize(name)}`]: {
-                get() {
-                    return this.data.has(key) || definition.hasCustomDefaultValue;
-                }
-            }
-        };
-    }
-    function parseValueDefinitionPair([token, typeDefinition], controller) {
-        return valueDescriptorForTokenAndTypeDefinition({
-            controller,
-            token,
-            typeDefinition,
-        });
-    }
-    function parseValueTypeConstant(constant) {
-        switch (constant) {
-            case Array: return "array";
-            case Boolean: return "boolean";
-            case Number: return "number";
-            case Object: return "object";
-            case String: return "string";
+          s5 = JSON.parse(t3);
+        } catch (t4) {
+          s5 = null;
         }
     }
-    function parseValueTypeDefault(defaultValue) {
-        switch (typeof defaultValue) {
-            case "boolean": return "boolean";
-            case "number": return "number";
-            case "string": return "string";
-        }
-        if (Array.isArray(defaultValue))
-            return "array";
-        if (Object.prototype.toString.call(defaultValue) === "[object Object]")
-            return "object";
+    return s5;
+  } };
+  var n2$3 = (t3, i3) => i3 !== t3 && (i3 == i3 || t3 == t3);
+  var l$4 = { attribute: true, type: String, converter: o2$2, reflect: false, hasChanged: n2$3 };
+  var a$2 = class extends HTMLElement {
+    constructor() {
+      super(), this._$Et = /* @__PURE__ */ new Map(), this.isUpdatePending = false, this.hasUpdated = false, this._$Ei = null, this.o();
     }
-    function parseValueTypeObject(payload) {
-        const typeFromObject = parseValueTypeConstant(payload.typeObject.type);
-        if (!typeFromObject)
-            return;
-        const defaultValueType = parseValueTypeDefault(payload.typeObject.default);
-        if (typeFromObject !== defaultValueType) {
-            const propertyPath = payload.controller ? `${payload.controller}.${payload.token}` : payload.token;
-            throw new Error(`The specified default value for the Stimulus Value "${propertyPath}" must match the defined type "${typeFromObject}". The provided default value of "${payload.typeObject.default}" is of type "${defaultValueType}".`);
-        }
-        return typeFromObject;
+    static addInitializer(t3) {
+      var i3;
+      null !== (i3 = this.l) && void 0 !== i3 || (this.l = []), this.l.push(t3);
     }
-    function parseValueTypeDefinition(payload) {
-        const typeFromObject = parseValueTypeObject({
-            controller: payload.controller,
-            token: payload.token,
-            typeObject: payload.typeDefinition
-        });
-        const typeFromDefaultValue = parseValueTypeDefault(payload.typeDefinition);
-        const typeFromConstant = parseValueTypeConstant(payload.typeDefinition);
-        const type = typeFromObject || typeFromDefaultValue || typeFromConstant;
-        if (type)
-            return type;
-        const propertyPath = payload.controller ? `${payload.controller}.${payload.typeDefinition}` : payload.token;
-        throw new Error(`Unknown value type "${propertyPath}" for "${payload.token}" value`);
+    static get observedAttributes() {
+      this.finalize();
+      const t3 = [];
+      return this.elementProperties.forEach((i3, s5) => {
+        const e4 = this._$Eh(s5, i3);
+        void 0 !== e4 && (this._$Eu.set(e4, s5), t3.push(e4));
+      }), t3;
     }
-    function defaultValueForDefinition(typeDefinition) {
-        const constant = parseValueTypeConstant(typeDefinition);
-        if (constant)
-            return defaultValuesByType[constant];
-        const defaultValue = typeDefinition.default;
-        if (defaultValue !== undefined)
-            return defaultValue;
-        return typeDefinition;
-    }
-    function valueDescriptorForTokenAndTypeDefinition(payload) {
-        const key = `${dasherize(payload.token)}-value`;
-        const type = parseValueTypeDefinition(payload);
-        return {
-            type,
-            key,
-            name: camelize(key),
-            get defaultValue() { return defaultValueForDefinition(payload.typeDefinition); },
-            get hasCustomDefaultValue() { return parseValueTypeDefault(payload.typeDefinition) !== undefined; },
-            reader: readers[type],
-            writer: writers[type] || writers.default
-        };
-    }
-    const defaultValuesByType = {
-        get array() { return []; },
-        boolean: false,
-        number: 0,
-        get object() { return {}; },
-        string: ""
-    };
-    const readers = {
-        array(value) {
-            const array = JSON.parse(value);
-            if (!Array.isArray(array)) {
-                throw new TypeError(`expected value of type "array" but instead got value "${value}" of type "${parseValueTypeDefault(array)}"`);
-            }
-            return array;
-        },
-        boolean(value) {
-            return !(value == "0" || String(value).toLowerCase() == "false");
-        },
-        number(value) {
-            return Number(value);
-        },
-        object(value) {
-            const object = JSON.parse(value);
-            if (object === null || typeof object != "object" || Array.isArray(object)) {
-                throw new TypeError(`expected value of type "object" but instead got value "${value}" of type "${parseValueTypeDefault(object)}"`);
-            }
-            return object;
-        },
-        string(value) {
-            return value;
-        }
-    };
-    const writers = {
-        default: writeString,
-        array: writeJSON,
-        object: writeJSON
-    };
-    function writeJSON(value) {
-        return JSON.stringify(value);
-    }
-    function writeString(value) {
-        return `${value}`;
-    }
-
-    class Controller {
-        constructor(context) {
-            this.context = context;
-        }
-        static get shouldLoad() {
-            return true;
-        }
-        get application() {
-            return this.context.application;
-        }
-        get scope() {
-            return this.context.scope;
-        }
-        get element() {
-            return this.scope.element;
-        }
-        get identifier() {
-            return this.scope.identifier;
-        }
-        get targets() {
-            return this.scope.targets;
-        }
-        get classes() {
-            return this.scope.classes;
-        }
-        get data() {
-            return this.scope.data;
-        }
-        initialize() {
-        }
-        connect() {
-        }
-        disconnect() {
-        }
-        dispatch(eventName, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true } = {}) {
-            const type = prefix ? `${prefix}:${eventName}` : eventName;
-            const event = new CustomEvent(type, { detail, bubbles, cancelable });
-            target.dispatchEvent(event);
-            return event;
-        }
-    }
-    Controller.blessings = [ClassPropertiesBlessing, TargetPropertiesBlessing, ValuePropertiesBlessing];
-    Controller.targets = [];
-    Controller.values = {};
-
-    class input_clipboard_controller extends Controller {
-      copy(_event) {
-        const clipboardCopyEl = this.element;
-        clipboardCopyEl.classList.add("clicked");
-        setTimeout(() => {
-          clipboardCopyEl.classList.remove("clicked");
-        }, 5000);
+    static createProperty(t3, i3 = l$4) {
+      if (i3.state && (i3.attribute = false), this.finalize(), this.elementProperties.set(t3, i3), !i3.noAccessor && !this.prototype.hasOwnProperty(t3)) {
+        const s5 = "symbol" == typeof t3 ? Symbol() : "__" + t3, e4 = this.getPropertyDescriptor(t3, s5, i3);
+        void 0 !== e4 && Object.defineProperty(this.prototype, t3, e4);
       }
-
     }
-
-    const Inputmask = require("inputmask").default;
-
-    class input_mask_controller extends Controller {
-      connect() {
-        Inputmask(this.data.get("pattern")).mask(this.element);
+    static getPropertyDescriptor(t3, i3, s5) {
+      return { get() {
+        return this[i3];
+      }, set(e4) {
+        const r4 = this[t3];
+        this[i3] = e4, this.requestUpdate(t3, r4, s5);
+      }, configurable: true, enumerable: true };
+    }
+    static getPropertyOptions(t3) {
+      return this.elementProperties.get(t3) || l$4;
+    }
+    static finalize() {
+      if (this.hasOwnProperty("finalized"))
+        return false;
+      this.finalized = true;
+      const t3 = Object.getPrototypeOf(this);
+      if (t3.finalize(), this.elementProperties = new Map(t3.elementProperties), this._$Eu = /* @__PURE__ */ new Map(), this.hasOwnProperty("properties")) {
+        const t4 = this.properties, i3 = [...Object.getOwnPropertyNames(t4), ...Object.getOwnPropertySymbols(t4)];
+        for (const s5 of i3)
+          this.createProperty(s5, t4[s5]);
       }
-
+      return this.elementStyles = this.finalizeStyles(this.styles), true;
     }
+    static finalizeStyles(i3) {
+      const s5 = [];
+      if (Array.isArray(i3)) {
+        const e4 = new Set(i3.flat(1 / 0).reverse());
+        for (const i4 of e4)
+          s5.unshift(S$1(i4));
+      } else
+        void 0 !== i3 && s5.push(S$1(i3));
+      return s5;
+    }
+    static _$Eh(t3, i3) {
+      const s5 = i3.attribute;
+      return false === s5 ? void 0 : "string" == typeof s5 ? s5 : "string" == typeof t3 ? t3.toLowerCase() : void 0;
+    }
+    o() {
+      var t3;
+      this._$Ep = new Promise((t4) => this.enableUpdating = t4), this._$AL = /* @__PURE__ */ new Map(), this._$Em(), this.requestUpdate(), null === (t3 = this.constructor.l) || void 0 === t3 || t3.forEach((t4) => t4(this));
+    }
+    addController(t3) {
+      var i3, s5;
+      (null !== (i3 = this._$Eg) && void 0 !== i3 ? i3 : this._$Eg = []).push(t3), void 0 !== this.renderRoot && this.isConnected && (null === (s5 = t3.hostConnected) || void 0 === s5 || s5.call(t3));
+    }
+    removeController(t3) {
+      var i3;
+      null === (i3 = this._$Eg) || void 0 === i3 || i3.splice(this._$Eg.indexOf(t3) >>> 0, 1);
+    }
+    _$Em() {
+      this.constructor.elementProperties.forEach((t3, i3) => {
+        this.hasOwnProperty(i3) && (this._$Et.set(i3, this[i3]), delete this[i3]);
+      });
+    }
+    createRenderRoot() {
+      var t3;
+      const s5 = null !== (t3 = this.shadowRoot) && void 0 !== t3 ? t3 : this.attachShadow(this.constructor.shadowRootOptions);
+      return i$2(s5, this.constructor.elementStyles), s5;
+    }
+    connectedCallback() {
+      var t3;
+      void 0 === this.renderRoot && (this.renderRoot = this.createRenderRoot()), this.enableUpdating(true), null === (t3 = this._$Eg) || void 0 === t3 || t3.forEach((t4) => {
+        var i3;
+        return null === (i3 = t4.hostConnected) || void 0 === i3 ? void 0 : i3.call(t4);
+      });
+    }
+    enableUpdating(t3) {
+    }
+    disconnectedCallback() {
+      var t3;
+      null === (t3 = this._$Eg) || void 0 === t3 || t3.forEach((t4) => {
+        var i3;
+        return null === (i3 = t4.hostDisconnected) || void 0 === i3 ? void 0 : i3.call(t4);
+      });
+    }
+    attributeChangedCallback(t3, i3, s5) {
+      this._$AK(t3, s5);
+    }
+    _$ES(t3, i3, s5 = l$4) {
+      var e4, r4;
+      const h3 = this.constructor._$Eh(t3, s5);
+      if (void 0 !== h3 && true === s5.reflect) {
+        const n5 = (null !== (r4 = null === (e4 = s5.converter) || void 0 === e4 ? void 0 : e4.toAttribute) && void 0 !== r4 ? r4 : o2$2.toAttribute)(i3, s5.type);
+        this._$Ei = t3, null == n5 ? this.removeAttribute(h3) : this.setAttribute(h3, n5), this._$Ei = null;
+      }
+    }
+    _$AK(t3, i3) {
+      var s5, e4, r4;
+      const h3 = this.constructor, n5 = h3._$Eu.get(t3);
+      if (void 0 !== n5 && this._$Ei !== n5) {
+        const t4 = h3.getPropertyOptions(n5), l4 = t4.converter, a3 = null !== (r4 = null !== (e4 = null === (s5 = l4) || void 0 === s5 ? void 0 : s5.fromAttribute) && void 0 !== e4 ? e4 : "function" == typeof l4 ? l4 : null) && void 0 !== r4 ? r4 : o2$2.fromAttribute;
+        this._$Ei = n5, this[n5] = a3(i3, t4.type), this._$Ei = null;
+      }
+    }
+    requestUpdate(t3, i3, s5) {
+      let e4 = true;
+      void 0 !== t3 && (((s5 = s5 || this.constructor.getPropertyOptions(t3)).hasChanged || n2$3)(this[t3], i3) ? (this._$AL.has(t3) || this._$AL.set(t3, i3), true === s5.reflect && this._$Ei !== t3 && (void 0 === this._$EC && (this._$EC = /* @__PURE__ */ new Map()), this._$EC.set(t3, s5))) : e4 = false), !this.isUpdatePending && e4 && (this._$Ep = this._$E_());
+    }
+    async _$E_() {
+      this.isUpdatePending = true;
+      try {
+        await this._$Ep;
+      } catch (t4) {
+        Promise.reject(t4);
+      }
+      const t3 = this.scheduleUpdate();
+      return null != t3 && await t3, !this.isUpdatePending;
+    }
+    scheduleUpdate() {
+      return this.performUpdate();
+    }
+    performUpdate() {
+      var t3;
+      if (!this.isUpdatePending)
+        return;
+      this.hasUpdated, this._$Et && (this._$Et.forEach((t4, i4) => this[i4] = t4), this._$Et = void 0);
+      let i3 = false;
+      const s5 = this._$AL;
+      try {
+        i3 = this.shouldUpdate(s5), i3 ? (this.willUpdate(s5), null === (t3 = this._$Eg) || void 0 === t3 || t3.forEach((t4) => {
+          var i4;
+          return null === (i4 = t4.hostUpdate) || void 0 === i4 ? void 0 : i4.call(t4);
+        }), this.update(s5)) : this._$EU();
+      } catch (t4) {
+        throw i3 = false, this._$EU(), t4;
+      }
+      i3 && this._$AE(s5);
+    }
+    willUpdate(t3) {
+    }
+    _$AE(t3) {
+      var i3;
+      null === (i3 = this._$Eg) || void 0 === i3 || i3.forEach((t4) => {
+        var i4;
+        return null === (i4 = t4.hostUpdated) || void 0 === i4 ? void 0 : i4.call(t4);
+      }), this.hasUpdated || (this.hasUpdated = true, this.firstUpdated(t3)), this.updated(t3);
+    }
+    _$EU() {
+      this._$AL = /* @__PURE__ */ new Map(), this.isUpdatePending = false;
+    }
+    get updateComplete() {
+      return this.getUpdateComplete();
+    }
+    getUpdateComplete() {
+      return this._$Ep;
+    }
+    shouldUpdate(t3) {
+      return true;
+    }
+    update(t3) {
+      void 0 !== this._$EC && (this._$EC.forEach((t4, i3) => this._$ES(i3, this[i3], t4)), this._$EC = void 0), this._$EU();
+    }
+    updated(t3) {
+    }
+    firstUpdated(t3) {
+    }
+  };
+  a$2.finalized = true, a$2.elementProperties = /* @__PURE__ */ new Map(), a$2.elementStyles = [], a$2.shadowRootOptions = { mode: "open" }, null == h$1 || h$1({ ReactiveElement: a$2 }), (null !== (s2$1 = globalThis.reactiveElementVersions) && void 0 !== s2$1 ? s2$1 : globalThis.reactiveElementVersions = []).push("1.3.2");
 
-    function _defineProperty(obj, key, value) {
-      if (key in obj) {
-        Object.defineProperty(obj, key, {
-          value: value,
-          enumerable: true,
-          configurable: true,
-          writable: true
+  // node_modules/lit-html/lit-html.js
+  var t2;
+  var i2$3 = globalThis.trustedTypes;
+  var s3 = i2$3 ? i2$3.createPolicy("lit-html", { createHTML: (t3) => t3 }) : void 0;
+  var e3$1 = `lit$${(Math.random() + "").slice(9)}$`;
+  var o3$1 = "?" + e3$1;
+  var n3$1 = `<${o3$1}>`;
+  var l2$1 = document;
+  var h2$1 = (t3 = "") => l2$1.createComment(t3);
+  var r3 = (t3) => null === t3 || "object" != typeof t3 && "function" != typeof t3;
+  var d$1 = Array.isArray;
+  var u$1 = (t3) => {
+    var i3;
+    return d$1(t3) || "function" == typeof (null === (i3 = t3) || void 0 === i3 ? void 0 : i3[Symbol.iterator]);
+  };
+  var c$1 = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g;
+  var v = /-->/g;
+  var a2$1 = />/g;
+  var f$2 = />|[ 	\n\r](?:([^\s"'>=/]+)([ 	\n\r]*=[ 	\n\r]*(?:[^ 	\n\r"'`<>=]|("|')|))|$)/g;
+  var _ = /'/g;
+  var m$1 = /"/g;
+  var g$1 = /^(?:script|style|textarea|title)$/i;
+  var p$1 = (t3) => (i3, ...s5) => ({ _$litType$: t3, strings: i3, values: s5 });
+  var $ = p$1(1);
+  var b$1 = Symbol.for("lit-noChange");
+  var w = Symbol.for("lit-nothing");
+  var T$1 = /* @__PURE__ */ new WeakMap();
+  var x$1 = (t3, i3, s5) => {
+    var e4, o5;
+    const n5 = null !== (e4 = null == s5 ? void 0 : s5.renderBefore) && void 0 !== e4 ? e4 : i3;
+    let l4 = n5._$litPart$;
+    if (void 0 === l4) {
+      const t4 = null !== (o5 = null == s5 ? void 0 : s5.renderBefore) && void 0 !== o5 ? o5 : null;
+      n5._$litPart$ = l4 = new N$1(i3.insertBefore(h2$1(), t4), t4, void 0, null != s5 ? s5 : {});
+    }
+    return l4._$AI(t3), l4;
+  };
+  var A = l2$1.createTreeWalker(l2$1, 129, null, false);
+  var C$1 = (t3, i3) => {
+    const o5 = t3.length - 1, l4 = [];
+    let h3, r4 = 2 === i3 ? "<svg>" : "", d2 = c$1;
+    for (let i4 = 0; i4 < o5; i4++) {
+      const s5 = t3[i4];
+      let o6, u3, p2 = -1, $2 = 0;
+      for (; $2 < s5.length && (d2.lastIndex = $2, u3 = d2.exec(s5), null !== u3); )
+        $2 = d2.lastIndex, d2 === c$1 ? "!--" === u3[1] ? d2 = v : void 0 !== u3[1] ? d2 = a2$1 : void 0 !== u3[2] ? (g$1.test(u3[2]) && (h3 = RegExp("</" + u3[2], "g")), d2 = f$2) : void 0 !== u3[3] && (d2 = f$2) : d2 === f$2 ? ">" === u3[0] ? (d2 = null != h3 ? h3 : c$1, p2 = -1) : void 0 === u3[1] ? p2 = -2 : (p2 = d2.lastIndex - u3[2].length, o6 = u3[1], d2 = void 0 === u3[3] ? f$2 : '"' === u3[3] ? m$1 : _) : d2 === m$1 || d2 === _ ? d2 = f$2 : d2 === v || d2 === a2$1 ? d2 = c$1 : (d2 = f$2, h3 = void 0);
+      const y2 = d2 === f$2 && t3[i4 + 1].startsWith("/>") ? " " : "";
+      r4 += d2 === c$1 ? s5 + n3$1 : p2 >= 0 ? (l4.push(o6), s5.slice(0, p2) + "$lit$" + s5.slice(p2) + e3$1 + y2) : s5 + e3$1 + (-2 === p2 ? (l4.push(void 0), i4) : y2);
+    }
+    const u2 = r4 + (t3[o5] || "<?>") + (2 === i3 ? "</svg>" : "");
+    if (!Array.isArray(t3) || !t3.hasOwnProperty("raw"))
+      throw Error("invalid template strings array");
+    return [void 0 !== s3 ? s3.createHTML(u2) : u2, l4];
+  };
+  var E = class {
+    constructor({ strings: t3, _$litType$: s5 }, n5) {
+      let l4;
+      this.parts = [];
+      let r4 = 0, d2 = 0;
+      const u2 = t3.length - 1, c2 = this.parts, [v2, a3] = C$1(t3, s5);
+      if (this.el = E.createElement(v2, n5), A.currentNode = this.el.content, 2 === s5) {
+        const t4 = this.el.content, i3 = t4.firstChild;
+        i3.remove(), t4.append(...i3.childNodes);
+      }
+      for (; null !== (l4 = A.nextNode()) && c2.length < u2; ) {
+        if (1 === l4.nodeType) {
+          if (l4.hasAttributes()) {
+            const t4 = [];
+            for (const i3 of l4.getAttributeNames())
+              if (i3.endsWith("$lit$") || i3.startsWith(e3$1)) {
+                const s6 = a3[d2++];
+                if (t4.push(i3), void 0 !== s6) {
+                  const t5 = l4.getAttribute(s6.toLowerCase() + "$lit$").split(e3$1), i4 = /([.?@])?(.*)/.exec(s6);
+                  c2.push({ type: 1, index: r4, name: i4[2], strings: t5, ctor: "." === i4[1] ? M : "?" === i4[1] ? H$2 : "@" === i4[1] ? I : S2 });
+                } else
+                  c2.push({ type: 6, index: r4 });
+              }
+            for (const i3 of t4)
+              l4.removeAttribute(i3);
+          }
+          if (g$1.test(l4.tagName)) {
+            const t4 = l4.textContent.split(e3$1), s6 = t4.length - 1;
+            if (s6 > 0) {
+              l4.textContent = i2$3 ? i2$3.emptyScript : "";
+              for (let i3 = 0; i3 < s6; i3++)
+                l4.append(t4[i3], h2$1()), A.nextNode(), c2.push({ type: 2, index: ++r4 });
+              l4.append(t4[s6], h2$1());
+            }
+          }
+        } else if (8 === l4.nodeType)
+          if (l4.data === o3$1)
+            c2.push({ type: 2, index: r4 });
+          else {
+            let t4 = -1;
+            for (; -1 !== (t4 = l4.data.indexOf(e3$1, t4 + 1)); )
+              c2.push({ type: 7, index: r4 }), t4 += e3$1.length - 1;
+          }
+        r4++;
+      }
+    }
+    static createElement(t3, i3) {
+      const s5 = l2$1.createElement("template");
+      return s5.innerHTML = t3, s5;
+    }
+  };
+  function P(t3, i3, s5 = t3, e4) {
+    var o5, n5, l4, h3;
+    if (i3 === b$1)
+      return i3;
+    let d2 = void 0 !== e4 ? null === (o5 = s5._$Cl) || void 0 === o5 ? void 0 : o5[e4] : s5._$Cu;
+    const u2 = r3(i3) ? void 0 : i3._$litDirective$;
+    return (null == d2 ? void 0 : d2.constructor) !== u2 && (null === (n5 = null == d2 ? void 0 : d2._$AO) || void 0 === n5 || n5.call(d2, false), void 0 === u2 ? d2 = void 0 : (d2 = new u2(t3), d2._$AT(t3, s5, e4)), void 0 !== e4 ? (null !== (l4 = (h3 = s5)._$Cl) && void 0 !== l4 ? l4 : h3._$Cl = [])[e4] = d2 : s5._$Cu = d2), void 0 !== d2 && (i3 = P(t3, d2._$AS(t3, i3.values), d2, e4)), i3;
+  }
+  var V = class {
+    constructor(t3, i3) {
+      this.v = [], this._$AN = void 0, this._$AD = t3, this._$AM = i3;
+    }
+    get parentNode() {
+      return this._$AM.parentNode;
+    }
+    get _$AU() {
+      return this._$AM._$AU;
+    }
+    p(t3) {
+      var i3;
+      const { el: { content: s5 }, parts: e4 } = this._$AD, o5 = (null !== (i3 = null == t3 ? void 0 : t3.creationScope) && void 0 !== i3 ? i3 : l2$1).importNode(s5, true);
+      A.currentNode = o5;
+      let n5 = A.nextNode(), h3 = 0, r4 = 0, d2 = e4[0];
+      for (; void 0 !== d2; ) {
+        if (h3 === d2.index) {
+          let i4;
+          2 === d2.type ? i4 = new N$1(n5, n5.nextSibling, this, t3) : 1 === d2.type ? i4 = new d2.ctor(n5, d2.name, d2.strings, this, t3) : 6 === d2.type && (i4 = new L$1(n5, this, t3)), this.v.push(i4), d2 = e4[++r4];
+        }
+        h3 !== (null == d2 ? void 0 : d2.index) && (n5 = A.nextNode(), h3++);
+      }
+      return o5;
+    }
+    m(t3) {
+      let i3 = 0;
+      for (const s5 of this.v)
+        void 0 !== s5 && (void 0 !== s5.strings ? (s5._$AI(t3, s5, i3), i3 += s5.strings.length - 2) : s5._$AI(t3[i3])), i3++;
+    }
+  };
+  var N$1 = class {
+    constructor(t3, i3, s5, e4) {
+      var o5;
+      this.type = 2, this._$AH = w, this._$AN = void 0, this._$AA = t3, this._$AB = i3, this._$AM = s5, this.options = e4, this._$Cg = null === (o5 = null == e4 ? void 0 : e4.isConnected) || void 0 === o5 || o5;
+    }
+    get _$AU() {
+      var t3, i3;
+      return null !== (i3 = null === (t3 = this._$AM) || void 0 === t3 ? void 0 : t3._$AU) && void 0 !== i3 ? i3 : this._$Cg;
+    }
+    get parentNode() {
+      let t3 = this._$AA.parentNode;
+      const i3 = this._$AM;
+      return void 0 !== i3 && 11 === t3.nodeType && (t3 = i3.parentNode), t3;
+    }
+    get startNode() {
+      return this._$AA;
+    }
+    get endNode() {
+      return this._$AB;
+    }
+    _$AI(t3, i3 = this) {
+      t3 = P(this, t3, i3), r3(t3) ? t3 === w || null == t3 || "" === t3 ? (this._$AH !== w && this._$AR(), this._$AH = w) : t3 !== this._$AH && t3 !== b$1 && this.$(t3) : void 0 !== t3._$litType$ ? this.T(t3) : void 0 !== t3.nodeType ? this.k(t3) : u$1(t3) ? this.S(t3) : this.$(t3);
+    }
+    M(t3, i3 = this._$AB) {
+      return this._$AA.parentNode.insertBefore(t3, i3);
+    }
+    k(t3) {
+      this._$AH !== t3 && (this._$AR(), this._$AH = this.M(t3));
+    }
+    $(t3) {
+      this._$AH !== w && r3(this._$AH) ? this._$AA.nextSibling.data = t3 : this.k(l2$1.createTextNode(t3)), this._$AH = t3;
+    }
+    T(t3) {
+      var i3;
+      const { values: s5, _$litType$: e4 } = t3, o5 = "number" == typeof e4 ? this._$AC(t3) : (void 0 === e4.el && (e4.el = E.createElement(e4.h, this.options)), e4);
+      if ((null === (i3 = this._$AH) || void 0 === i3 ? void 0 : i3._$AD) === o5)
+        this._$AH.m(s5);
+      else {
+        const t4 = new V(o5, this), i4 = t4.p(this.options);
+        t4.m(s5), this.k(i4), this._$AH = t4;
+      }
+    }
+    _$AC(t3) {
+      let i3 = T$1.get(t3.strings);
+      return void 0 === i3 && T$1.set(t3.strings, i3 = new E(t3)), i3;
+    }
+    S(t3) {
+      d$1(this._$AH) || (this._$AH = [], this._$AR());
+      const i3 = this._$AH;
+      let s5, e4 = 0;
+      for (const o5 of t3)
+        e4 === i3.length ? i3.push(s5 = new N$1(this.M(h2$1()), this.M(h2$1()), this, this.options)) : s5 = i3[e4], s5._$AI(o5), e4++;
+      e4 < i3.length && (this._$AR(s5 && s5._$AB.nextSibling, e4), i3.length = e4);
+    }
+    _$AR(t3 = this._$AA.nextSibling, i3) {
+      var s5;
+      for (null === (s5 = this._$AP) || void 0 === s5 || s5.call(this, false, true, i3); t3 && t3 !== this._$AB; ) {
+        const i4 = t3.nextSibling;
+        t3.remove(), t3 = i4;
+      }
+    }
+    setConnected(t3) {
+      var i3;
+      void 0 === this._$AM && (this._$Cg = t3, null === (i3 = this._$AP) || void 0 === i3 || i3.call(this, t3));
+    }
+  };
+  var S2 = class {
+    constructor(t3, i3, s5, e4, o5) {
+      this.type = 1, this._$AH = w, this._$AN = void 0, this.element = t3, this.name = i3, this._$AM = e4, this.options = o5, s5.length > 2 || "" !== s5[0] || "" !== s5[1] ? (this._$AH = Array(s5.length - 1).fill(new String()), this.strings = s5) : this._$AH = w;
+    }
+    get tagName() {
+      return this.element.tagName;
+    }
+    get _$AU() {
+      return this._$AM._$AU;
+    }
+    _$AI(t3, i3 = this, s5, e4) {
+      const o5 = this.strings;
+      let n5 = false;
+      if (void 0 === o5)
+        t3 = P(this, t3, i3, 0), n5 = !r3(t3) || t3 !== this._$AH && t3 !== b$1, n5 && (this._$AH = t3);
+      else {
+        const e5 = t3;
+        let l4, h3;
+        for (t3 = o5[0], l4 = 0; l4 < o5.length - 1; l4++)
+          h3 = P(this, e5[s5 + l4], i3, l4), h3 === b$1 && (h3 = this._$AH[l4]), n5 || (n5 = !r3(h3) || h3 !== this._$AH[l4]), h3 === w ? t3 = w : t3 !== w && (t3 += (null != h3 ? h3 : "") + o5[l4 + 1]), this._$AH[l4] = h3;
+      }
+      n5 && !e4 && this.C(t3);
+    }
+    C(t3) {
+      t3 === w ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, null != t3 ? t3 : "");
+    }
+  };
+  var M = class extends S2 {
+    constructor() {
+      super(...arguments), this.type = 3;
+    }
+    C(t3) {
+      this.element[this.name] = t3 === w ? void 0 : t3;
+    }
+  };
+  var k$1 = i2$3 ? i2$3.emptyScript : "";
+  var H$2 = class extends S2 {
+    constructor() {
+      super(...arguments), this.type = 4;
+    }
+    C(t3) {
+      t3 && t3 !== w ? this.element.setAttribute(this.name, k$1) : this.element.removeAttribute(this.name);
+    }
+  };
+  var I = class extends S2 {
+    constructor(t3, i3, s5, e4, o5) {
+      super(t3, i3, s5, e4, o5), this.type = 5;
+    }
+    _$AI(t3, i3 = this) {
+      var s5;
+      if ((t3 = null !== (s5 = P(this, t3, i3, 0)) && void 0 !== s5 ? s5 : w) === b$1)
+        return;
+      const e4 = this._$AH, o5 = t3 === w && e4 !== w || t3.capture !== e4.capture || t3.once !== e4.once || t3.passive !== e4.passive, n5 = t3 !== w && (e4 === w || o5);
+      o5 && this.element.removeEventListener(this.name, this, e4), n5 && this.element.addEventListener(this.name, this, t3), this._$AH = t3;
+    }
+    handleEvent(t3) {
+      var i3, s5;
+      "function" == typeof this._$AH ? this._$AH.call(null !== (s5 = null === (i3 = this.options) || void 0 === i3 ? void 0 : i3.host) && void 0 !== s5 ? s5 : this.element, t3) : this._$AH.handleEvent(t3);
+    }
+  };
+  var L$1 = class {
+    constructor(t3, i3, s5) {
+      this.element = t3, this.type = 6, this._$AN = void 0, this._$AM = i3, this.options = s5;
+    }
+    get _$AU() {
+      return this._$AM._$AU;
+    }
+    _$AI(t3) {
+      P(this, t3);
+    }
+  };
+  var z$1 = window.litHtmlPolyfillSupport;
+  null == z$1 || z$1(E, N$1), (null !== (t2 = globalThis.litHtmlVersions) && void 0 !== t2 ? t2 : globalThis.litHtmlVersions = []).push("2.2.4");
+
+  // node_modules/lit-element/lit-element.js
+  var l3;
+  var o4;
+  var s4 = class extends a$2 {
+    constructor() {
+      super(...arguments), this.renderOptions = { host: this }, this._$Dt = void 0;
+    }
+    createRenderRoot() {
+      var t3, e4;
+      const i3 = super.createRenderRoot();
+      return null !== (t3 = (e4 = this.renderOptions).renderBefore) && void 0 !== t3 || (e4.renderBefore = i3.firstChild), i3;
+    }
+    update(t3) {
+      const i3 = this.render();
+      this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t3), this._$Dt = x$1(i3, this.renderRoot, this.renderOptions);
+    }
+    connectedCallback() {
+      var t3;
+      super.connectedCallback(), null === (t3 = this._$Dt) || void 0 === t3 || t3.setConnected(true);
+    }
+    disconnectedCallback() {
+      var t3;
+      super.disconnectedCallback(), null === (t3 = this._$Dt) || void 0 === t3 || t3.setConnected(false);
+    }
+    render() {
+      return b$1;
+    }
+  };
+  s4.finalized = true, s4._$litElement$ = true, null === (l3 = globalThis.litElementHydrateSupport) || void 0 === l3 || l3.call(globalThis, { LitElement: s4 });
+  var n4 = globalThis.litElementPolyfillSupport;
+  null == n4 || n4({ LitElement: s4 });
+  (null !== (o4 = globalThis.litElementVersions) && void 0 !== o4 ? o4 : globalThis.litElementVersions = []).push("3.2.0");
+  /**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+  /**
+   * @license
+   * Copyright 2019 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+
+  // src/styles/component.styles.ts
+  var component_styles_default = r$2`
+  :host {
+    box-sizing: border-box;
+  }
+
+  :host *,
+  :host *::before,
+  :host *::after {
+    box-sizing: inherit;
+  }
+
+  [hidden] {
+    display: none !important;
+  }
+`;
+
+  // src/components/tooltip/tooltip.styles.ts
+  var tooltip_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --max-width: 20rem;
+    --hide-delay: 0ms;
+    --show-delay: 150ms;
+
+    display: contents;
+  }
+
+  .tooltip {
+    --arrow-size: var(--sl-tooltip-arrow-size);
+    --arrow-color: var(--sl-tooltip-background-color);
+  }
+
+  .tooltip::part(popup) {
+    pointer-events: none;
+    z-index: var(--sl-z-index-tooltip);
+  }
+
+  .tooltip[placement^='top']::part(popup) {
+    transform-origin: bottom;
+  }
+
+  .tooltip[placement^='bottom']::part(popup) {
+    transform-origin: top;
+  }
+
+  .tooltip[placement^='left']::part(popup) {
+    transform-origin: right;
+  }
+
+  .tooltip[placement^='right']::part(popup) {
+    transform-origin: left;
+  }
+
+  .tooltip__body {
+    width: max-content;
+    max-width: var(--max-width);
+    border-radius: var(--sl-tooltip-border-radius);
+    background-color: var(--sl-tooltip-background-color);
+    font-family: var(--sl-tooltip-font-family);
+    font-size: var(--sl-tooltip-font-size);
+    font-weight: var(--sl-tooltip-font-weight);
+    line-height: var(--sl-tooltip-line-height);
+    color: var(--sl-tooltip-color);
+    padding: var(--sl-tooltip-padding);
+    pointer-events: none;
+  }
+`;
+
+  // src/internal/event.ts
+  function waitForEvent(el, eventName) {
+    return new Promise((resolve) => {
+      function done(event) {
+        if (event.target === el) {
+          el.removeEventListener(eventName, done);
+          resolve();
+        }
+      }
+      el.addEventListener(eventName, done);
+    });
+  }
+
+  var __create = Object.create;
+  var __defProp = Object.defineProperty;
+  var __defProps = Object.defineProperties;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __getOwnPropSymbols = Object.getOwnPropertySymbols;
+  var __getProtoOf = Object.getPrototypeOf;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __propIsEnum = Object.prototype.propertyIsEnumerable;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __spreadValues = (a, b) => {
+    for (var prop in b || (b = {}))
+      if (__hasOwnProp.call(b, prop))
+        __defNormalProp(a, prop, b[prop]);
+    if (__getOwnPropSymbols)
+      for (var prop of __getOwnPropSymbols(b)) {
+        if (__propIsEnum.call(b, prop))
+          __defNormalProp(a, prop, b[prop]);
+      }
+    return a;
+  };
+  var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
+  var __objRest = (source, exclude) => {
+    var target = {};
+    for (var prop in source)
+      if (__hasOwnProp.call(source, prop) && exclude.indexOf(prop) < 0)
+        target[prop] = source[prop];
+    if (source != null && __getOwnPropSymbols)
+      for (var prop of __getOwnPropSymbols(source)) {
+        if (exclude.indexOf(prop) < 0 && __propIsEnum.call(source, prop))
+          target[prop] = source[prop];
+      }
+    return target;
+  };
+  var __commonJS = (cb, mod) => function __require() {
+    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  };
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+    isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+    mod
+  ));
+  var __decorateClass = (decorators, target, key, kind) => {
+    var result = kind > 1 ? void 0 : kind ? __getOwnPropDesc(target, key) : target;
+    for (var i = decorators.length - 1, decorator; i >= 0; i--)
+      if (decorator = decorators[i])
+        result = (kind ? decorator(target, key, result) : decorator(result)) || result;
+    if (kind && result)
+      __defProp(target, key, result);
+    return result;
+  };
+
+  // src/internal/animate.ts
+  function animateTo(el, keyframes, options) {
+    return new Promise((resolve) => {
+      if ((options == null ? void 0 : options.duration) === Infinity) {
+        throw new Error("Promise-based animations must be finite.");
+      }
+      const animation = el.animate(keyframes, __spreadProps(__spreadValues({}, options), {
+        duration: prefersReducedMotion() ? 0 : options.duration
+      }));
+      animation.addEventListener("cancel", resolve, { once: true });
+      animation.addEventListener("finish", resolve, { once: true });
+    });
+  }
+  function parseDuration(delay) {
+    delay = delay.toString().toLowerCase();
+    if (delay.indexOf("ms") > -1) {
+      return parseFloat(delay);
+    }
+    if (delay.indexOf("s") > -1) {
+      return parseFloat(delay) * 1e3;
+    }
+    return parseFloat(delay);
+  }
+  function prefersReducedMotion() {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    return query.matches;
+  }
+  function stopAnimations(el) {
+    return Promise.all(
+      el.getAnimations().map((animation) => {
+        return new Promise((resolve) => {
+          const handleAnimationEvent = requestAnimationFrame(resolve);
+          animation.addEventListener("cancel", () => handleAnimationEvent, { once: true });
+          animation.addEventListener("finish", () => handleAnimationEvent, { once: true });
+          animation.cancel();
         });
+      })
+    );
+  }
+  function shimKeyframesHeightAuto(keyframes, calculatedHeight) {
+    return keyframes.map((keyframe) => __spreadProps(__spreadValues({}, keyframe), {
+      height: keyframe.height === "auto" ? `${calculatedHeight}px` : keyframe.height
+    }));
+  }
+
+  // src/utilities/animation-registry.ts
+  var defaultAnimationRegistry = /* @__PURE__ */ new Map();
+  var customAnimationRegistry = /* @__PURE__ */ new WeakMap();
+  function ensureAnimation(animation) {
+    return animation != null ? animation : { keyframes: [], options: { duration: 0 } };
+  }
+  function getLogicalAnimation(animation, dir) {
+    if (dir.toLowerCase() === "rtl") {
+      return {
+        keyframes: animation.rtlKeyframes || animation.keyframes,
+        options: animation.options
+      };
+    }
+    return animation;
+  }
+  function setDefaultAnimation(animationName, animation) {
+    defaultAnimationRegistry.set(animationName, ensureAnimation(animation));
+  }
+  function getAnimation(el, animationName, options) {
+    const customAnimation = customAnimationRegistry.get(el);
+    if (customAnimation == null ? void 0 : customAnimation[animationName]) {
+      return getLogicalAnimation(customAnimation[animationName], options.dir);
+    }
+    const defaultAnimation = defaultAnimationRegistry.get(animationName);
+    if (defaultAnimation) {
+      return getLogicalAnimation(defaultAnimation, options.dir);
+    }
+    return {
+      keyframes: [],
+      options: { duration: 0 }
+    };
+  }
+
+  // node_modules/@shoelace-style/localize/dist/index.js
+  var connectedElements = /* @__PURE__ */ new Set();
+  var documentElementObserver = new MutationObserver(update);
+  var translations = /* @__PURE__ */ new Map();
+  var documentDirection = document.documentElement.dir || "ltr";
+  var documentLanguage = document.documentElement.lang || navigator.language;
+  var fallback;
+  documentElementObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["dir", "lang"]
+  });
+  function registerTranslation(...translation2) {
+    translation2.map((t) => {
+      const code = t.$code.toLowerCase();
+      if (translations.has(code)) {
+        translations.set(code, Object.assign(Object.assign({}, translations.get(code)), t));
       } else {
-        obj[key] = value;
+        translations.set(code, t);
       }
-
-      return obj;
+      if (!fallback) {
+        fallback = t;
+      }
+    });
+    update();
+  }
+  function update() {
+    documentDirection = document.documentElement.dir || "ltr";
+    documentLanguage = document.documentElement.lang || navigator.language;
+    [...connectedElements.keys()].map((el) => {
+      if (typeof el.requestUpdate === "function") {
+        el.requestUpdate();
+      }
+    });
+  }
+  var LocalizeController = class {
+    constructor(host) {
+      this.host = host;
+      this.host.addController(this);
     }
-
-    class _class$1 extends Controller {
-      connect() {
-        this.element[this.identifier] = this;
-        this.classToToggle = this.hasToggleClass ? this.toggleClass : "hidden";
-        this.externalTargets = document.getElementsByClassName(this.data.get("externalTargetClass"));
+    hostConnected() {
+      connectedElements.add(this.host);
+    }
+    hostDisconnected() {
+      connectedElements.delete(this.host);
+    }
+    dir() {
+      return `${this.host.dir || documentDirection}`.toLowerCase();
+    }
+    lang() {
+      return `${this.host.lang || documentLanguage}`.toLowerCase();
+    }
+    term(key, ...args) {
+      const code = this.lang().toLowerCase().slice(0, 2);
+      const regionCode = this.lang().length > 2 ? this.lang().toLowerCase() : "";
+      const primary = translations.get(regionCode);
+      const secondary = translations.get(code);
+      let term;
+      if (primary && primary[key]) {
+        term = primary[key];
+      } else if (secondary && secondary[key]) {
+        term = secondary[key];
+      } else if (fallback && fallback[key]) {
+        term = fallback[key];
+      } else {
+        console.error(`No translation found for: ${String(key)}`);
+        return key;
       }
-
-      classIsApplied() {
-        return this.element.classList.contains(this.classToToggle);
+      if (typeof term === "function") {
+        return term(...args);
       }
+      return term;
+    }
+    date(dateToFormat, options) {
+      dateToFormat = new Date(dateToFormat);
+      return new Intl.DateTimeFormat(this.lang(), options).format(dateToFormat);
+    }
+    number(numberToFormat, options) {
+      numberToFormat = Number(numberToFormat);
+      return isNaN(numberToFormat) ? "" : new Intl.NumberFormat(this.lang(), options).format(numberToFormat);
+    }
+    relativeTime(value, unit, options) {
+      return new Intl.RelativeTimeFormat(this.lang(), options).format(value, unit);
+    }
+  };
 
-      toggle(event) {
-        if (!this.data.has("allowDefault")) event.preventDefault();
-        this.toggleControllerTargets();
-        this.toggleExternalTargets();
+  // src/utilities/localize.ts
+  var LocalizeController2 = class extends LocalizeController {
+  };
+
+  // src/translations/en.ts
+  var translation = {
+    $code: "en",
+    $name: "English",
+    $dir: "ltr",
+    clearEntry: "Clear entry",
+    close: "Close",
+    copy: "Copy",
+    currentValue: "Current value",
+    hidePassword: "Hide password",
+    loading: "Loading",
+    progress: "Progress",
+    remove: "Remove",
+    resize: "Resize",
+    scrollToEnd: "Scroll to end",
+    scrollToStart: "Scroll to start",
+    selectAColorFromTheScreen: "Select a color from the screen",
+    showPassword: "Show password",
+    toggleColorFormat: "Toggle color format"
+  };
+  registerTranslation(translation);
+
+  // node_modules/lit-html/directive.js
+  var t$2 = { ATTRIBUTE: 1, CHILD: 2, PROPERTY: 3, BOOLEAN_ATTRIBUTE: 4, EVENT: 5, ELEMENT: 6 };
+  var e$2 = (t2) => (...e2) => ({ _$litDirective$: t2, values: e2 });
+  var i$1 = class {
+    constructor(t2) {
+    }
+    get _$AU() {
+      return this._$AM._$AU;
+    }
+    _$AT(t2, e2, i2) {
+      this._$Ct = t2, this._$AM = e2, this._$Ci = i2;
+    }
+    _$AS(t2, e2) {
+      return this.update(t2, e2);
+    }
+    update(t2, e2) {
+      return this.render(...e2);
+    }
+  };
+  /**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+
+  // node_modules/lit-html/directives/class-map.js
+  var o$3 = e$2(class extends i$1 {
+    constructor(t2) {
+      var i2;
+      if (super(t2), t2.type !== t$2.ATTRIBUTE || "class" !== t2.name || (null === (i2 = t2.strings) || void 0 === i2 ? void 0 : i2.length) > 2)
+        throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.");
+    }
+    render(t2) {
+      return " " + Object.keys(t2).filter((i2) => t2[i2]).join(" ") + " ";
+    }
+    update(i2, [s]) {
+      var r, o2;
+      if (void 0 === this.et) {
+        this.et = /* @__PURE__ */ new Set(), void 0 !== i2.strings && (this.st = new Set(i2.strings.join(" ").split(/\s/).filter((t2) => "" !== t2)));
+        for (const t2 in s)
+          s[t2] && !(null === (r = this.st) || void 0 === r ? void 0 : r.has(t2)) && this.et.add(t2);
+        return this.render(s);
       }
-
-      toggleOff(event) {
-        if (!this.data.has("allowDefault")) event.preventDefault();
-        if (this.classIsApplied()) this.toggle(event);
+      const e2 = i2.element.classList;
+      this.et.forEach((t2) => {
+        t2 in s || (e2.remove(t2), this.et.delete(t2));
+      });
+      for (const t2 in s) {
+        const i3 = !!s[t2];
+        i3 === this.et.has(t2) || (null === (o2 = this.st) || void 0 === o2 ? void 0 : o2.has(t2)) || (i3 ? (e2.add(t2), this.et.add(t2)) : (e2.remove(t2), this.et.delete(t2)));
       }
+      return b$1;
+    }
+  });
+  /**
+   * @license
+   * Copyright 2018 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
 
-      toggleControllerTargets() {
-        this.toggleableTargets.forEach(target => {
-          this.toggleElementClassList(target);
-        });
+  // src/internal/watch.ts
+  function watch(propName, options) {
+    const resolvedOptions = __spreadValues({
+      waitUntilFirstUpdate: false
+    }, options);
+    return (proto, decoratedFnName) => {
+      const { update } = proto;
+      if (propName in proto) {
+        const propNameKey = propName;
+        proto.update = function(changedProps) {
+          if (changedProps.has(propNameKey)) {
+            const oldValue = changedProps.get(propNameKey);
+            const newValue = this[propNameKey];
+            if (oldValue !== newValue) {
+              if (!resolvedOptions.waitUntilFirstUpdate || this.hasUpdated) {
+                this[decoratedFnName](oldValue, newValue);
+              }
+            }
+          }
+          update.call(this, changedProps);
+        };
       }
+    };
+  }
 
-      toggleExternalTargets() {
-        for (let i = 0; i < this.externalTargets.length; ++i) {
-          this.toggleElementClassList(this.externalTargets[i]);
+  // node_modules/@lit/reactive-element/decorators/custom-element.js
+  var n$1 = (n3) => (e4) => "function" == typeof e4 ? ((n4, e5) => (window.customElements.define(n4, e5), e5))(n3, e4) : ((n4, e5) => {
+    const { kind: t2, elements: i3 } = e5;
+    return { kind: t2, elements: i3, finisher(e6) {
+      window.customElements.define(n4, e6);
+    } };
+  })(n3, e4);
+
+  // node_modules/@lit/reactive-element/decorators/property.js
+  var i = (i3, e4) => "method" === e4.kind && e4.descriptor && !("value" in e4.descriptor) ? __spreadProps(__spreadValues({}, e4), { finisher(n3) {
+    n3.createProperty(e4.key, i3);
+  } }) : { kind: "field", key: Symbol(), placement: "own", descriptor: {}, originalKey: e4.key, initializer() {
+    "function" == typeof e4.initializer && (this[e4.key] = e4.initializer.call(this));
+  }, finisher(n3) {
+    n3.createProperty(e4.key, i3);
+  } };
+  function e$1(e4) {
+    return (n3, t2) => void 0 !== t2 ? ((i3, e5, n4) => {
+      e5.constructor.createProperty(n4, i3);
+    })(e4, n3, t2) : i(e4, n3);
+  }
+
+  // node_modules/@lit/reactive-element/decorators/state.js
+  function t$1(t2) {
+    return e$1(__spreadProps(__spreadValues({}, t2), { state: true }));
+  }
+
+  // node_modules/@lit/reactive-element/decorators/base.js
+  var o$2 = ({ finisher: e4, descriptor: t2 }) => (o2, n3) => {
+    var r;
+    if (void 0 === n3) {
+      const n4 = null !== (r = o2.originalKey) && void 0 !== r ? r : o2.key, i3 = null != t2 ? { kind: "method", placement: "prototype", key: n4, descriptor: t2(o2.key) } : __spreadProps(__spreadValues({}, o2), { key: n4 });
+      return null != e4 && (i3.finisher = function(t3) {
+        e4(t3, n4);
+      }), i3;
+    }
+    {
+      const r2 = o2.constructor;
+      void 0 !== t2 && Object.defineProperty(o2, n3, t2(n3)), null == e4 || e4(r2, n3);
+    }
+  };
+
+  // node_modules/@lit/reactive-element/decorators/query.js
+  function i2$2(i3, n3) {
+    return o$2({ descriptor: (o2) => {
+      const t2 = { get() {
+        var o3, n4;
+        return null !== (n4 = null === (o3 = this.renderRoot) || void 0 === o3 ? void 0 : o3.querySelector(i3)) && void 0 !== n4 ? n4 : null;
+      }, enumerable: true, configurable: true };
+      if (n3) {
+        const n4 = "symbol" == typeof o2 ? Symbol() : "__" + o2;
+        t2.get = function() {
+          var o3, t3;
+          return void 0 === this[n4] && (this[n4] = null !== (t3 = null === (o3 = this.renderRoot) || void 0 === o3 ? void 0 : o3.querySelector(i3)) && void 0 !== t3 ? t3 : null), this[n4];
+        };
+      }
+      return t2;
+    } });
+  }
+
+  // node_modules/@lit/reactive-element/decorators/query-async.js
+  function e2$1(e4) {
+    return o$2({ descriptor: (r) => ({ async get() {
+      var r2;
+      return await this.updateComplete, null === (r2 = this.renderRoot) || void 0 === r2 ? void 0 : r2.querySelector(e4);
+    }, enumerable: true, configurable: true }) });
+  }
+
+  // node_modules/@lit/reactive-element/decorators/query-assigned-elements.js
+  var n2$2;
+  null != (null === (n2$2 = window.HTMLSlotElement) || void 0 === n2$2 ? void 0 : n2$2.prototype.assignedElements) ? (o2, n3) => o2.assignedElements(n3) : (o2, n3) => o2.assignedNodes(n3).filter((o3) => o3.nodeType === Node.ELEMENT_NODE);
+
+  // src/internal/shoelace-element.ts
+  var ShoelaceElement = class extends s4 {
+    emit(name, options) {
+      const event = new CustomEvent(name, __spreadValues({
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+        detail: {}
+      }, options));
+      this.dispatchEvent(event);
+      return event;
+    }
+  };
+  __decorateClass([
+    e$1()
+  ], ShoelaceElement.prototype, "dir", 2);
+  __decorateClass([
+    e$1()
+  ], ShoelaceElement.prototype, "lang", 2);
+  /**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+  /**
+   * @license
+   * Copyright 2021 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+
+  // src/components/tooltip/tooltip.ts
+  var SlTooltip = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.content = "";
+      this.placement = "top";
+      this.disabled = false;
+      this.distance = 8;
+      this.open = false;
+      this.skidding = 0;
+      this.trigger = "hover focus";
+      this.hoist = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.handleBlur = this.handleBlur.bind(this);
+      this.handleClick = this.handleClick.bind(this);
+      this.handleFocus = this.handleFocus.bind(this);
+      this.handleKeyDown = this.handleKeyDown.bind(this);
+      this.handleMouseOver = this.handleMouseOver.bind(this);
+      this.handleMouseOut = this.handleMouseOut.bind(this);
+      this.updateComplete.then(() => {
+        this.addEventListener("blur", this.handleBlur, true);
+        this.addEventListener("focus", this.handleFocus, true);
+        this.addEventListener("click", this.handleClick);
+        this.addEventListener("keydown", this.handleKeyDown);
+        this.addEventListener("mouseover", this.handleMouseOver);
+        this.addEventListener("mouseout", this.handleMouseOut);
+      });
+    }
+    firstUpdated() {
+      this.body.hidden = !this.open;
+      if (this.open) {
+        this.popup.active = true;
+        this.popup.reposition();
+      }
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.removeEventListener("blur", this.handleBlur, true);
+      this.removeEventListener("focus", this.handleFocus, true);
+      this.removeEventListener("click", this.handleClick);
+      this.removeEventListener("keydown", this.handleKeyDown);
+      this.removeEventListener("mouseover", this.handleMouseOver);
+      this.removeEventListener("mouseout", this.handleMouseOut);
+    }
+    async show() {
+      if (this.open) {
+        return void 0;
+      }
+      this.open = true;
+      return waitForEvent(this, "sl-after-show");
+    }
+    async hide() {
+      if (!this.open) {
+        return void 0;
+      }
+      this.open = false;
+      return waitForEvent(this, "sl-after-hide");
+    }
+    getTarget() {
+      const target = [...this.children].find(
+        (el) => el.tagName.toLowerCase() !== "style" && el.getAttribute("slot") !== "content"
+      );
+      if (!target) {
+        throw new Error("Invalid tooltip target: no child element was found.");
+      }
+      return target;
+    }
+    handleBlur() {
+      if (this.hasTrigger("focus")) {
+        this.hide();
+      }
+    }
+    handleClick() {
+      if (this.hasTrigger("click")) {
+        if (this.open) {
+          this.hide();
+        } else {
+          this.show();
         }
       }
-
-      toggleElementClassList(targetElement) {
-        targetElement.classList.toggle(this.classToToggle);
-      }
-
     }
-
-    _defineProperty(_class$1, "targets", ["toggleable"]);
-
-    _defineProperty(_class$1, "classes", ["toggle"]);
-
-    class _class extends Controller {
-      // TODO: hardcoded to work with /for-leaders page - switch to using Values to customize active/inactive classes
-      connect() {
-        this.element[this.identifier] = this;
+    handleFocus() {
+      if (this.hasTrigger("focus")) {
+        this.show();
       }
+    }
+    handleKeyDown(event) {
+      if (this.open && event.key === "Escape") {
+        event.stopPropagation();
+        this.hide();
+      }
+    }
+    handleMouseOver() {
+      if (this.hasTrigger("hover")) {
+        const delay = parseDuration(getComputedStyle(this).getPropertyValue("--show-delay"));
+        clearTimeout(this.hoverTimeout);
+        this.hoverTimeout = window.setTimeout(() => this.show(), delay);
+      }
+    }
+    handleMouseOut() {
+      if (this.hasTrigger("hover")) {
+        const delay = parseDuration(getComputedStyle(this).getPropertyValue("--hide-delay"));
+        clearTimeout(this.hoverTimeout);
+        this.hoverTimeout = window.setTimeout(() => this.hide(), delay);
+      }
+    }
+    async handleOpenChange() {
+      if (this.open) {
+        if (this.disabled) {
+          return;
+        }
+        this.emit("sl-show");
+        await stopAnimations(this.body);
+        this.body.hidden = false;
+        this.popup.active = true;
+        const { keyframes, options } = getAnimation(this, "tooltip.show", { dir: this.localize.dir() });
+        await animateTo(this.popup.popup, keyframes, options);
+        this.emit("sl-after-show");
+      } else {
+        this.emit("sl-hide");
+        await stopAnimations(this.body);
+        const { keyframes, options } = getAnimation(this, "tooltip.hide", { dir: this.localize.dir() });
+        await animateTo(this.popup.popup, keyframes, options);
+        this.popup.active = false;
+        this.body.hidden = true;
+        this.emit("sl-after-hide");
+      }
+    }
+    async handleOptionsChange() {
+      if (this.hasUpdated) {
+        await this.updateComplete;
+        this.popup.reposition();
+      }
+    }
+    handleDisabledChange() {
+      if (this.disabled && this.open) {
+        this.hide();
+      }
+    }
+    hasTrigger(triggerType) {
+      const triggers = this.trigger.split(" ");
+      return triggers.includes(triggerType);
+    }
+    render() {
+      return $`
+      <sl-popup
+        part="base"
+        exportparts="
+          popup:base__popup,
+          arrow:base__arrow
+        "
+        class=${o$3({
+      tooltip: true,
+      "tooltip--open": this.open
+    })}
+        placement=${this.placement}
+        distance=${this.distance}
+        skidding=${this.skidding}
+        strategy=${this.hoist ? "fixed" : "absolute"}
+        flip
+        shift
+        arrow
+      >
+        <slot slot="anchor" aria-describedby="tooltip"></slot>
 
-      switch(event) {
-        if (!this.data.has("allowDefault")) {
+        <div part="body" id="tooltip" class="tooltip__body" role="tooltip" aria-hidden=${this.open ? "false" : "true"}>
+          <slot name="content" aria-live=${this.open ? "polite" : "off"}> ${this.content} </slot>
+        </div>
+      </sl-popup>
+    `;
+    }
+  };
+  SlTooltip.styles = tooltip_styles_default;
+  __decorateClass([
+    i2$2("slot:not([name])")
+  ], SlTooltip.prototype, "defaultSlot", 2);
+  __decorateClass([
+    i2$2(".tooltip__body")
+  ], SlTooltip.prototype, "body", 2);
+  __decorateClass([
+    i2$2("sl-popup")
+  ], SlTooltip.prototype, "popup", 2);
+  __decorateClass([
+    e$1()
+  ], SlTooltip.prototype, "content", 2);
+  __decorateClass([
+    e$1()
+  ], SlTooltip.prototype, "placement", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTooltip.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlTooltip.prototype, "distance", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTooltip.prototype, "open", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlTooltip.prototype, "skidding", 2);
+  __decorateClass([
+    e$1()
+  ], SlTooltip.prototype, "trigger", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlTooltip.prototype, "hoist", 2);
+  __decorateClass([
+    watch("open", { waitUntilFirstUpdate: true })
+  ], SlTooltip.prototype, "handleOpenChange", 1);
+  __decorateClass([
+    watch("content"),
+    watch("distance"),
+    watch("hoist"),
+    watch("placement"),
+    watch("skidding")
+  ], SlTooltip.prototype, "handleOptionsChange", 1);
+  __decorateClass([
+    watch("disabled")
+  ], SlTooltip.prototype, "handleDisabledChange", 1);
+  SlTooltip = __decorateClass([
+    n$1("sl-tooltip")
+  ], SlTooltip);
+  setDefaultAnimation("tooltip.show", {
+    keyframes: [
+      { opacity: 0, transform: "scale(0.8)" },
+      { opacity: 1, transform: "scale(1)" }
+    ],
+    options: { duration: 150, easing: "ease" }
+  });
+  setDefaultAnimation("tooltip.hide", {
+    keyframes: [
+      { opacity: 1, transform: "scale(1)" },
+      { opacity: 0, transform: "scale(0.8)" }
+    ],
+    options: { duration: 150, easing: "ease" }
+  });
+
+  // src/components/tree/tree.styles.ts
+  var tree_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    /*
+     * These are actually used by tree item, but we define them here so they can more easily be set and all tree items
+     * stay consistent.
+     */
+    --indent-guide-color: var(--sl-color-neutral-200);
+    --indent-guide-offset: 0;
+    --indent-guide-style: solid;
+    --indent-guide-width: 0;
+    --indent-size: var(--sl-spacing-large);
+
+    display: block;
+    isolation: isolate;
+
+    /*
+     * Tree item indentation uses the "em" unit to increment its width on each level, so setting the font size to zero
+     * here removes the indentation for all the nodes on the first level.
+     */
+    font-size: 0;
+  }
+`;
+
+  // src/components/tree-item/tree-item.styles.ts
+  var tree_item_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+    outline: 0;
+    z-index: 0;
+  }
+
+  :host(:focus) {
+    outline: 0;
+  }
+
+  slot:not([name])::slotted(sl-icon) {
+    margin-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .tree-item {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    flex-direction: column;
+    color: var(--sl-color-neutral-700);
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+  }
+
+  .tree-item__checkbox {
+    pointer-events: none;
+  }
+
+  .tree-item__expand-button,
+  .tree-item__checkbox,
+  .tree-item__label {
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+    font-weight: var(--sl-font-weight-normal);
+    line-height: var(--sl-line-height-normal);
+    letter-spacing: var(--sl-letter-spacing-normal);
+  }
+
+  .tree-item__default-toggle-button {
+    transition: var(--sl-transition-medium) transform ease;
+  }
+
+  .tree-item--expanded .tree-item__default-toggle-button {
+    transform: rotate(90deg);
+  }
+
+  .tree-item--expanded.tree-item--rtl .tree-item__default-toggle-button {
+    transform: rotate(-90deg);
+  }
+
+  .tree-item__checkbox::part(base) {
+    display: flex;
+    align-items: center;
+  }
+
+  .tree-item__indentation {
+    display: block;
+    width: 1em;
+    flex-shrink: 0;
+  }
+
+  .tree-item__expand-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: content-box;
+    color: var(--sl-color-neutral-500);
+    padding: var(--sl-spacing-x-small);
+    width: 1rem;
+    height: 1rem;
+    cursor: pointer;
+  }
+
+  .tree-item__expand-button--visible {
+    cursor: pointer;
+  }
+
+  .tree-item__item {
+    display: flex;
+    align-items: center;
+    border-inline-start: solid 3px transparent;
+  }
+
+  .tree-item--disabled .tree-item__item {
+    opacity: 0.5;
+    outline: none;
+    cursor: not-allowed;
+  }
+
+  :host(:focus-visible) .tree-item__item {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+    z-index: 2;
+  }
+
+  :host(:not([aria-disabled='true'])) .tree-item--selected .tree-item__item {
+    background-color: var(--sl-color-neutral-100);
+    border-inline-start-color: var(--sl-color-primary-600);
+  }
+
+  :host(:not([aria-disabled='true'])) .tree-item__expand-button {
+    color: var(--sl-color-neutral-600);
+  }
+
+  .tree-item__label {
+    display: flex;
+    align-items: center;
+    transition: var(--sl-transition-fast) color;
+  }
+
+  .tree-item__children {
+    font-size: calc(1em + var(--indent-size, var(--sl-spacing-medium)));
+  }
+
+  /* Indentation lines */
+  .tree-item__children {
+    position: relative;
+  }
+
+  .tree-item__children::before {
+    content: '';
+    position: absolute;
+    top: var(--indent-guide-offset);
+    bottom: var(--indent-guide-offset);
+    left: calc(1em - (var(--indent-guide-width) / 2) - 1px);
+    border-inline-end: var(--indent-guide-width) var(--indent-guide-style) var(--indent-guide-color);
+    z-index: 1;
+  }
+
+  .tree-item--rtl .tree-item__children::before {
+    left: auto;
+    right: 1em;
+  }
+`;
+
+  var r$1 = (o) => void 0 === o.strings;
+  var f$1 = {};
+  var s$2 = (o, i3 = f$1) => o._$AH = i3;
+
+  // node_modules/lit-html/directives/live.js
+  var l$3 = e$2(class extends i$1 {
+    constructor(r2) {
+      if (super(r2), r2.type !== t$2.PROPERTY && r2.type !== t$2.ATTRIBUTE && r2.type !== t$2.BOOLEAN_ATTRIBUTE)
+        throw Error("The `live` directive is not allowed on child or event bindings");
+      if (!r$1(r2))
+        throw Error("`live` bindings can only contain a single expression");
+    }
+    render(r2) {
+      return r2;
+    }
+    update(i3, [t2]) {
+      if (t2 === b$1 || t2 === w)
+        return t2;
+      const o = i3.element, l2 = i3.name;
+      if (i3.type === t$2.PROPERTY) {
+        if (t2 === o[l2])
+          return b$1;
+      } else if (i3.type === t$2.BOOLEAN_ATTRIBUTE) {
+        if (!!t2 === o.hasAttribute(l2))
+          return b$1;
+      } else if (i3.type === t$2.ATTRIBUTE && o.getAttribute(l2) === t2 + "")
+        return b$1;
+      return s$2(i3), t2;
+    }
+  });
+  /**
+   * @license
+   * Copyright 2020 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+
+  // node_modules/lit-html/directives/when.js
+  function n2$1(n3, o2, r) {
+    return n3 ? o2() : null == r ? void 0 : r();
+  }
+
+  // src/components/tree-item/tree-item.ts
+  function isTreeItem(element) {
+    return element && (element == null ? void 0 : element.getAttribute("role")) === "treeitem";
+  }
+  var SlTreeItem = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.indeterminate = false;
+      this.isLeaf = false;
+      this.loading = false;
+      this.selectable = false;
+      this.expanded = false;
+      this.selected = false;
+      this.disabled = false;
+      this.lazy = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.setAttribute("role", "treeitem");
+      this.setAttribute("tabindex", "-1");
+      if (this.isNestedItem()) {
+        this.slot = "children";
+      }
+    }
+    firstUpdated() {
+      this.childrenContainer.hidden = !this.expanded;
+      this.childrenContainer.style.height = this.expanded ? "auto" : "0";
+      this.isLeaf = this.getChildrenItems().length === 0;
+      this.handleExpandedChange();
+    }
+    handleLoadingChange() {
+      this.setAttribute("aria-busy", this.loading ? "true" : "false");
+      if (!this.loading) {
+        this.animateExpand();
+      }
+    }
+    handleDisabledChange() {
+      this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+    }
+    handleSelectedChange() {
+      this.setAttribute("aria-selected", this.selected ? "true" : "false");
+    }
+    handleExpandedChange() {
+      if (!this.isLeaf) {
+        this.setAttribute("aria-expanded", this.expanded ? "true" : "false");
+      } else {
+        this.removeAttribute("aria-expanded");
+      }
+    }
+    handleExpandAnimation() {
+      if (this.expandButtonSlot) {
+        this.expandButtonSlot.name = this.expanded ? "collapse-icon" : "expand-icon";
+      }
+      if (this.expanded) {
+        if (this.lazy) {
+          this.loading = true;
+          this.emit("sl-lazy-load");
+        } else {
+          this.animateExpand();
+        }
+      } else {
+        this.animateCollapse();
+      }
+    }
+    handleLazyChange() {
+      this.emit("sl-lazy-change");
+    }
+    async animateExpand() {
+      this.emit("sl-expand");
+      await stopAnimations(this.childrenContainer);
+      this.childrenContainer.hidden = false;
+      const { keyframes, options } = getAnimation(this, "tree-item.expand", { dir: this.localize.dir() });
+      await animateTo(
+        this.childrenContainer,
+        shimKeyframesHeightAuto(keyframes, this.childrenContainer.scrollHeight),
+        options
+      );
+      this.childrenContainer.style.height = "auto";
+      this.emit("sl-after-expand");
+    }
+    async animateCollapse() {
+      this.emit("sl-collapse");
+      await stopAnimations(this.childrenContainer);
+      const { keyframes, options } = getAnimation(this, "tree-item.collapse", { dir: this.localize.dir() });
+      await animateTo(
+        this.childrenContainer,
+        shimKeyframesHeightAuto(keyframes, this.childrenContainer.scrollHeight),
+        options
+      );
+      this.childrenContainer.hidden = true;
+      this.emit("sl-after-collapse");
+    }
+    getChildrenItems({ includeDisabled = true } = {}) {
+      return this.childrenSlot ? [...this.childrenSlot.assignedElements({ flatten: true })].filter(
+        (item) => isTreeItem(item) && (includeDisabled || !item.disabled)
+      ) : [];
+    }
+    isNestedItem() {
+      const parent = this.parentElement;
+      return !!parent && isTreeItem(parent);
+    }
+    handleChildrenSlotChange() {
+      this.loading = false;
+      this.isLeaf = this.getChildrenItems().length === 0;
+    }
+    willUpdate(changedProperties) {
+      if (changedProperties.has("selected") && !changedProperties.has("indeterminate")) {
+        this.indeterminate = false;
+      }
+    }
+    render() {
+      const isRtl = this.localize.dir() === "rtl";
+      const showExpandButton = !this.loading && (!this.isLeaf || this.lazy);
+      return $`
+      <div
+        part="base"
+        class="${o$3({
+      "tree-item": true,
+      "tree-item--expanded": this.expanded,
+      "tree-item--selected": this.selected,
+      "tree-item--disabled": this.disabled,
+      "tree-item--leaf": this.isLeaf,
+      "tree-item--rtl": this.localize.dir() === "rtl"
+    })}"
+      >
+        <div
+          class="tree-item__item"
+          part="
+            item
+            ${this.disabled ? "item--disabled" : ""}
+            ${this.expanded ? "item--expanded" : ""}
+            ${this.indeterminate ? "item--indeterminate" : ""}
+            ${this.selected ? "item--selected" : ""}
+          "
+        >
+          <div class="tree-item__indentation" part="indentation"></div>
+
+          <div
+            part="expand-button"
+            class=${o$3({
+      "tree-item__expand-button": true,
+      "tree-item__expand-button--visible": showExpandButton
+    })}
+            aria-hidden="true"
+          >
+            ${n2$1(this.loading, () => $` <sl-spinner></sl-spinner> `)}
+            ${n2$1(
+      showExpandButton,
+      () => $`
+                <slot class="tree-item__expand-icon-slot" name="expand-icon">
+                  <sl-icon
+                    class="tree-item__default-toggle-button"
+                    library="system"
+                    name=${isRtl ? "chevron-left" : "chevron-right"}
+                  ></sl-icon>
+                </slot>
+              `
+    )}
+          </div>
+
+          ${n2$1(
+      this.selectable,
+      () => $`
+                <sl-checkbox
+                  tabindex="-1"
+                  class="tree-item__checkbox"
+                  ?disabled="${this.disabled}"
+                  ?checked="${l$3(this.selected)}"
+                  ?indeterminate="${this.indeterminate}"
+                >
+                  <div class="tree-item__label" part="label">
+                    <slot></slot>
+                  </div>
+                </sl-checkbox>
+              `,
+      () => $`
+              <div class="tree-item__label" part="label">
+                <slot></slot>
+              </div>
+            `
+    )}
+        </div>
+
+        <div class="tree-item__children" part="children" role="group">
+          <slot name="children" @slotchange="${this.handleChildrenSlotChange}"></slot>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlTreeItem.styles = tree_item_styles_default;
+  __decorateClass([
+    t$1()
+  ], SlTreeItem.prototype, "indeterminate", 2);
+  __decorateClass([
+    t$1()
+  ], SlTreeItem.prototype, "isLeaf", 2);
+  __decorateClass([
+    t$1()
+  ], SlTreeItem.prototype, "loading", 2);
+  __decorateClass([
+    t$1()
+  ], SlTreeItem.prototype, "selectable", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTreeItem.prototype, "expanded", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTreeItem.prototype, "selected", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTreeItem.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTreeItem.prototype, "lazy", 2);
+  __decorateClass([
+    i2$2("slot:not([name])")
+  ], SlTreeItem.prototype, "defaultSlot", 2);
+  __decorateClass([
+    i2$2("slot[name=children]")
+  ], SlTreeItem.prototype, "childrenSlot", 2);
+  __decorateClass([
+    i2$2(".tree-item__item")
+  ], SlTreeItem.prototype, "itemElement", 2);
+  __decorateClass([
+    i2$2(".tree-item__children")
+  ], SlTreeItem.prototype, "childrenContainer", 2);
+  __decorateClass([
+    i2$2(".tree-item__expand-button slot")
+  ], SlTreeItem.prototype, "expandButtonSlot", 2);
+  __decorateClass([
+    watch("loading", { waitUntilFirstUpdate: true })
+  ], SlTreeItem.prototype, "handleLoadingChange", 1);
+  __decorateClass([
+    watch("disabled")
+  ], SlTreeItem.prototype, "handleDisabledChange", 1);
+  __decorateClass([
+    watch("selected")
+  ], SlTreeItem.prototype, "handleSelectedChange", 1);
+  __decorateClass([
+    watch("expanded", { waitUntilFirstUpdate: true })
+  ], SlTreeItem.prototype, "handleExpandedChange", 1);
+  __decorateClass([
+    watch("expanded", { waitUntilFirstUpdate: true })
+  ], SlTreeItem.prototype, "handleExpandAnimation", 1);
+  __decorateClass([
+    watch("lazy", { waitUntilFirstUpdate: true })
+  ], SlTreeItem.prototype, "handleLazyChange", 1);
+  SlTreeItem = __decorateClass([
+    n$1("sl-tree-item")
+  ], SlTreeItem);
+  setDefaultAnimation("tree-item.expand", {
+    keyframes: [
+      { height: "0", opacity: "0", overflow: "hidden" },
+      { height: "auto", opacity: "1", overflow: "hidden" }
+    ],
+    options: { duration: 250, easing: "cubic-bezier(0.4, 0.0, 0.2, 1)" }
+  });
+  setDefaultAnimation("tree-item.collapse", {
+    keyframes: [
+      { height: "auto", opacity: "1", overflow: "hidden" },
+      { height: "0", opacity: "0", overflow: "hidden" }
+    ],
+    options: { duration: 200, easing: "cubic-bezier(0.4, 0.0, 0.2, 1)" }
+  });
+  /**
+   * @license
+   * Copyright 2021 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+
+  // src/internal/math.ts
+  function clamp(value, min, max) {
+    if (value < min) {
+      return min;
+    }
+    if (value > max) {
+      return max;
+    }
+    return value;
+  }
+
+  // src/components/tree/tree.ts
+  function syncCheckboxes(changedTreeItem) {
+    function syncAncestors(treeItem) {
+      const parentItem = treeItem.parentElement;
+      if (isTreeItem(parentItem)) {
+        const children = parentItem.getChildrenItems({ includeDisabled: false });
+        const allChecked = !!children.length && children.every((item) => item.selected);
+        const allUnchecked = children.every((item) => !item.selected && !item.indeterminate);
+        parentItem.selected = allChecked;
+        parentItem.indeterminate = !allChecked && !allUnchecked;
+        syncAncestors(parentItem);
+      }
+    }
+    function syncDescendants(treeItem) {
+      for (const childItem of treeItem.getChildrenItems()) {
+        childItem.selected = !childItem.disabled && treeItem.selected;
+        syncDescendants(childItem);
+      }
+    }
+    syncAncestors(changedTreeItem);
+    syncDescendants(changedTreeItem);
+  }
+  var SlTree = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.selection = "single";
+      this.treeItems = [];
+      this.localize = new LocalizeController2(this);
+      this.initTreeItem = (item) => {
+        item.selectable = this.selection === "multiple";
+        ["expand", "collapse"].filter((status) => !!this.querySelector(`[slot="${status}-icon"]`)).forEach((status) => {
+          const existingIcon = item.querySelector(`[slot="${status}-icon"]`);
+          if (existingIcon === null) {
+            item.append(this.getExpandButtonIcon(status));
+          } else if (existingIcon.hasAttribute("data-default")) {
+            existingIcon.replaceWith(this.getExpandButtonIcon(status));
+          } else ;
+        });
+      };
+      this.handleTreeChanged = (mutations) => {
+        for (const mutation of mutations) {
+          const addedNodes = [...mutation.addedNodes].filter(isTreeItem);
+          const removedNodes = [...mutation.removedNodes].filter(isTreeItem);
+          addedNodes.forEach(this.initTreeItem);
+          if (removedNodes.includes(this.lastFocusedItem)) {
+            this.focusItem(this.getFocusableItems()[0]);
+          }
+        }
+      };
+      this.handleFocusOut = (event) => {
+        const relatedTarget = event.relatedTarget;
+        if (!relatedTarget || !this.contains(relatedTarget)) {
+          this.tabIndex = 0;
+        }
+      };
+      this.handleFocusIn = (event) => {
+        const target = event.target;
+        if (event.target === this) {
+          this.focusItem(this.lastFocusedItem || this.treeItems[0]);
+        }
+        if (isTreeItem(target) && !target.disabled) {
+          if (this.lastFocusedItem) {
+            this.lastFocusedItem.tabIndex = -1;
+          }
+          this.lastFocusedItem = target;
+          this.tabIndex = -1;
+          target.tabIndex = 0;
+        }
+      };
+    }
+    async connectedCallback() {
+      super.connectedCallback();
+      this.setAttribute("role", "tree");
+      this.setAttribute("tabindex", "0");
+      this.addEventListener("focusin", this.handleFocusIn);
+      this.addEventListener("focusout", this.handleFocusOut);
+      this.addEventListener("sl-lazy-change", this.updateItems);
+      await this.updateComplete;
+      this.mutationObserver = new MutationObserver(this.handleTreeChanged);
+      this.mutationObserver.observe(this, { childList: true, subtree: true });
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.mutationObserver.disconnect();
+      this.removeEventListener("focusin", this.handleFocusIn);
+      this.removeEventListener("focusout", this.handleFocusOut);
+      this.removeEventListener("sl-lazy-change", this.updateItems);
+    }
+    getExpandButtonIcon(status) {
+      const slot = status === "expand" ? this.expandedIconSlot : this.collapsedIconSlot;
+      const icon = slot.assignedElements({ flatten: true })[0];
+      if (icon) {
+        const clone = icon.cloneNode(true);
+        [clone, ...clone.querySelectorAll("[id]")].forEach((el) => el.removeAttribute("id"));
+        clone.setAttribute("data-default", "");
+        clone.slot = `${status}-icon`;
+        return clone;
+      }
+      return null;
+    }
+    handleSelectionChange() {
+      this.setAttribute("aria-multiselectable", this.selection === "multiple" ? "true" : "false");
+      for (const item of this.treeItems) {
+        item.selectable = this.selection === "multiple";
+      }
+    }
+    syncTreeItems(selectedItem) {
+      if (this.selection === "multiple") {
+        syncCheckboxes(selectedItem);
+      } else {
+        for (const item of this.treeItems) {
+          if (item !== selectedItem) {
+            item.selected = false;
+          }
+        }
+      }
+    }
+    selectItem(selectedItem) {
+      if (this.selection === "multiple") {
+        selectedItem.selected = !selectedItem.selected;
+        if (selectedItem.lazy) {
+          selectedItem.expanded = true;
+        }
+        this.syncTreeItems(selectedItem);
+      } else if (this.selection === "single" || selectedItem.isLeaf) {
+        selectedItem.expanded = !selectedItem.expanded;
+        selectedItem.selected = true;
+        this.syncTreeItems(selectedItem);
+      } else if (this.selection === "leaf") {
+        selectedItem.expanded = !selectedItem.expanded;
+      }
+      this.emit("sl-selection-change", { detail: { selection: this.selectedItems } });
+    }
+    get selectedItems() {
+      const items = [...this.treeItems];
+      const isSelected = (item) => item.selected;
+      return items.filter(isSelected);
+    }
+    getFocusableItems() {
+      const collapsedItems = /* @__PURE__ */ new Set();
+      return [...this.treeItems].filter((item) => {
+        var _a;
+        if (item.disabled)
+          return false;
+        const parent = (_a = item.parentElement) == null ? void 0 : _a.closest("[role=treeitem]");
+        if (parent && (!parent.expanded || parent.loading || collapsedItems.has(parent))) {
+          collapsedItems.add(item);
+        }
+        return !collapsedItems.has(item);
+      });
+    }
+    focusItem(item) {
+      item == null ? void 0 : item.focus();
+    }
+    handleKeyDown(event) {
+      if (!["ArrowDown", "ArrowUp", "ArrowRight", "ArrowLeft", "Home", "End", "Enter", " "].includes(event.key)) {
+        return;
+      }
+      const items = this.getFocusableItems();
+      const isLtr = this.localize.dir() === "ltr";
+      const isRtl = this.localize.dir() === "rtl";
+      if (items.length > 0) {
+        event.preventDefault();
+        const activeItemIndex = items.findIndex((item) => item.matches(":focus"));
+        const activeItem = items[activeItemIndex];
+        const focusItemAt = (index) => {
+          const item = items[clamp(index, 0, items.length - 1)];
+          this.focusItem(item);
+        };
+        const toggleExpand = (expanded) => {
+          activeItem.expanded = expanded;
+        };
+        if (event.key === "ArrowDown") {
+          focusItemAt(activeItemIndex + 1);
+        } else if (event.key === "ArrowUp") {
+          focusItemAt(activeItemIndex - 1);
+        } else if (isLtr && event.key === "ArrowRight" || isRtl && event.key === "ArrowLeft") {
+          if (!activeItem || activeItem.disabled || activeItem.expanded || activeItem.isLeaf && !activeItem.lazy) {
+            focusItemAt(activeItemIndex + 1);
+          } else {
+            toggleExpand(true);
+          }
+        } else if (isLtr && event.key === "ArrowLeft" || isRtl && event.key === "ArrowRight") {
+          if (!activeItem || activeItem.disabled || activeItem.isLeaf || !activeItem.expanded) {
+            focusItemAt(activeItemIndex - 1);
+          } else {
+            toggleExpand(false);
+          }
+        } else if (event.key === "Home") {
+          focusItemAt(0);
+        } else if (event.key === "End") {
+          focusItemAt(items.length - 1);
+        } else if (event.key === "Enter" || event.key === " ") {
+          if (!activeItem.disabled) {
+            this.selectItem(activeItem);
+          }
+        }
+      }
+    }
+    handleClick(event) {
+      const target = event.target;
+      const treeItem = target.closest("sl-tree-item");
+      const isExpandButton = event.composedPath().some((el) => {
+        var _a;
+        return (_a = el == null ? void 0 : el.classList) == null ? void 0 : _a.contains("tree-item__expand-button");
+      });
+      if (!treeItem || treeItem.disabled) {
+        return;
+      }
+      if (this.selection === "multiple" && isExpandButton) {
+        treeItem.expanded = !treeItem.expanded;
+      } else {
+        this.selectItem(treeItem);
+      }
+    }
+    updateItems() {
+      this.treeItems = [...this.querySelectorAll("sl-tree-item")];
+      [...this.treeItems].forEach(this.initTreeItem);
+    }
+    render() {
+      return $`
+      <div part="base" class="tree" @click=${this.handleClick} @keydown=${this.handleKeyDown}>
+        <slot @slotchange=${this.updateItems}></slot>
+        <slot name="expand-icon" hidden aria-hidden="true"> </slot>
+        <slot name="collapse-icon" hidden aria-hidden="true"> </slot>
+      </div>
+    `;
+    }
+  };
+  SlTree.styles = tree_styles_default;
+  __decorateClass([
+    i2$2("slot:not([name])")
+  ], SlTree.prototype, "defaultSlot", 2);
+  __decorateClass([
+    i2$2("slot[name=expand-icon]")
+  ], SlTree.prototype, "expandedIconSlot", 2);
+  __decorateClass([
+    i2$2("slot[name=collapse-icon]")
+  ], SlTree.prototype, "collapsedIconSlot", 2);
+  __decorateClass([
+    e$1()
+  ], SlTree.prototype, "selection", 2);
+  __decorateClass([
+    watch("selection")
+  ], SlTree.prototype, "handleSelectionChange", 1);
+  SlTree = __decorateClass([
+    n$1("sl-tree")
+  ], SlTree);
+
+  // src/components/tab-group/tab-group.styles.ts
+  var tab_group_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --indicator-color: var(--sl-color-primary-600);
+    --track-color: var(--sl-color-neutral-200);
+    --track-width: 2px;
+
+    display: block;
+  }
+
+  .tab-group {
+    display: flex;
+    border: solid 1px transparent;
+    border-radius: 0;
+  }
+
+  .tab-group__tabs {
+    display: flex;
+    position: relative;
+  }
+
+  .tab-group__indicator {
+    position: absolute;
+    transition: var(--sl-transition-fast) transform ease, var(--sl-transition-fast) width ease;
+  }
+
+  .tab-group--has-scroll-controls .tab-group__nav-container {
+    position: relative;
+    padding: 0 var(--sl-spacing-x-large);
+  }
+
+  .tab-group__body {
+    overflow: auto;
+  }
+
+  .tab-group__scroll-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: var(--sl-spacing-x-large);
+  }
+
+  .tab-group__scroll-button--start {
+    left: 0;
+  }
+
+  .tab-group__scroll-button--end {
+    right: 0;
+  }
+
+  .tab-group--rtl .tab-group__scroll-button--start {
+    left: auto;
+    right: 0;
+  }
+
+  .tab-group--rtl .tab-group__scroll-button--end {
+    left: 0;
+    right: auto;
+  }
+
+  /*
+   * Top
+   */
+
+  .tab-group--top {
+    flex-direction: column;
+  }
+
+  .tab-group--top .tab-group__nav-container {
+    order: 1;
+  }
+
+  .tab-group--top .tab-group__nav {
+    display: flex;
+    overflow-x: auto;
+
+    /* Hide scrollbar in Firefox */
+    scrollbar-width: none;
+  }
+
+  /* Hide scrollbar in Chrome/Safari */
+  .tab-group--top .tab-group__nav::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .tab-group--top .tab-group__tabs {
+    flex: 1 1 auto;
+    position: relative;
+    flex-direction: row;
+    border-bottom: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--top .tab-group__indicator {
+    bottom: calc(-1 * var(--track-width));
+    border-bottom: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--top .tab-group__body {
+    order: 2;
+  }
+
+  .tab-group--top ::slotted(sl-tab-panel) {
+    --padding: var(--sl-spacing-medium) 0;
+  }
+
+  /*
+   * Bottom
+   */
+
+  .tab-group--bottom {
+    flex-direction: column;
+  }
+
+  .tab-group--bottom .tab-group__nav-container {
+    order: 2;
+  }
+
+  .tab-group--bottom .tab-group__nav {
+    display: flex;
+    overflow-x: auto;
+
+    /* Hide scrollbar in Firefox */
+    scrollbar-width: none;
+  }
+
+  /* Hide scrollbar in Chrome/Safari */
+  .tab-group--bottom .tab-group__nav::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .tab-group--bottom .tab-group__tabs {
+    flex: 1 1 auto;
+    position: relative;
+    flex-direction: row;
+    border-top: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--bottom .tab-group__indicator {
+    top: calc(-1 * var(--track-width));
+    border-top: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--bottom .tab-group__body {
+    order: 1;
+  }
+
+  .tab-group--bottom ::slotted(sl-tab-panel) {
+    --padding: var(--sl-spacing-medium) 0;
+  }
+
+  /*
+   * Start
+   */
+
+  .tab-group--start {
+    flex-direction: row;
+  }
+
+  .tab-group--start .tab-group__nav-container {
+    order: 1;
+  }
+
+  .tab-group--start .tab-group__tabs {
+    flex: 0 0 auto;
+    flex-direction: column;
+    border-inline-end: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--start .tab-group__indicator {
+    right: calc(-1 * var(--track-width));
+    border-right: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--start.tab-group--rtl .tab-group__indicator {
+    right: auto;
+    left: calc(-1 * var(--track-width));
+  }
+
+  .tab-group--start .tab-group__body {
+    flex: 1 1 auto;
+    order: 2;
+  }
+
+  .tab-group--start ::slotted(sl-tab-panel) {
+    --padding: 0 var(--sl-spacing-medium);
+  }
+
+  /*
+   * End
+   */
+
+  .tab-group--end {
+    flex-direction: row;
+  }
+
+  .tab-group--end .tab-group__nav-container {
+    order: 2;
+  }
+
+  .tab-group--end .tab-group__tabs {
+    flex: 0 0 auto;
+    flex-direction: column;
+    border-left: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--end .tab-group__indicator {
+    left: calc(-1 * var(--track-width));
+    border-inline-start: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--end.tab-group--rtl .tab-group__indicator {
+    right: calc(-1 * var(--track-width));
+    left: auto;
+  }
+
+  .tab-group--end .tab-group__body {
+    flex: 1 1 auto;
+    order: 1;
+  }
+
+  .tab-group--end ::slotted(sl-tab-panel) {
+    --padding: 0 var(--sl-spacing-medium);
+  }
+`;
+
+  // src/internal/offset.ts
+  function getOffset(element, parent) {
+    return {
+      top: Math.round(element.getBoundingClientRect().top - parent.getBoundingClientRect().top),
+      left: Math.round(element.getBoundingClientRect().left - parent.getBoundingClientRect().left)
+    };
+  }
+
+  // src/internal/scroll.ts
+  var locks = /* @__PURE__ */ new Set();
+  function lockBodyScrolling(lockingEl) {
+    locks.add(lockingEl);
+    document.body.classList.add("sl-scroll-lock");
+  }
+  function unlockBodyScrolling(lockingEl) {
+    locks.delete(lockingEl);
+    if (locks.size === 0) {
+      document.body.classList.remove("sl-scroll-lock");
+    }
+  }
+  function scrollIntoView(element, container, direction = "vertical", behavior = "smooth") {
+    const offset = getOffset(element, container);
+    const offsetTop = offset.top + container.scrollTop;
+    const offsetLeft = offset.left + container.scrollLeft;
+    const minX = container.scrollLeft;
+    const maxX = container.scrollLeft + container.offsetWidth;
+    const minY = container.scrollTop;
+    const maxY = container.scrollTop + container.offsetHeight;
+    if (direction === "horizontal" || direction === "both") {
+      if (offsetLeft < minX) {
+        container.scrollTo({ left: offsetLeft, behavior });
+      } else if (offsetLeft + element.clientWidth > maxX) {
+        container.scrollTo({ left: offsetLeft - container.offsetWidth + element.clientWidth, behavior });
+      }
+    }
+    if (direction === "vertical" || direction === "both") {
+      if (offsetTop < minY) {
+        container.scrollTo({ top: offsetTop, behavior });
+      } else if (offsetTop + element.clientHeight > maxY) {
+        container.scrollTo({ top: offsetTop - container.offsetHeight + element.clientHeight, behavior });
+      }
+    }
+  }
+
+  // src/components/tab-group/tab-group.ts
+  var SlTabGroup = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.tabs = [];
+      this.panels = [];
+      this.hasScrollControls = false;
+      this.placement = "top";
+      this.activation = "auto";
+      this.noScrollControls = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.resizeObserver = new ResizeObserver(() => {
+        this.preventIndicatorTransition();
+        this.repositionIndicator();
+        this.updateScrollControls();
+      });
+      this.mutationObserver = new MutationObserver((mutations) => {
+        if (mutations.some((m) => !["aria-labelledby", "aria-controls"].includes(m.attributeName))) {
+          setTimeout(() => this.setAriaLabels());
+        }
+        if (mutations.some((m) => m.attributeName === "disabled")) {
+          this.syncTabsAndPanels();
+        }
+      });
+      this.updateComplete.then(() => {
+        this.syncTabsAndPanels();
+        this.mutationObserver.observe(this, { attributes: true, childList: true, subtree: true });
+        this.resizeObserver.observe(this.nav);
+        const intersectionObserver = new IntersectionObserver((entries, observer) => {
+          var _a;
+          if (entries[0].intersectionRatio > 0) {
+            this.setAriaLabels();
+            this.setActiveTab((_a = this.getActiveTab()) != null ? _a : this.tabs[0], { emitEvents: false });
+            observer.unobserve(entries[0].target);
+          }
+        });
+        intersectionObserver.observe(this.tabGroup);
+      });
+    }
+    disconnectedCallback() {
+      this.mutationObserver.disconnect();
+      this.resizeObserver.unobserve(this.nav);
+    }
+    show(panel) {
+      const tab = this.tabs.find((el) => el.panel === panel);
+      if (tab) {
+        this.setActiveTab(tab, { scrollBehavior: "smooth" });
+      }
+    }
+    getAllTabs(options = { includeDisabled: true }) {
+      const slot = this.shadowRoot.querySelector('slot[name="nav"]');
+      return [...slot.assignedElements()].filter((el) => {
+        return options.includeDisabled ? el.tagName.toLowerCase() === "sl-tab" : el.tagName.toLowerCase() === "sl-tab" && !el.disabled;
+      });
+    }
+    getAllPanels() {
+      const slot = this.body.querySelector("slot");
+      return [...slot.assignedElements()].filter((el) => el.tagName.toLowerCase() === "sl-tab-panel");
+    }
+    getActiveTab() {
+      return this.tabs.find((el) => el.active);
+    }
+    handleClick(event) {
+      const target = event.target;
+      const tab = target.closest("sl-tab");
+      const tabGroup = tab == null ? void 0 : tab.closest("sl-tab-group");
+      if (tabGroup !== this) {
+        return;
+      }
+      if (tab !== null) {
+        this.setActiveTab(tab, { scrollBehavior: "smooth" });
+      }
+    }
+    handleKeyDown(event) {
+      const target = event.target;
+      const tab = target.closest("sl-tab");
+      const tabGroup = tab == null ? void 0 : tab.closest("sl-tab-group");
+      if (tabGroup !== this) {
+        return;
+      }
+      if (["Enter", " "].includes(event.key)) {
+        if (tab !== null) {
+          this.setActiveTab(tab, { scrollBehavior: "smooth" });
           event.preventDefault();
         }
-
-        this.deactivate();
-        this.activate(event.target);
       }
-
-      deactivate() {
-        this.switchableTargets.forEach(target => {
-          target.classList.add("hidden");
+      if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"].includes(event.key)) {
+        const activeEl = this.tabs.find((t2) => t2.matches(":focus"));
+        const isRtl = this.localize.dir() === "rtl";
+        if ((activeEl == null ? void 0 : activeEl.tagName.toLowerCase()) === "sl-tab") {
+          let index = this.tabs.indexOf(activeEl);
+          if (event.key === "Home") {
+            index = 0;
+          } else if (event.key === "End") {
+            index = this.tabs.length - 1;
+          } else if (["top", "bottom"].includes(this.placement) && event.key === (isRtl ? "ArrowRight" : "ArrowLeft") || ["start", "end"].includes(this.placement) && event.key === "ArrowUp") {
+            index--;
+          } else if (["top", "bottom"].includes(this.placement) && event.key === (isRtl ? "ArrowLeft" : "ArrowRight") || ["start", "end"].includes(this.placement) && event.key === "ArrowDown") {
+            index++;
+          }
+          if (index < 0) {
+            index = this.tabs.length - 1;
+          }
+          if (index > this.tabs.length - 1) {
+            index = 0;
+          }
+          this.tabs[index].focus({ preventScroll: true });
+          if (this.activation === "auto") {
+            this.setActiveTab(this.tabs[index], { scrollBehavior: "smooth" });
+          }
+          if (["top", "bottom"].includes(this.placement)) {
+            scrollIntoView(this.tabs[index], this.nav, "horizontal");
+          }
+          event.preventDefault();
+        }
+      }
+    }
+    handleScrollToStart() {
+      this.nav.scroll({
+        left: this.localize.dir() === "rtl" ? this.nav.scrollLeft + this.nav.clientWidth : this.nav.scrollLeft - this.nav.clientWidth,
+        behavior: "smooth"
+      });
+    }
+    handleScrollToEnd() {
+      this.nav.scroll({
+        left: this.localize.dir() === "rtl" ? this.nav.scrollLeft - this.nav.clientWidth : this.nav.scrollLeft + this.nav.clientWidth,
+        behavior: "smooth"
+      });
+    }
+    updateScrollControls() {
+      if (this.noScrollControls) {
+        this.hasScrollControls = false;
+      } else {
+        this.hasScrollControls = ["top", "bottom"].includes(this.placement) && this.nav.scrollWidth > this.nav.clientWidth;
+      }
+    }
+    setActiveTab(tab, options) {
+      options = __spreadValues({
+        emitEvents: true,
+        scrollBehavior: "auto"
+      }, options);
+      if (tab !== this.activeTab && !tab.disabled) {
+        const previousTab = this.activeTab;
+        this.activeTab = tab;
+        this.tabs.map((el) => el.active = el === this.activeTab);
+        this.panels.map((el) => {
+          var _a;
+          return el.active = el.name === ((_a = this.activeTab) == null ? void 0 : _a.panel);
         });
-        this.clickableTargets.forEach(target => {
-          target.classList.remove("text-gray-100", "border-gray-100");
-          target.classList.add("border-gray-900");
+        this.syncIndicator();
+        if (["top", "bottom"].includes(this.placement)) {
+          scrollIntoView(this.activeTab, this.nav, "horizontal", options.scrollBehavior);
+        }
+        if (options.emitEvents) {
+          if (previousTab) {
+            this.emit("sl-tab-hide", { detail: { name: previousTab.panel } });
+          }
+          this.emit("sl-tab-show", { detail: { name: this.activeTab.panel } });
+        }
+      }
+    }
+    setAriaLabels() {
+      this.tabs.forEach((tab) => {
+        const panel = this.panels.find((el) => el.name === tab.panel);
+        if (panel) {
+          tab.setAttribute("aria-controls", panel.getAttribute("id"));
+          panel.setAttribute("aria-labelledby", tab.getAttribute("id"));
+        }
+      });
+    }
+    syncIndicator() {
+      const tab = this.getActiveTab();
+      if (tab) {
+        this.indicator.style.display = "block";
+        this.repositionIndicator();
+      } else {
+        this.indicator.style.display = "none";
+      }
+    }
+    repositionIndicator() {
+      const currentTab = this.getActiveTab();
+      if (!currentTab) {
+        return;
+      }
+      const width = currentTab.clientWidth;
+      const height = currentTab.clientHeight;
+      const isRtl = this.localize.dir() === "rtl";
+      const allTabs = this.getAllTabs();
+      const precedingTabs = allTabs.slice(0, allTabs.indexOf(currentTab));
+      const offset = precedingTabs.reduce(
+        (previous, current) => ({
+          left: previous.left + current.clientWidth,
+          top: previous.top + current.clientHeight
+        }),
+        { left: 0, top: 0 }
+      );
+      switch (this.placement) {
+        case "top":
+        case "bottom":
+          this.indicator.style.width = `${width}px`;
+          this.indicator.style.height = "auto";
+          this.indicator.style.transform = isRtl ? `translateX(${-1 * offset.left}px)` : `translateX(${offset.left}px)`;
+          break;
+        case "start":
+        case "end":
+          this.indicator.style.width = "auto";
+          this.indicator.style.height = `${height}px`;
+          this.indicator.style.transform = `translateY(${offset.top}px)`;
+          break;
+      }
+    }
+    preventIndicatorTransition() {
+      const transitionValue = this.indicator.style.transition;
+      this.indicator.style.transition = "none";
+      requestAnimationFrame(() => {
+        this.indicator.style.transition = transitionValue;
+      });
+    }
+    syncTabsAndPanels() {
+      this.tabs = this.getAllTabs({ includeDisabled: false });
+      this.panels = this.getAllPanels();
+      this.syncIndicator();
+    }
+    render() {
+      const isRtl = this.localize.dir() === "rtl";
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      "tab-group": true,
+      "tab-group--top": this.placement === "top",
+      "tab-group--bottom": this.placement === "bottom",
+      "tab-group--start": this.placement === "start",
+      "tab-group--end": this.placement === "end",
+      "tab-group--rtl": this.localize.dir() === "rtl",
+      "tab-group--has-scroll-controls": this.hasScrollControls
+    })}
+        @click=${this.handleClick}
+        @keydown=${this.handleKeyDown}
+      >
+        <div class="tab-group__nav-container" part="nav">
+          ${this.hasScrollControls ? $`
+                <sl-icon-button
+                  part="scroll-button scroll-button--start"
+                  exportparts="base:scroll-button__base"
+                  class="tab-group__scroll-button tab-group__scroll-button--start"
+                  name=${isRtl ? "chevron-right" : "chevron-left"}
+                  library="system"
+                  label=${this.localize.term("scrollToStart")}
+                  @click=${this.handleScrollToStart}
+                ></sl-icon-button>
+              ` : ""}
+
+          <div class="tab-group__nav">
+            <div part="tabs" class="tab-group__tabs" role="tablist">
+              <div part="active-tab-indicator" class="tab-group__indicator"></div>
+              <slot name="nav" @slotchange=${this.syncTabsAndPanels}></slot>
+            </div>
+          </div>
+
+          ${this.hasScrollControls ? $`
+                <sl-icon-button
+                  part="scroll-button scroll-button--end"
+                  exportparts="base:scroll-button__base"
+                  class="tab-group__scroll-button tab-group__scroll-button--end"
+                  name=${isRtl ? "chevron-left" : "chevron-right"}
+                  library="system"
+                  label=${this.localize.term("scrollToEnd")}
+                  @click=${this.handleScrollToEnd}
+                ></sl-icon-button>
+              ` : ""}
+        </div>
+
+        <div part="body" class="tab-group__body">
+          <slot @slotchange=${this.syncTabsAndPanels}></slot>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlTabGroup.styles = tab_group_styles_default;
+  __decorateClass([
+    i2$2(".tab-group")
+  ], SlTabGroup.prototype, "tabGroup", 2);
+  __decorateClass([
+    i2$2(".tab-group__body")
+  ], SlTabGroup.prototype, "body", 2);
+  __decorateClass([
+    i2$2(".tab-group__nav")
+  ], SlTabGroup.prototype, "nav", 2);
+  __decorateClass([
+    i2$2(".tab-group__indicator")
+  ], SlTabGroup.prototype, "indicator", 2);
+  __decorateClass([
+    t$1()
+  ], SlTabGroup.prototype, "hasScrollControls", 2);
+  __decorateClass([
+    e$1()
+  ], SlTabGroup.prototype, "placement", 2);
+  __decorateClass([
+    e$1()
+  ], SlTabGroup.prototype, "activation", 2);
+  __decorateClass([
+    e$1({ attribute: "no-scroll-controls", type: Boolean })
+  ], SlTabGroup.prototype, "noScrollControls", 2);
+  __decorateClass([
+    watch("noScrollControls", { waitUntilFirstUpdate: true })
+  ], SlTabGroup.prototype, "updateScrollControls", 1);
+  __decorateClass([
+    watch("placement", { waitUntilFirstUpdate: true })
+  ], SlTabGroup.prototype, "syncIndicator", 1);
+  SlTabGroup = __decorateClass([
+    n$1("sl-tab-group")
+  ], SlTabGroup);
+
+  // src/components/tab-panel/tab-panel.styles.ts
+  var tab_panel_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --padding: 0;
+
+    display: block;
+  }
+
+  .tab-panel {
+    border: solid 1px transparent;
+    padding: var(--padding);
+  }
+
+  .tab-panel:not(.tab-panel--active) {
+    display: none;
+  }
+`;
+
+  // src/internal/auto-increment.ts
+  var id = 0;
+  function autoIncrement() {
+    return ++id;
+  }
+
+  // src/components/tab-panel/tab-panel.ts
+  var SlTabPanel = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.attrId = autoIncrement();
+      this.componentId = `sl-tab-panel-${this.attrId}`;
+      this.name = "";
+      this.active = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.id = this.id.length > 0 ? this.id : this.componentId;
+      this.setAttribute("role", "tabpanel");
+    }
+    handleActiveChange() {
+      this.setAttribute("aria-hidden", this.active ? "false" : "true");
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      "tab-panel": true,
+      "tab-panel--active": this.active
+    })}
+      >
+        <slot></slot>
+      </div>
+    `;
+    }
+  };
+  SlTabPanel.styles = tab_panel_styles_default;
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlTabPanel.prototype, "name", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTabPanel.prototype, "active", 2);
+  __decorateClass([
+    watch("active")
+  ], SlTabPanel.prototype, "handleActiveChange", 1);
+  SlTabPanel = __decorateClass([
+    n$1("sl-tab-panel")
+  ], SlTabPanel);
+
+  // src/styles/form-control.styles.ts
+  var form_control_styles_default = r$2`
+  .form-control .form-control__label {
+    display: none;
+  }
+
+  .form-control .form-control__help-text {
+    display: none;
+  }
+
+  /* Label */
+  .form-control--has-label .form-control__label {
+    display: inline-block;
+    color: var(--sl-input-label-color);
+    margin-bottom: var(--sl-spacing-3x-small);
+  }
+
+  .form-control--has-label.form-control--small .form-control__label {
+    font-size: var(--sl-input-label-font-size-small);
+  }
+
+  .form-control--has-label.form-control--medium .form-control__label {
+    font-size: var(--sl-input-label-font-size-medium);
+  }
+
+  .form-control--has-label.form-control--large .form-control_label {
+    font-size: var(--sl-input-label-font-size-large);
+  }
+
+  :host([required]) .form-control--has-label .form-control__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+
+  /* Help text */
+  .form-control--has-help-text .form-control__help-text {
+    display: block;
+    color: var(--sl-input-help-text-color);
+  }
+
+  .form-control--has-help-text .form-control__help-text ::slotted(*) {
+    margin-top: var(--sl-spacing-3x-small);
+  }
+
+  .form-control--has-help-text.form-control--small .form-control__help-text {
+    font-size: var(--sl-input-help-text-font-size-small);
+  }
+
+  .form-control--has-help-text.form-control--medium .form-control__help-text {
+    font-size: var(--sl-input-help-text-font-size-medium);
+  }
+
+  .form-control--has-help-text.form-control--large .form-control__help-text {
+    font-size: var(--sl-input-help-text-font-size-large);
+  }
+`;
+
+  // src/components/textarea/textarea.styles.ts
+  var textarea_styles_default = r$2`
+  ${component_styles_default}
+  ${form_control_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .textarea {
+    display: flex;
+    align-items: center;
+    position: relative;
+    width: 100%;
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-input-font-weight);
+    line-height: var(--sl-line-height-normal);
+    letter-spacing: var(--sl-input-letter-spacing);
+    vertical-align: middle;
+    transition: var(--sl-transition-fast) color, var(--sl-transition-fast) border, var(--sl-transition-fast) box-shadow,
+      var(--sl-transition-fast) background-color;
+    cursor: text;
+  }
+
+  /* Standard textareas */
+  .textarea--standard {
+    background-color: var(--sl-input-background-color);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+  }
+
+  .textarea--standard:hover:not(.textarea--disabled) {
+    background-color: var(--sl-input-background-color-hover);
+    border-color: var(--sl-input-border-color-hover);
+  }
+  .textarea--standard:hover:not(.textarea--disabled) .textarea__control {
+    color: var(--sl-input-color-hover);
+  }
+
+  .textarea--standard.textarea--focused:not(.textarea--disabled) {
+    background-color: var(--sl-input-background-color-focus);
+    border-color: var(--sl-input-border-color-focus);
+    color: var(--sl-input-color-focus);
+    box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-input-focus-ring-color);
+  }
+
+  .textarea--standard.textarea--focused:not(.textarea--disabled) .textarea__control {
+    color: var(--sl-input-color-focus);
+  }
+
+  .textarea--standard.textarea--disabled {
+    background-color: var(--sl-input-background-color-disabled);
+    border-color: var(--sl-input-border-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .textarea--standard.textarea--disabled .textarea__control {
+    color: var(--sl-input-color-disabled);
+  }
+
+  .textarea--standard.textarea--disabled .textarea__control::placeholder {
+    color: var(--sl-input-placeholder-color-disabled);
+  }
+
+  /* Filled textareas */
+  .textarea--filled {
+    border: none;
+    background-color: var(--sl-input-filled-background-color);
+    color: var(--sl-input-color);
+  }
+
+  .textarea--filled:hover:not(.textarea--disabled) {
+    background-color: var(--sl-input-filled-background-color-hover);
+  }
+
+  .textarea--filled.textarea--focused:not(.textarea--disabled) {
+    background-color: var(--sl-input-filled-background-color-focus);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .textarea--filled.textarea--disabled {
+    background-color: var(--sl-input-filled-background-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .textarea__control {
+    flex: 1 1 auto;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: 1.4;
+    color: var(--sl-input-color);
+    border: none;
+    background: none;
+    box-shadow: none;
+    cursor: inherit;
+    -webkit-appearance: none;
+  }
+
+  .textarea__control::-webkit-search-decoration,
+  .textarea__control::-webkit-search-cancel-button,
+  .textarea__control::-webkit-search-results-button,
+  .textarea__control::-webkit-search-results-decoration {
+    -webkit-appearance: none;
+  }
+
+  .textarea__control::placeholder {
+    color: var(--sl-input-placeholder-color);
+    user-select: none;
+  }
+
+  .textarea__control:focus {
+    outline: none;
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .textarea--small {
+    border-radius: var(--sl-input-border-radius-small);
+    font-size: var(--sl-input-font-size-small);
+  }
+
+  .textarea--small .textarea__control {
+    padding: 0.5em var(--sl-input-spacing-small);
+  }
+
+  .textarea--medium {
+    border-radius: var(--sl-input-border-radius-medium);
+    font-size: var(--sl-input-font-size-medium);
+  }
+
+  .textarea--medium .textarea__control {
+    padding: 0.5em var(--sl-input-spacing-medium);
+  }
+
+  .textarea--large {
+    border-radius: var(--sl-input-border-radius-large);
+    font-size: var(--sl-input-font-size-large);
+  }
+
+  .textarea--large .textarea__control {
+    padding: 0.5em var(--sl-input-spacing-large);
+  }
+
+  /*
+   * Resize types
+   */
+
+  .textarea--resize-none .textarea__control {
+    resize: none;
+  }
+
+  .textarea--resize-vertical .textarea__control {
+    resize: vertical;
+  }
+
+  .textarea--resize-auto .textarea__control {
+    height: auto;
+    resize: none;
+  }
+`;
+
+  // src/internal/default-value.ts
+  var defaultValue = (propertyName = "value") => (proto, key) => {
+    const ctor = proto.constructor;
+    const attributeChangedCallback = ctor.prototype.attributeChangedCallback;
+    ctor.prototype.attributeChangedCallback = function(name, old, value) {
+      var _a;
+      const options = ctor.getPropertyOptions(propertyName);
+      const attributeName = typeof options.attribute === "string" ? options.attribute : propertyName;
+      if (name === attributeName) {
+        const converter = options.converter || o2$2;
+        const fromAttribute = typeof converter === "function" ? converter : (_a = converter == null ? void 0 : converter.fromAttribute) != null ? _a : o2$2.fromAttribute;
+        const newValue = fromAttribute(value, options.type);
+        if (this[propertyName] !== newValue) {
+          this[key] = newValue;
+        }
+      }
+      attributeChangedCallback.call(this, name, old, value);
+    };
+  };
+
+  // src/internal/formdata-event-polyfill.ts
+  var FormDataEventPolyfill = class extends Event {
+    constructor(formData) {
+      super("formdata");
+      this.formData = formData;
+    }
+  };
+  var FormDataPolyfill = class extends FormData {
+    constructor(form) {
+      var __super = (...args) => {
+        super(...args);
+      };
+      if (form) {
+        __super(form);
+        this.form = form;
+        form.dispatchEvent(new FormDataEventPolyfill(this));
+      } else {
+        __super();
+      }
+    }
+    append(name, value) {
+      if (!this.form) {
+        return super.append(name, value);
+      }
+      let input = this.form.elements[name];
+      if (!input) {
+        input = document.createElement("input");
+        input.type = "hidden";
+        input.name = name;
+        this.form.appendChild(input);
+      }
+      if (this.has(name)) {
+        const entries = this.getAll(name);
+        const index = entries.indexOf(input.value);
+        if (index !== -1) {
+          entries.splice(index, 1);
+        }
+        entries.push(value);
+        this.set(name, entries);
+      } else {
+        super.append(name, value);
+      }
+      input.value = value;
+    }
+  };
+  function supportsFormDataEvent() {
+    const form = document.createElement("form");
+    let isSupported = false;
+    document.body.append(form);
+    form.addEventListener("submit", (event) => {
+      new FormData(event.target);
+      event.preventDefault();
+    });
+    form.addEventListener("formdata", () => isSupported = true);
+    form.dispatchEvent(new Event("submit", { cancelable: true }));
+    form.remove();
+    return isSupported;
+  }
+  function polyfillFormData() {
+    if (!window.FormData || supportsFormDataEvent()) {
+      return;
+    }
+    window.FormData = FormDataPolyfill;
+    window.addEventListener("submit", (event) => {
+      if (!event.defaultPrevented) {
+        new FormData(event.target);
+      }
+    });
+  }
+  if (document.readyState === "complete") {
+    polyfillFormData();
+  } else {
+    window.addEventListener("DOMContentLoaded", () => polyfillFormData());
+  }
+
+  // src/internal/form.ts
+  var reportValidityOverloads = /* @__PURE__ */ new WeakMap();
+  var FormSubmitController = class {
+    constructor(host, options) {
+      (this.host = host).addController(this);
+      this.options = __spreadValues({
+        form: (input) => input.closest("form"),
+        name: (input) => input.name,
+        value: (input) => input.value,
+        defaultValue: (input) => input.defaultValue,
+        disabled: (input) => input.disabled,
+        reportValidity: (input) => {
+          return typeof input.reportValidity === "function" ? input.reportValidity() : true;
+        },
+        setValue: (input, value) => {
+          input.value = value;
+        }
+      }, options);
+      this.handleFormData = this.handleFormData.bind(this);
+      this.handleFormSubmit = this.handleFormSubmit.bind(this);
+      this.handleFormReset = this.handleFormReset.bind(this);
+      this.reportFormValidity = this.reportFormValidity.bind(this);
+    }
+    hostConnected() {
+      this.form = this.options.form(this.host);
+      if (this.form) {
+        this.form.addEventListener("formdata", this.handleFormData);
+        this.form.addEventListener("submit", this.handleFormSubmit);
+        this.form.addEventListener("reset", this.handleFormReset);
+        if (!reportValidityOverloads.has(this.form)) {
+          reportValidityOverloads.set(this.form, this.form.reportValidity);
+          this.form.reportValidity = () => this.reportFormValidity();
+        }
+      }
+    }
+    hostDisconnected() {
+      if (this.form) {
+        this.form.removeEventListener("formdata", this.handleFormData);
+        this.form.removeEventListener("submit", this.handleFormSubmit);
+        this.form.removeEventListener("reset", this.handleFormReset);
+        if (reportValidityOverloads.has(this.form)) {
+          this.form.reportValidity = reportValidityOverloads.get(this.form);
+          reportValidityOverloads.delete(this.form);
+        }
+        this.form = void 0;
+      }
+    }
+    handleFormData(event) {
+      const disabled = this.options.disabled(this.host);
+      const name = this.options.name(this.host);
+      const value = this.options.value(this.host);
+      if (!disabled && typeof name === "string" && typeof value !== "undefined") {
+        if (Array.isArray(value)) {
+          value.forEach((val) => {
+            event.formData.append(name, val.toString());
+          });
+        } else {
+          event.formData.append(name, value.toString());
+        }
+      }
+    }
+    handleFormSubmit(event) {
+      const disabled = this.options.disabled(this.host);
+      const reportValidity = this.options.reportValidity;
+      if (this.form && !this.form.noValidate && !disabled && !reportValidity(this.host)) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+    }
+    handleFormReset() {
+      this.options.setValue(this.host, this.options.defaultValue(this.host));
+    }
+    reportFormValidity() {
+      if (this.form && !this.form.noValidate) {
+        const elements = this.form.querySelectorAll("*");
+        for (const element of elements) {
+          if (typeof element.reportValidity === "function") {
+            if (!element.reportValidity()) {
+              return false;
+            }
+          }
+        }
+      }
+      return true;
+    }
+    doAction(type, invoker) {
+      if (this.form) {
+        const button = document.createElement("button");
+        button.type = type;
+        button.style.position = "absolute";
+        button.style.width = "0";
+        button.style.height = "0";
+        button.style.clipPath = "inset(50%)";
+        button.style.overflow = "hidden";
+        button.style.whiteSpace = "nowrap";
+        if (invoker) {
+          ["formaction", "formmethod", "formnovalidate", "formtarget"].forEach((attr) => {
+            if (invoker.hasAttribute(attr)) {
+              button.setAttribute(attr, invoker.getAttribute(attr));
+            }
+          });
+        }
+        this.form.append(button);
+        button.click();
+        button.remove();
+      }
+    }
+    reset(invoker) {
+      this.doAction("reset", invoker);
+    }
+    submit(invoker) {
+      this.doAction("submit", invoker);
+    }
+  };
+
+  // src/internal/slot.ts
+  var HasSlotController = class {
+    constructor(host, ...slotNames) {
+      this.slotNames = [];
+      (this.host = host).addController(this);
+      this.slotNames = slotNames;
+      this.handleSlotChange = this.handleSlotChange.bind(this);
+    }
+    hasDefaultSlot() {
+      return [...this.host.childNodes].some((node) => {
+        if (node.nodeType === node.TEXT_NODE && node.textContent.trim() !== "") {
+          return true;
+        }
+        if (node.nodeType === node.ELEMENT_NODE) {
+          const el = node;
+          const tagName = el.tagName.toLowerCase();
+          if (tagName === "sl-visually-hidden") {
+            return false;
+          }
+          if (!el.hasAttribute("slot")) {
+            return true;
+          }
+        }
+        return false;
+      });
+    }
+    hasNamedSlot(name) {
+      return this.host.querySelector(`:scope > [slot="${name}"]`) !== null;
+    }
+    test(slotName) {
+      return slotName === "[default]" ? this.hasDefaultSlot() : this.hasNamedSlot(slotName);
+    }
+    hostConnected() {
+      this.host.shadowRoot.addEventListener("slotchange", this.handleSlotChange);
+    }
+    hostDisconnected() {
+      this.host.shadowRoot.removeEventListener("slotchange", this.handleSlotChange);
+    }
+    handleSlotChange(event) {
+      const slot = event.target;
+      if (this.slotNames.includes("[default]") && !slot.name || slot.name && this.slotNames.includes(slot.name)) {
+        this.host.requestUpdate();
+      }
+    }
+  };
+  function getTextContent(slot) {
+    if (!slot) {
+      return "";
+    }
+    const nodes = slot.assignedNodes({ flatten: true });
+    let text = "";
+    [...nodes].forEach((node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        text += node.textContent;
+      }
+    });
+    return text;
+  }
+
+  // node_modules/lit-html/directives/if-defined.js
+  var l$2 = (l2) => null != l2 ? l2 : w;
+  /**
+   * @license
+   * Copyright 2018 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+
+  // src/components/textarea/textarea.ts
+  var SlTextarea = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.formSubmitController = new FormSubmitController(this);
+      this.hasSlotController = new HasSlotController(this, "help-text", "label");
+      this.hasFocus = false;
+      this.size = "medium";
+      this.value = "";
+      this.filled = false;
+      this.label = "";
+      this.helpText = "";
+      this.rows = 4;
+      this.resize = "vertical";
+      this.disabled = false;
+      this.readonly = false;
+      this.required = false;
+      this.invalid = false;
+      this.defaultValue = "";
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.resizeObserver = new ResizeObserver(() => this.setTextareaHeight());
+      this.updateComplete.then(() => {
+        this.setTextareaHeight();
+        this.resizeObserver.observe(this.input);
+      });
+    }
+    firstUpdated() {
+      this.invalid = !this.input.checkValidity();
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.resizeObserver.unobserve(this.input);
+    }
+    focus(options) {
+      this.input.focus(options);
+    }
+    blur() {
+      this.input.blur();
+    }
+    select() {
+      this.input.select();
+    }
+    scrollPosition(position) {
+      if (position) {
+        if (typeof position.top === "number")
+          this.input.scrollTop = position.top;
+        if (typeof position.left === "number")
+          this.input.scrollLeft = position.left;
+        return void 0;
+      }
+      return {
+        top: this.input.scrollTop,
+        left: this.input.scrollTop
+      };
+    }
+    setSelectionRange(selectionStart, selectionEnd, selectionDirection = "none") {
+      this.input.setSelectionRange(selectionStart, selectionEnd, selectionDirection);
+    }
+    setRangeText(replacement, start, end, selectMode = "preserve") {
+      this.input.setRangeText(replacement, start, end, selectMode);
+      if (this.value !== this.input.value) {
+        this.value = this.input.value;
+        this.emit("sl-input");
+      }
+      if (this.value !== this.input.value) {
+        this.value = this.input.value;
+        this.setTextareaHeight();
+        this.emit("sl-input");
+        this.emit("sl-change");
+      }
+    }
+    reportValidity() {
+      return this.input.reportValidity();
+    }
+    setCustomValidity(message) {
+      this.input.setCustomValidity(message);
+      this.invalid = !this.input.checkValidity();
+    }
+    handleBlur() {
+      this.hasFocus = false;
+      this.emit("sl-blur");
+    }
+    handleChange() {
+      this.value = this.input.value;
+      this.setTextareaHeight();
+      this.emit("sl-change");
+    }
+    handleDisabledChange() {
+      this.input.disabled = this.disabled;
+      this.invalid = !this.input.checkValidity();
+    }
+    handleFocus() {
+      this.hasFocus = true;
+      this.emit("sl-focus");
+    }
+    handleInput() {
+      this.value = this.input.value;
+      this.emit("sl-input");
+    }
+    handleRowsChange() {
+      this.setTextareaHeight();
+    }
+    handleValueChange() {
+      this.invalid = !this.input.checkValidity();
+      this.updateComplete.then(() => this.setTextareaHeight());
+    }
+    setTextareaHeight() {
+      if (this.resize === "auto") {
+        this.input.style.height = "auto";
+        this.input.style.height = `${this.input.scrollHeight}px`;
+      } else {
+        this.input.style.height = void 0;
+      }
+    }
+    render() {
+      const hasLabelSlot = this.hasSlotController.test("label");
+      const hasHelpTextSlot = this.hasSlotController.test("help-text");
+      const hasLabel = this.label ? true : !!hasLabelSlot;
+      const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
+      return $`
+      <div
+        part="form-control"
+        class=${o$3({
+      "form-control": true,
+      "form-control--small": this.size === "small",
+      "form-control--medium": this.size === "medium",
+      "form-control--large": this.size === "large",
+      "form-control--has-label": hasLabel,
+      "form-control--has-help-text": hasHelpText
+    })}
+      >
+        <label
+          part="form-control-label"
+          class="form-control__label"
+          for="input"
+          aria-hidden=${hasLabel ? "false" : "true"}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <div
+            part="base"
+            class=${o$3({
+      textarea: true,
+      "textarea--small": this.size === "small",
+      "textarea--medium": this.size === "medium",
+      "textarea--large": this.size === "large",
+      "textarea--standard": !this.filled,
+      "textarea--filled": this.filled,
+      "textarea--disabled": this.disabled,
+      "textarea--focused": this.hasFocus,
+      "textarea--empty": !this.value,
+      "textarea--invalid": this.invalid,
+      "textarea--resize-none": this.resize === "none",
+      "textarea--resize-vertical": this.resize === "vertical",
+      "textarea--resize-auto": this.resize === "auto"
+    })}
+          >
+            <textarea
+              part="textarea"
+              id="input"
+              class="textarea__control"
+              name=${l$2(this.name)}
+              .value=${l$3(this.value)}
+              ?disabled=${this.disabled}
+              ?readonly=${this.readonly}
+              ?required=${this.required}
+              placeholder=${l$2(this.placeholder)}
+              rows=${l$2(this.rows)}
+              minlength=${l$2(this.minlength)}
+              maxlength=${l$2(this.maxlength)}
+              autocapitalize=${l$2(this.autocapitalize)}
+              autocorrect=${l$2(this.autocorrect)}
+              ?autofocus=${this.autofocus}
+              spellcheck=${l$2(this.spellcheck)}
+              enterkeyhint=${l$2(this.enterkeyhint)}
+              inputmode=${l$2(this.inputmode)}
+              aria-describedby="help-text"
+              @change=${this.handleChange}
+              @input=${this.handleInput}
+              @focus=${this.handleFocus}
+              @blur=${this.handleBlur}
+            ></textarea>
+          </div>
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${hasHelpText ? "false" : "true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlTextarea.styles = textarea_styles_default;
+  __decorateClass([
+    i2$2(".textarea__control")
+  ], SlTextarea.prototype, "input", 2);
+  __decorateClass([
+    t$1()
+  ], SlTextarea.prototype, "hasFocus", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlTextarea.prototype, "size", 2);
+  __decorateClass([
+    e$1()
+  ], SlTextarea.prototype, "name", 2);
+  __decorateClass([
+    e$1()
+  ], SlTextarea.prototype, "value", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTextarea.prototype, "filled", 2);
+  __decorateClass([
+    e$1()
+  ], SlTextarea.prototype, "label", 2);
+  __decorateClass([
+    e$1({ attribute: "help-text" })
+  ], SlTextarea.prototype, "helpText", 2);
+  __decorateClass([
+    e$1()
+  ], SlTextarea.prototype, "placeholder", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlTextarea.prototype, "rows", 2);
+  __decorateClass([
+    e$1()
+  ], SlTextarea.prototype, "resize", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTextarea.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTextarea.prototype, "readonly", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlTextarea.prototype, "minlength", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlTextarea.prototype, "maxlength", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTextarea.prototype, "required", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTextarea.prototype, "invalid", 2);
+  __decorateClass([
+    e$1()
+  ], SlTextarea.prototype, "autocapitalize", 2);
+  __decorateClass([
+    e$1()
+  ], SlTextarea.prototype, "autocorrect", 2);
+  __decorateClass([
+    e$1()
+  ], SlTextarea.prototype, "autocomplete", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlTextarea.prototype, "autofocus", 2);
+  __decorateClass([
+    e$1()
+  ], SlTextarea.prototype, "enterkeyhint", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlTextarea.prototype, "spellcheck", 2);
+  __decorateClass([
+    e$1()
+  ], SlTextarea.prototype, "inputmode", 2);
+  __decorateClass([
+    defaultValue()
+  ], SlTextarea.prototype, "defaultValue", 2);
+  __decorateClass([
+    watch("disabled", { waitUntilFirstUpdate: true })
+  ], SlTextarea.prototype, "handleDisabledChange", 1);
+  __decorateClass([
+    watch("rows", { waitUntilFirstUpdate: true })
+  ], SlTextarea.prototype, "handleRowsChange", 1);
+  __decorateClass([
+    watch("value", { waitUntilFirstUpdate: true })
+  ], SlTextarea.prototype, "handleValueChange", 1);
+  SlTextarea = __decorateClass([
+    n$1("sl-textarea")
+  ], SlTextarea);
+
+  // src/components/split-panel/split-panel.styles.ts
+  var split_panel_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --divider-width: 4px;
+    --divider-hit-area: 12px;
+    --min: 0%;
+    --max: 100%;
+
+    display: grid;
+  }
+
+  .start,
+  .end {
+    overflow: hidden;
+  }
+
+  .divider {
+    flex: 0 0 var(--divider-width);
+    display: flex;
+    position: relative;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--sl-color-neutral-200);
+    color: var(--sl-color-neutral-900);
+    z-index: 1;
+  }
+
+  .divider:focus {
+    outline: none;
+  }
+
+  :host(:not([disabled])) .divider:focus-visible {
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  :host([disabled]) .divider {
+    cursor: not-allowed;
+  }
+
+  /* Horizontal */
+  :host(:not([vertical], [disabled])) .divider {
+    cursor: col-resize;
+  }
+
+  :host(:not([vertical])) .divider::after {
+    display: flex;
+    content: '';
+    position: absolute;
+    height: 100%;
+    left: calc(var(--divider-hit-area) / -2 + var(--divider-width) / 2);
+    width: var(--divider-hit-area);
+  }
+
+  /* Vertical */
+  :host([vertical]) {
+    flex-direction: column;
+  }
+
+  :host([vertical]:not([disabled])) .divider {
+    cursor: row-resize;
+  }
+
+  :host([vertical]) .divider::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    top: calc(var(--divider-hit-area) / -2 + var(--divider-width) / 2);
+    height: var(--divider-hit-area);
+  }
+`;
+
+  // src/internal/drag.ts
+  function drag(container, options) {
+    var _a;
+    function move(pointerEvent) {
+      const dims = container.getBoundingClientRect();
+      const defaultView = container.ownerDocument.defaultView;
+      const offsetX = dims.left + defaultView.pageXOffset;
+      const offsetY = dims.top + defaultView.pageYOffset;
+      const x = pointerEvent.pageX - offsetX;
+      const y = pointerEvent.pageY - offsetY;
+      if (options == null ? void 0 : options.onMove) {
+        options.onMove(x, y);
+      }
+    }
+    function stop() {
+      document.removeEventListener("pointermove", move);
+      document.removeEventListener("pointerup", stop);
+      if (options == null ? void 0 : options.onStop) {
+        options.onStop();
+      }
+    }
+    document.addEventListener("pointermove", move, { passive: true });
+    document.addEventListener("pointerup", stop);
+    if (((_a = options == null ? void 0 : options.initialEvent) == null ? void 0 : _a.type) === "pointermove") {
+      move(options.initialEvent);
+    }
+  }
+
+  // src/components/split-panel/split-panel.ts
+  var SlSplitPanel = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.position = 50;
+      this.vertical = false;
+      this.disabled = false;
+      this.snapThreshold = 12;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.resizeObserver = new ResizeObserver((entries) => this.handleResize(entries));
+      this.updateComplete.then(() => this.resizeObserver.observe(this));
+      this.detectSize();
+      this.cachedPositionInPixels = this.percentageToPixels(this.position);
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.resizeObserver.unobserve(this);
+    }
+    detectSize() {
+      const { width, height } = this.getBoundingClientRect();
+      this.size = this.vertical ? height : width;
+    }
+    percentageToPixels(value) {
+      return this.size * (value / 100);
+    }
+    pixelsToPercentage(value) {
+      return value / this.size * 100;
+    }
+    handleDrag(event) {
+      const isRtl = this.localize.dir() === "rtl";
+      if (this.disabled) {
+        return;
+      }
+      if (event.cancelable) {
+        event.preventDefault();
+      }
+      drag(this, {
+        onMove: (x, y) => {
+          let newPositionInPixels = this.vertical ? y : x;
+          if (this.primary === "end") {
+            newPositionInPixels = this.size - newPositionInPixels;
+          }
+          if (this.snap) {
+            const snaps = this.snap.split(" ");
+            snaps.forEach((value) => {
+              let snapPoint;
+              if (value.endsWith("%")) {
+                snapPoint = this.size * (parseFloat(value) / 100);
+              } else {
+                snapPoint = parseFloat(value);
+              }
+              if (isRtl && !this.vertical) {
+                snapPoint = this.size - snapPoint;
+              }
+              if (newPositionInPixels >= snapPoint - this.snapThreshold && newPositionInPixels <= snapPoint + this.snapThreshold) {
+                newPositionInPixels = snapPoint;
+              }
+            });
+          }
+          this.position = clamp(this.pixelsToPercentage(newPositionInPixels), 0, 100);
+        },
+        initialEvent: event
+      });
+    }
+    handleKeyDown(event) {
+      if (this.disabled) {
+        return;
+      }
+      if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"].includes(event.key)) {
+        let newPosition = this.position;
+        const incr = (event.shiftKey ? 10 : 1) * (this.primary === "end" ? -1 : 1);
+        event.preventDefault();
+        if (event.key === "ArrowLeft" && !this.vertical || event.key === "ArrowUp" && this.vertical) {
+          newPosition -= incr;
+        }
+        if (event.key === "ArrowRight" && !this.vertical || event.key === "ArrowDown" && this.vertical) {
+          newPosition += incr;
+        }
+        if (event.key === "Home") {
+          newPosition = this.primary === "end" ? 100 : 0;
+        }
+        if (event.key === "End") {
+          newPosition = this.primary === "end" ? 0 : 100;
+        }
+        this.position = clamp(newPosition, 0, 100);
+      }
+    }
+    handlePositionChange() {
+      this.cachedPositionInPixels = this.percentageToPixels(this.position);
+      this.positionInPixels = this.percentageToPixels(this.position);
+      this.emit("sl-reposition");
+    }
+    handlePositionInPixelsChange() {
+      this.position = this.pixelsToPercentage(this.positionInPixels);
+    }
+    handleVerticalChange() {
+      this.detectSize();
+    }
+    handleResize(entries) {
+      const { width, height } = entries[0].contentRect;
+      this.size = this.vertical ? height : width;
+      if (this.primary) {
+        this.position = this.pixelsToPercentage(this.cachedPositionInPixels);
+      }
+    }
+    render() {
+      const gridTemplate = this.vertical ? "gridTemplateRows" : "gridTemplateColumns";
+      const gridTemplateAlt = this.vertical ? "gridTemplateColumns" : "gridTemplateRows";
+      const isRtl = this.localize.dir() === "rtl";
+      const primary = `
+      clamp(
+        0%,
+        clamp(
+          var(--min),
+          ${this.position}% - var(--divider-width) / 2,
+          var(--max)
+        ),
+        calc(100% - var(--divider-width))
+      )
+    `;
+      const secondary = "auto";
+      if (this.primary === "end") {
+        if (isRtl && !this.vertical) {
+          this.style[gridTemplate] = `${primary} var(--divider-width) ${secondary}`;
+        } else {
+          this.style[gridTemplate] = `${secondary} var(--divider-width) ${primary}`;
+        }
+      } else {
+        if (isRtl && !this.vertical) {
+          this.style[gridTemplate] = `${secondary} var(--divider-width) ${primary}`;
+        } else {
+          this.style[gridTemplate] = `${primary} var(--divider-width) ${secondary}`;
+        }
+      }
+      this.style[gridTemplateAlt] = "";
+      return $`
+      <div part="panel start" class="start">
+        <slot name="start"></slot>
+      </div>
+
+      <div
+        part="divider"
+        class="divider"
+        tabindex=${l$2(this.disabled ? void 0 : "0")}
+        role="separator"
+        aria-label=${this.localize.term("resize")}
+        @keydown=${this.handleKeyDown}
+        @mousedown=${this.handleDrag}
+        @touchstart=${this.handleDrag}
+      >
+        <slot name="handle"></slot>
+      </div>
+
+      <div part="panel end" class="end">
+        <slot name="end"></slot>
+      </div>
+    `;
+    }
+  };
+  SlSplitPanel.styles = split_panel_styles_default;
+  __decorateClass([
+    i2$2(".divider")
+  ], SlSplitPanel.prototype, "divider", 2);
+  __decorateClass([
+    e$1({ type: Number, reflect: true })
+  ], SlSplitPanel.prototype, "position", 2);
+  __decorateClass([
+    e$1({ attribute: "position-in-pixels", type: Number })
+  ], SlSplitPanel.prototype, "positionInPixels", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSplitPanel.prototype, "vertical", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSplitPanel.prototype, "disabled", 2);
+  __decorateClass([
+    e$1()
+  ], SlSplitPanel.prototype, "primary", 2);
+  __decorateClass([
+    e$1()
+  ], SlSplitPanel.prototype, "snap", 2);
+  __decorateClass([
+    e$1({ type: Number, attribute: "snap-threshold" })
+  ], SlSplitPanel.prototype, "snapThreshold", 2);
+  __decorateClass([
+    watch("position")
+  ], SlSplitPanel.prototype, "handlePositionChange", 1);
+  __decorateClass([
+    watch("positionInPixels")
+  ], SlSplitPanel.prototype, "handlePositionInPixelsChange", 1);
+  __decorateClass([
+    watch("vertical")
+  ], SlSplitPanel.prototype, "handleVerticalChange", 1);
+  SlSplitPanel = __decorateClass([
+    n$1("sl-split-panel")
+  ], SlSplitPanel);
+
+  // src/components/switch/switch.styles.ts
+  var switch_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --height: var(--sl-toggle-size);
+    --thumb-size: calc(var(--sl-toggle-size) + 4px);
+    --width: calc(var(--height) * 2);
+
+    display: inline-block;
+  }
+
+  .switch {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--sl-input-font-family);
+    font-size: var(--sl-input-font-size-medium);
+    font-weight: var(--sl-input-font-weight);
+    color: var(--sl-input-color);
+    vertical-align: middle;
+    cursor: pointer;
+  }
+
+  .switch__control {
+    flex: 0 0 auto;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--width);
+    height: var(--height);
+    background-color: var(--sl-color-neutral-400);
+    border: solid var(--sl-input-border-width) var(--sl-color-neutral-400);
+    border-radius: var(--height);
+    transition: var(--sl-transition-fast) border-color, var(--sl-transition-fast) background-color;
+  }
+
+  .switch__control .switch__thumb {
+    width: var(--thumb-size);
+    height: var(--thumb-size);
+    background-color: var(--sl-color-neutral-0);
+    border-radius: 50%;
+    border: solid var(--sl-input-border-width) var(--sl-color-neutral-400);
+    transform: translateX(calc((var(--width) - var(--height)) / -2));
+    transition: var(--sl-transition-fast) transform ease, var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) border-color, var(--sl-transition-fast) box-shadow;
+  }
+
+  .switch__input {
+    position: absolute;
+    opacity: 0;
+    padding: 0;
+    margin: 0;
+    pointer-events: none;
+  }
+
+  /* Hover */
+  .switch:not(.switch--checked):not(.switch--disabled) .switch__control:hover {
+    background-color: var(--sl-color-neutral-400);
+    border-color: var(--sl-color-neutral-400);
+  }
+
+  .switch:not(.switch--checked):not(.switch--disabled) .switch__control:hover .switch__thumb {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-neutral-400);
+  }
+
+  /* Focus */
+  .switch:not(.switch--checked):not(.switch--disabled) .switch__input:focus-visible ~ .switch__control {
+    background-color: var(--sl-color-neutral-400);
+    border-color: var(--sl-color-neutral-400);
+  }
+
+  .switch:not(.switch--checked):not(.switch--disabled) .switch__input:focus-visible ~ .switch__control .switch__thumb {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-primary-600);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Checked */
+  .switch--checked .switch__control {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+  }
+
+  .switch--checked .switch__control .switch__thumb {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-primary-600);
+    transform: translateX(calc((var(--width) - var(--height)) / 2));
+  }
+
+  /* Checked + hover */
+  .switch.switch--checked:not(.switch--disabled) .switch__control:hover {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+  }
+
+  .switch.switch--checked:not(.switch--disabled) .switch__control:hover .switch__thumb {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-primary-600);
+  }
+
+  /* Checked + focus */
+  .switch.switch--checked:not(.switch--disabled) .switch__input:focus-visible ~ .switch__control {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+  }
+
+  .switch.switch--checked:not(.switch--disabled) .switch__input:focus-visible ~ .switch__control .switch__thumb {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-primary-600);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Disabled */
+  .switch--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .switch__label {
+    line-height: var(--height);
+    margin-inline-start: 0.5em;
+    user-select: none;
+  }
+
+  :host([required]) .switch__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+`;
+
+  // src/components/switch/switch.ts
+  var SlSwitch = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.formSubmitController = new FormSubmitController(this, {
+        value: (control) => control.checked ? control.value : void 0,
+        defaultValue: (control) => control.defaultChecked,
+        setValue: (control, checked) => control.checked = checked
+      });
+      this.hasFocus = false;
+      this.disabled = false;
+      this.required = false;
+      this.checked = false;
+      this.invalid = false;
+      this.defaultChecked = false;
+    }
+    firstUpdated() {
+      this.invalid = !this.input.checkValidity();
+    }
+    click() {
+      this.input.click();
+    }
+    focus(options) {
+      this.input.focus(options);
+    }
+    blur() {
+      this.input.blur();
+    }
+    reportValidity() {
+      return this.input.reportValidity();
+    }
+    setCustomValidity(message) {
+      this.input.setCustomValidity(message);
+      this.invalid = !this.input.checkValidity();
+    }
+    handleBlur() {
+      this.hasFocus = false;
+      this.emit("sl-blur");
+    }
+    handleCheckedChange() {
+      this.input.checked = this.checked;
+      this.invalid = !this.input.checkValidity();
+    }
+    handleClick() {
+      this.checked = !this.checked;
+      this.emit("sl-change");
+    }
+    handleDisabledChange() {
+      this.input.disabled = this.disabled;
+      this.invalid = !this.input.checkValidity();
+    }
+    handleFocus() {
+      this.hasFocus = true;
+      this.emit("sl-focus");
+    }
+    handleKeyDown(event) {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        this.checked = false;
+        this.emit("sl-change");
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        this.checked = true;
+        this.emit("sl-change");
+      }
+    }
+    render() {
+      return $`
+      <label
+        part="base"
+        class=${o$3({
+      switch: true,
+      "switch--checked": this.checked,
+      "switch--disabled": this.disabled,
+      "switch--focused": this.hasFocus
+    })}
+      >
+        <input
+          class="switch__input"
+          type="checkbox"
+          name=${l$2(this.name)}
+          value=${l$2(this.value)}
+          .checked=${l$3(this.checked)}
+          .disabled=${this.disabled}
+          .required=${this.required}
+          role="switch"
+          aria-checked=${this.checked ? "true" : "false"}
+          @click=${this.handleClick}
+          @blur=${this.handleBlur}
+          @focus=${this.handleFocus}
+          @keydown=${this.handleKeyDown}
+        />
+
+        <span part="control" class="switch__control">
+          <span part="thumb" class="switch__thumb"></span>
+        </span>
+
+        <span part="label" class="switch__label">
+          <slot></slot>
+        </span>
+      </label>
+    `;
+    }
+  };
+  SlSwitch.styles = switch_styles_default;
+  __decorateClass([
+    i2$2('input[type="checkbox"]')
+  ], SlSwitch.prototype, "input", 2);
+  __decorateClass([
+    t$1()
+  ], SlSwitch.prototype, "hasFocus", 2);
+  __decorateClass([
+    e$1()
+  ], SlSwitch.prototype, "name", 2);
+  __decorateClass([
+    e$1()
+  ], SlSwitch.prototype, "value", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSwitch.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSwitch.prototype, "required", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSwitch.prototype, "checked", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSwitch.prototype, "invalid", 2);
+  __decorateClass([
+    defaultValue("checked")
+  ], SlSwitch.prototype, "defaultChecked", 2);
+  __decorateClass([
+    watch("checked", { waitUntilFirstUpdate: true })
+  ], SlSwitch.prototype, "handleCheckedChange", 1);
+  __decorateClass([
+    watch("disabled", { waitUntilFirstUpdate: true })
+  ], SlSwitch.prototype, "handleDisabledChange", 1);
+  SlSwitch = __decorateClass([
+    n$1("sl-switch")
+  ], SlSwitch);
+
+  // src/components/tab/tab.styles.ts
+  var tab_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .tab {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-small);
+    font-weight: var(--sl-font-weight-semibold);
+    border-radius: var(--sl-border-radius-medium);
+    color: var(--sl-color-neutral-600);
+    padding: var(--sl-spacing-medium) var(--sl-spacing-large);
+    white-space: nowrap;
+    user-select: none;
+    cursor: pointer;
+    transition: var(--transition-speed) box-shadow, var(--transition-speed) color;
+  }
+
+  .tab:hover:not(.tab--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  .tab:focus {
+    outline: none;
+  }
+
+  .tab:focus-visible:not(.tab--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  .tab:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: calc(-1 * var(--sl-focus-ring-width) - var(--sl-focus-ring-offset));
+  }
+
+  .tab.tab--active:not(.tab--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  .tab.tab--closable {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .tab.tab--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .tab__close-button {
+    font-size: var(--sl-font-size-large);
+    margin-inline-start: var(--sl-spacing-2x-small);
+  }
+
+  .tab__close-button::part(base) {
+    padding: var(--sl-spacing-3x-small);
+  }
+`;
+
+  // src/components/tab/tab.ts
+  var SlTab = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.attrId = autoIncrement();
+      this.componentId = `sl-tab-${this.attrId}`;
+      this.panel = "";
+      this.active = false;
+      this.closable = false;
+      this.disabled = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.setAttribute("role", "tab");
+    }
+    focus(options) {
+      this.tab.focus(options);
+    }
+    blur() {
+      this.tab.blur();
+    }
+    handleCloseClick() {
+      this.emit("sl-close");
+    }
+    handleActiveChange() {
+      this.setAttribute("aria-selected", this.active ? "true" : "false");
+    }
+    handleDisabledChange() {
+      this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+    }
+    render() {
+      this.id = this.id.length > 0 ? this.id : this.componentId;
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      tab: true,
+      "tab--active": this.active,
+      "tab--closable": this.closable,
+      "tab--disabled": this.disabled
+    })}
+        tabindex=${this.disabled ? "-1" : "0"}
+      >
+        <slot></slot>
+        ${this.closable ? $`
+              <sl-icon-button
+                part="close-button"
+                exportparts="base:close-button__base"
+                name="x"
+                library="system"
+                label=${this.localize.term("close")}
+                class="tab__close-button"
+                @click=${this.handleCloseClick}
+                tabindex="-1"
+              ></sl-icon-button>
+            ` : ""}
+      </div>
+    `;
+    }
+  };
+  SlTab.styles = tab_styles_default;
+  __decorateClass([
+    i2$2(".tab")
+  ], SlTab.prototype, "tab", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlTab.prototype, "panel", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTab.prototype, "active", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlTab.prototype, "closable", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTab.prototype, "disabled", 2);
+  __decorateClass([
+    watch("active")
+  ], SlTab.prototype, "handleActiveChange", 1);
+  __decorateClass([
+    watch("disabled")
+  ], SlTab.prototype, "handleDisabledChange", 1);
+  SlTab = __decorateClass([
+    n$1("sl-tab")
+  ], SlTab);
+
+  // src/components/resize-observer/resize-observer.styles.ts
+  var resize_observer_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: contents;
+  }
+`;
+
+  // src/components/resize-observer/resize-observer.ts
+  var SlResizeObserver = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.observedElements = [];
+      this.disabled = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.resizeObserver = new ResizeObserver((entries) => {
+        this.emit("sl-resize", { detail: { entries } });
+      });
+      if (!this.disabled) {
+        this.startObserver();
+      }
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.stopObserver();
+    }
+    handleSlotChange() {
+      if (!this.disabled) {
+        this.startObserver();
+      }
+    }
+    startObserver() {
+      const slot = this.shadowRoot.querySelector("slot");
+      if (slot !== null) {
+        const elements = slot.assignedElements({ flatten: true });
+        this.observedElements.forEach((el) => this.resizeObserver.unobserve(el));
+        this.observedElements = [];
+        elements.forEach((el) => {
+          this.resizeObserver.observe(el);
+          this.observedElements.push(el);
         });
       }
+    }
+    stopObserver() {
+      this.resizeObserver.disconnect();
+    }
+    handleDisabledChange() {
+      if (this.disabled) {
+        this.stopObserver();
+      } else {
+        this.startObserver();
+      }
+    }
+    render() {
+      return $` <slot @slotchange=${this.handleSlotChange}></slot> `;
+    }
+  };
+  SlResizeObserver.styles = resize_observer_styles_default;
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlResizeObserver.prototype, "disabled", 2);
+  __decorateClass([
+    watch("disabled", { waitUntilFirstUpdate: true })
+  ], SlResizeObserver.prototype, "handleDisabledChange", 1);
+  SlResizeObserver = __decorateClass([
+    n$1("sl-resize-observer")
+  ], SlResizeObserver);
 
-      activate(currentElement) {
-        currentElement.classList.remove("border-gray-900");
-        currentElement.classList.add("text-gray-100", "border-gray-100");
-        document.querySelectorAll(`.${currentElement.id}`).forEach(element => {
-          element.classList.remove("hidden");
+  // src/components/relative-time/relative-time.ts
+  var availableUnits = [
+    { max: 276e4, value: 6e4, unit: "minute" },
+    { max: 72e6, value: 36e5, unit: "hour" },
+    { max: 5184e5, value: 864e5, unit: "day" },
+    { max: 24192e5, value: 6048e5, unit: "week" },
+    { max: 28512e6, value: 2592e6, unit: "month" },
+    { max: Infinity, value: 31536e6, unit: "year" }
+  ];
+  var SlRelativeTime = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.isoTime = "";
+      this.relativeTime = "";
+      this.titleTime = "";
+      this.format = "long";
+      this.numeric = "auto";
+      this.sync = false;
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      clearTimeout(this.updateTimeout);
+    }
+    render() {
+      const now = new Date();
+      const then = new Date(this.date);
+      if (isNaN(then.getMilliseconds())) {
+        this.relativeTime = "";
+        this.isoTime = "";
+        return "";
+      }
+      const diff = then.getTime() - now.getTime();
+      const { unit, value } = availableUnits.find((singleUnit) => Math.abs(diff) < singleUnit.max);
+      this.isoTime = then.toISOString();
+      this.titleTime = this.localize.date(then, {
+        month: "long",
+        year: "numeric",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        timeZoneName: "short"
+      });
+      this.relativeTime = this.localize.relativeTime(Math.round(diff / value), unit, {
+        numeric: this.numeric,
+        style: this.format
+      });
+      clearTimeout(this.updateTimeout);
+      if (this.sync) {
+        let nextInterval;
+        if (unit === "minute") {
+          nextInterval = getTimeUntilNextUnit("second");
+        } else if (unit === "hour") {
+          nextInterval = getTimeUntilNextUnit("minute");
+        } else if (unit === "day") {
+          nextInterval = getTimeUntilNextUnit("hour");
+        } else {
+          nextInterval = getTimeUntilNextUnit("day");
+        }
+        this.updateTimeout = window.setTimeout(() => this.requestUpdate(), nextInterval);
+      }
+      return $` <time datetime=${this.isoTime} title=${this.titleTime}>${this.relativeTime}</time> `;
+    }
+  };
+  __decorateClass([
+    t$1()
+  ], SlRelativeTime.prototype, "isoTime", 2);
+  __decorateClass([
+    t$1()
+  ], SlRelativeTime.prototype, "relativeTime", 2);
+  __decorateClass([
+    t$1()
+  ], SlRelativeTime.prototype, "titleTime", 2);
+  __decorateClass([
+    e$1()
+  ], SlRelativeTime.prototype, "date", 2);
+  __decorateClass([
+    e$1()
+  ], SlRelativeTime.prototype, "format", 2);
+  __decorateClass([
+    e$1()
+  ], SlRelativeTime.prototype, "numeric", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlRelativeTime.prototype, "sync", 2);
+  SlRelativeTime = __decorateClass([
+    n$1("sl-relative-time")
+  ], SlRelativeTime);
+  function getTimeUntilNextUnit(unit) {
+    const units = { second: 1e3, minute: 6e4, hour: 36e5, day: 864e5 };
+    const value = units[unit];
+    return value - Date.now() % value;
+  }
+
+  // src/components/select/select.styles.ts
+  var select_styles_default = r$2`
+  ${component_styles_default}
+  ${form_control_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .select {
+    display: block;
+  }
+
+  .select::part(panel) {
+    overflow: hidden;
+  }
+
+  .select__control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: start;
+    position: relative;
+    width: 100%;
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-input-font-weight);
+    letter-spacing: var(--sl-input-letter-spacing);
+    vertical-align: middle;
+    overflow: hidden;
+    transition: var(--sl-transition-fast) color, var(--sl-transition-fast) border, var(--sl-transition-fast) box-shadow;
+    cursor: pointer;
+  }
+
+  .select::part(panel) {
+    border-radius: var(--sl-border-radius-medium);
+  }
+
+  /* Standard selects */
+  .select--standard .select__control {
+    background-color: var(--sl-input-background-color);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+    color: var(--sl-input-color);
+  }
+
+  .select--standard:not(.select--disabled) .select__control:hover {
+    background-color: var(--sl-input-background-color-hover);
+    border-color: var(--sl-input-border-color-hover);
+    color: var(--sl-input-color-hover);
+  }
+
+  .select--standard.select--focused:not(.select--disabled) .select__control {
+    background-color: var(--sl-input-background-color-focus);
+    border-color: var(--sl-input-border-color-focus);
+    color: var(--sl-input-color-focus);
+    box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-input-focus-ring-color);
+    outline: none;
+  }
+
+  .select--standard.select--disabled .select__control {
+    background-color: var(--sl-input-background-color-disabled);
+    border-color: var(--sl-input-border-color-disabled);
+    color: var(--sl-input-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+    outline: none;
+  }
+
+  /* Filled selects */
+  .select--filled .select__control {
+    border: none;
+    background-color: var(--sl-input-filled-background-color);
+    color: var(--sl-input-color);
+  }
+
+  .select--filled:hover:not(.select--disabled) .select__control {
+    background-color: var(--sl-input-filled-background-color-hover);
+  }
+
+  .select--filled.select--focused:not(.select--disabled) .select__control {
+    background-color: var(--sl-input-filled-background-color-focus);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .select--filled.select--disabled .select__control {
+    background-color: var(--sl-input-filled-background-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .select--disabled .select__tags,
+  .select--disabled .select__clear {
+    pointer-events: none;
+  }
+
+  .select__prefix {
+    display: inline-flex;
+    align-items: center;
+    color: var(--sl-input-placeholder-color);
+  }
+
+  .select__label {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    user-select: none;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+
+    /* Hide scrollbar in Firefox */
+    scrollbar-width: none;
+  }
+
+  /* Hide scrollbar in Chrome/Safari */
+  .select__label::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .select__clear {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    width: 1.25em;
+    font-size: inherit;
+    color: var(--sl-input-icon-color);
+    border: none;
+    background: none;
+    padding: 0;
+    transition: var(--sl-transition-fast) color;
+    cursor: pointer;
+  }
+
+  .select__clear:hover {
+    color: var(--sl-input-icon-color-hover);
+  }
+
+  .select__suffix {
+    display: inline-flex;
+    align-items: center;
+    color: var(--sl-input-placeholder-color);
+  }
+
+  .select__icon {
+    flex: 0 0 auto;
+    display: inline-flex;
+    transition: var(--sl-transition-medium) transform ease;
+  }
+
+  .select--open .select__icon {
+    transform: rotate(-180deg);
+  }
+
+  /* Placeholder */
+  .select--placeholder-visible .select__label {
+    color: var(--sl-input-placeholder-color);
+  }
+
+  .select--disabled.select--placeholder-visible .select__label {
+    color: var(--sl-input-placeholder-color-disabled);
+  }
+
+  /* Tags */
+  .select__tags {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: left;
+    margin-inline-start: var(--sl-spacing-2x-small);
+  }
+
+  /* Hidden input (for form control validation to show) */
+  .select__hidden-select {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  /* Small */
+  .select--small .select__control {
+    border-radius: var(--sl-input-border-radius-small);
+    font-size: var(--sl-input-font-size-small);
+    min-height: var(--sl-input-height-small);
+  }
+
+  .select--small .select__prefix ::slotted(*) {
+    margin-inline-start: var(--sl-input-spacing-small);
+  }
+
+  .select--small .select__label {
+    margin: 0 var(--sl-input-spacing-small);
+  }
+
+  .select--small .select__clear {
+    margin-inline-end: var(--sl-input-spacing-small);
+  }
+
+  .select--small .select__suffix ::slotted(*) {
+    margin-inline-end: var(--sl-input-spacing-small);
+  }
+
+  .select--small .select__icon {
+    margin-inline-end: var(--sl-input-spacing-small);
+  }
+
+  .select--small .select__tags {
+    padding-bottom: 2px;
+  }
+
+  .select--small .select__tags sl-tag {
+    padding-top: 2px;
+  }
+
+  .select--small .select__tags sl-tag:not(:last-of-type) {
+    margin-inline-end: var(--sl-spacing-2x-small);
+  }
+
+  .select--small.select--has-tags .select__label {
+    margin-inline-start: 0;
+  }
+
+  /* Medium */
+  .select--medium .select__control {
+    border-radius: var(--sl-input-border-radius-medium);
+    font-size: var(--sl-input-font-size-medium);
+    min-height: var(--sl-input-height-medium);
+  }
+
+  .select--medium .select__prefix ::slotted(*) {
+    margin-inline-start: var(--sl-input-spacing-medium);
+  }
+
+  .select--medium .select__label {
+    margin: 0 var(--sl-input-spacing-medium);
+  }
+
+  .select--medium .select__clear {
+    margin-inline-end: var(--sl-input-spacing-medium);
+  }
+
+  .select--medium .select__suffix ::slotted(*) {
+    margin-inline-end: var(--sl-input-spacing-medium);
+  }
+
+  .select--medium .select__icon {
+    margin-inline-end: var(--sl-input-spacing-medium);
+  }
+
+  .select--medium .select__tags {
+    padding-bottom: 3px;
+  }
+
+  .select--medium .select__tags sl-tag {
+    padding-top: 3px;
+  }
+
+  .select--medium .select__tags sl-tag:not(:last-of-type) {
+    margin-inline-end: var(--sl-spacing-2x-small);
+  }
+
+  .select--medium.select--has-tags .select__label {
+    margin-inline-start: 0;
+  }
+
+  /* Large */
+  .select--large .select__control {
+    border-radius: var(--sl-input-border-radius-large);
+    font-size: var(--sl-input-font-size-large);
+    min-height: var(--sl-input-height-large);
+  }
+
+  .select--large .select__prefix ::slotted(*) {
+    margin-inline-start: var(--sl-input-spacing-large);
+  }
+
+  .select--large .select__label {
+    margin: 0 var(--sl-input-spacing-large);
+  }
+
+  .select--large .select__clear {
+    margin-inline-end: var(--sl-input-spacing-large);
+  }
+
+  .select--large .select__suffix ::slotted(*) {
+    margin-inline-end: var(--sl-input-spacing-large);
+  }
+
+  .select--large .select__icon {
+    margin-inline-end: var(--sl-input-spacing-large);
+  }
+
+  .select--large .select__tags {
+    padding-bottom: 4px;
+  }
+  .select--large .select__tags sl-tag {
+    padding-top: 4px;
+  }
+
+  .select--large .select__tags sl-tag:not(:last-of-type) {
+    margin-inline-end: var(--sl-spacing-2x-small);
+  }
+
+  .select--large.select--has-tags .select__label {
+    margin-inline-start: 0;
+  }
+
+  /*
+   * Pill modifier
+   */
+  .select--pill.select--small .select__control {
+    border-radius: var(--sl-input-height-small);
+  }
+
+  .select--pill.select--medium .select__control {
+    border-radius: var(--sl-input-height-medium);
+  }
+
+  .select--pill.select--large .select__control {
+    border-radius: var(--sl-input-height-large);
+  }
+`;
+
+  // src/components/select/select.ts
+  var SlSelect = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.formSubmitController = new FormSubmitController(this);
+      this.hasSlotController = new HasSlotController(this, "help-text", "label");
+      this.localize = new LocalizeController2(this);
+      this.menuItems = [];
+      this.hasFocus = false;
+      this.isOpen = false;
+      this.displayLabel = "";
+      this.displayTags = [];
+      this.multiple = false;
+      this.maxTagsVisible = 3;
+      this.disabled = false;
+      this.name = "";
+      this.placeholder = "";
+      this.size = "medium";
+      this.hoist = false;
+      this.value = "";
+      this.filled = false;
+      this.pill = false;
+      this.label = "";
+      this.placement = "bottom";
+      this.helpText = "";
+      this.required = false;
+      this.clearable = false;
+      this.invalid = false;
+      this.defaultValue = "";
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.resizeObserver = new ResizeObserver(() => this.resizeMenu());
+      this.updateComplete.then(() => {
+        this.resizeObserver.observe(this);
+        this.syncItemsFromValue();
+      });
+    }
+    firstUpdated() {
+      this.invalid = !this.input.checkValidity();
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.resizeObserver.unobserve(this);
+    }
+    reportValidity() {
+      return this.input.reportValidity();
+    }
+    setCustomValidity(message) {
+      this.input.setCustomValidity(message);
+      this.invalid = !this.input.checkValidity();
+    }
+    getValueAsArray() {
+      if (this.multiple && this.value === "") {
+        return [];
+      }
+      return Array.isArray(this.value) ? this.value : [this.value];
+    }
+    focus(options) {
+      this.control.focus(options);
+    }
+    blur() {
+      this.control.blur();
+    }
+    handleBlur() {
+      if (!this.isOpen) {
+        this.hasFocus = false;
+        this.emit("sl-blur");
+      }
+    }
+    handleClearClick(event) {
+      event.stopPropagation();
+      this.value = this.multiple ? [] : "";
+      this.emit("sl-clear");
+      this.syncItemsFromValue();
+    }
+    handleDisabledChange() {
+      if (this.disabled && this.isOpen) {
+        this.dropdown.hide();
+      }
+      this.input.disabled = this.disabled;
+      this.invalid = !this.input.checkValidity();
+    }
+    handleFocus() {
+      if (!this.hasFocus) {
+        this.hasFocus = true;
+        this.emit("sl-focus");
+      }
+    }
+    handleKeyDown(event) {
+      const target = event.target;
+      const firstItem = this.menuItems[0];
+      const lastItem = this.menuItems[this.menuItems.length - 1];
+      if (target.tagName.toLowerCase() === "sl-tag") {
+        return;
+      }
+      if (event.key === "Tab") {
+        if (this.isOpen) {
+          this.dropdown.hide();
+        }
+        return;
+      }
+      if (["ArrowDown", "ArrowUp"].includes(event.key)) {
+        event.preventDefault();
+        if (!this.isOpen) {
+          this.dropdown.show();
+        }
+        if (event.key === "ArrowDown") {
+          this.menu.setCurrentItem(firstItem);
+          firstItem.focus();
+          return;
+        }
+        if (event.key === "ArrowUp") {
+          this.menu.setCurrentItem(lastItem);
+          lastItem.focus();
+          return;
+        }
+      }
+      if (event.ctrlKey || event.metaKey) {
+        return;
+      }
+      if (!this.isOpen && event.key.length === 1) {
+        event.stopPropagation();
+        event.preventDefault();
+        this.dropdown.show();
+        this.menu.typeToSelect(event);
+      }
+    }
+    handleLabelClick() {
+      this.focus();
+    }
+    handleMenuSelect(event) {
+      const item = event.detail.item;
+      if (this.multiple) {
+        this.value = this.value.includes(item.value) ? this.value.filter((v) => v !== item.value) : [...this.value, item.value];
+      } else {
+        this.value = item.value;
+      }
+      this.syncItemsFromValue();
+    }
+    handleMenuShow() {
+      this.resizeMenu();
+      this.isOpen = true;
+    }
+    handleMenuHide() {
+      this.isOpen = false;
+      this.control.focus();
+    }
+    handleMenuItemLabelChange() {
+      if (!this.multiple) {
+        const checkedItem = this.menuItems.find((item) => item.value === this.value);
+        this.displayLabel = checkedItem ? checkedItem.getTextLabel() : "";
+      }
+    }
+    handleMultipleChange() {
+      var _a;
+      const value = this.getValueAsArray();
+      this.value = this.multiple ? value : (_a = value[0]) != null ? _a : "";
+      this.syncItemsFromValue();
+    }
+    async handleMenuSlotChange() {
+      this.menuItems = [...this.querySelectorAll("sl-menu-item")];
+      const values = [];
+      this.menuItems.forEach((item) => {
+        if (values.includes(item.value)) {
+          console.error(`Duplicate value found in <sl-select> menu item: '${item.value}'`, item);
+        }
+        values.push(item.value);
+      });
+      await Promise.all(this.menuItems.map((item) => item.render));
+      this.syncItemsFromValue();
+    }
+    handleTagInteraction(event) {
+      const path = event.composedPath();
+      const clearButton = path.find((el) => {
+        if (el instanceof HTMLElement) {
+          const element = el;
+          return element.classList.contains("tag__remove");
+        }
+        return false;
+      });
+      if (clearButton) {
+        event.stopPropagation();
+      }
+    }
+    async handleValueChange() {
+      this.syncItemsFromValue();
+      await this.updateComplete;
+      this.invalid = !this.input.checkValidity();
+      this.emit("sl-change");
+    }
+    resizeMenu() {
+      this.menu.style.width = `${this.control.clientWidth}px`;
+      requestAnimationFrame(() => this.dropdown.reposition());
+    }
+    syncItemsFromValue() {
+      const value = this.getValueAsArray();
+      this.menuItems.forEach((item) => item.checked = value.includes(item.value));
+      if (this.multiple) {
+        const checkedItems = this.menuItems.filter((item) => value.includes(item.value));
+        this.displayLabel = checkedItems.length > 0 ? checkedItems[0].getTextLabel() : "";
+        this.displayTags = checkedItems.map((item) => {
+          return $`
+          <sl-tag
+            part="tag"
+            exportparts="
+              base:tag__base,
+              content:tag__content,
+              remove-button:tag__remove-button
+            "
+            variant="neutral"
+            size=${this.size}
+            ?pill=${this.pill}
+            removable
+            @click=${this.handleTagInteraction}
+            @keydown=${this.handleTagInteraction}
+            @sl-remove=${(event) => {
+          event.stopPropagation();
+          if (!this.disabled) {
+            item.checked = false;
+            this.syncValueFromItems();
+          }
+        }}
+          >
+            ${item.getTextLabel()}
+          </sl-tag>
+        `;
+        });
+        if (this.maxTagsVisible > 0 && this.displayTags.length > this.maxTagsVisible) {
+          const total = this.displayTags.length;
+          this.displayLabel = "";
+          this.displayTags = this.displayTags.slice(0, this.maxTagsVisible);
+          this.displayTags.push($`
+          <sl-tag
+            part="tag"
+            exportparts="
+              base:tag__base,
+              content:tag__content,
+              remove-button:tag__remove-button
+            "
+            variant="neutral"
+            size=${this.size}
+          >
+            +${total - this.maxTagsVisible}
+          </sl-tag>
+        `);
+        }
+      } else {
+        const checkedItem = this.menuItems.find((item) => item.value === value[0]);
+        this.displayLabel = checkedItem ? checkedItem.getTextLabel() : "";
+        this.displayTags = [];
+      }
+    }
+    syncValueFromItems() {
+      const checkedItems = this.menuItems.filter((item) => item.checked);
+      const checkedValues = checkedItems.map((item) => item.value);
+      if (this.multiple) {
+        this.value = this.value.filter((val) => checkedValues.includes(val));
+      } else {
+        this.value = checkedValues.length > 0 ? checkedValues[0] : "";
+      }
+    }
+    render() {
+      const hasLabelSlot = this.hasSlotController.test("label");
+      const hasHelpTextSlot = this.hasSlotController.test("help-text");
+      const hasSelection = this.multiple ? this.value.length > 0 : this.value !== "";
+      const hasLabel = this.label ? true : !!hasLabelSlot;
+      const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
+      const hasClearIcon = this.clearable && !this.disabled && hasSelection;
+      return $`
+      <div
+        part="form-control"
+        class=${o$3({
+      "form-control": true,
+      "form-control--small": this.size === "small",
+      "form-control--medium": this.size === "medium",
+      "form-control--large": this.size === "large",
+      "form-control--has-label": hasLabel,
+      "form-control--has-help-text": hasHelpText
+    })}
+      >
+        <label
+          part="form-control-label"
+          class="form-control__label"
+          for="input"
+          aria-hidden=${hasLabel ? "false" : "true"}
+          @click=${this.handleLabelClick}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <sl-dropdown
+            part="base"
+            .hoist=${this.hoist}
+            .placement=${this.placement}
+            .stayOpenOnSelect=${this.multiple}
+            .containingElement=${this}
+            ?disabled=${this.disabled}
+            class=${o$3({
+      select: true,
+      "select--open": this.isOpen,
+      "select--empty": !this.value,
+      "select--focused": this.hasFocus,
+      "select--clearable": this.clearable,
+      "select--disabled": this.disabled,
+      "select--multiple": this.multiple,
+      "select--standard": !this.filled,
+      "select--filled": this.filled,
+      "select--has-tags": this.multiple && this.displayTags.length > 0,
+      "select--placeholder-visible": this.displayLabel === "",
+      "select--small": this.size === "small",
+      "select--medium": this.size === "medium",
+      "select--large": this.size === "large",
+      "select--pill": this.pill,
+      "select--invalid": this.invalid
+    })}
+            @sl-show=${this.handleMenuShow}
+            @sl-hide=${this.handleMenuHide}
+          >
+            <div
+              part="control"
+              slot="trigger"
+              id="input"
+              class="select__control"
+              role="combobox"
+              aria-describedby="help-text"
+              aria-haspopup="true"
+              aria-disabled=${this.disabled ? "true" : "false"}
+              aria-expanded=${this.isOpen ? "true" : "false"}
+              aria-controls="menu"
+              tabindex=${this.disabled ? "-1" : "0"}
+              @blur=${this.handleBlur}
+              @focus=${this.handleFocus}
+              @keydown=${this.handleKeyDown}
+            >
+              <span part="prefix" class="select__prefix">
+                <slot name="prefix"></slot>
+              </span>
+
+              <div part="display-label" class="select__label">
+                ${this.displayTags.length > 0 ? $` <span part="tags" class="select__tags"> ${this.displayTags} </span> ` : this.displayLabel.length > 0 ? this.displayLabel : this.placeholder}
+              </div>
+
+              ${hasClearIcon ? $`
+                    <button
+                      part="clear-button"
+                      class="select__clear"
+                      @click=${this.handleClearClick}
+                      aria-label=${this.localize.term("clearEntry")}
+                      tabindex="-1"
+                    >
+                      <slot name="clear-icon">
+                        <sl-icon name="x-circle-fill" library="system"></sl-icon>
+                      </slot>
+                    </button>
+                  ` : ""}
+
+              <span part="suffix" class="select__suffix">
+                <slot name="suffix"></slot>
+              </span>
+
+              <span part="icon" class="select__icon" aria-hidden="true">
+                <sl-icon name="chevron-down" library="system"></sl-icon>
+              </span>
+
+              <!-- The hidden input tricks the browser's built-in validation so it works as expected. We use an input
+              instead of a select because, otherwise, iOS will show a list of options during validation. The focus
+              handler is used to move focus to the primary control when it's marked invalid.  -->
+              <input
+                class="select__hidden-select"
+                aria-hidden="true"
+                ?required=${this.required}
+                .value=${hasSelection ? "1" : ""}
+                tabindex="-1"
+                @focus=${() => this.control.focus()}
+              />
+            </div>
+
+            <sl-menu part="menu" id="menu" class="select__menu" @sl-select=${this.handleMenuSelect}>
+              <slot @slotchange=${this.handleMenuSlotChange} @sl-label-change=${this.handleMenuItemLabelChange}></slot>
+            </sl-menu>
+          </sl-dropdown>
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${hasHelpText ? "false" : "true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlSelect.styles = select_styles_default;
+  __decorateClass([
+    i2$2(".select")
+  ], SlSelect.prototype, "dropdown", 2);
+  __decorateClass([
+    i2$2(".select__control")
+  ], SlSelect.prototype, "control", 2);
+  __decorateClass([
+    i2$2(".select__hidden-select")
+  ], SlSelect.prototype, "input", 2);
+  __decorateClass([
+    i2$2(".select__menu")
+  ], SlSelect.prototype, "menu", 2);
+  __decorateClass([
+    t$1()
+  ], SlSelect.prototype, "hasFocus", 2);
+  __decorateClass([
+    t$1()
+  ], SlSelect.prototype, "isOpen", 2);
+  __decorateClass([
+    t$1()
+  ], SlSelect.prototype, "displayLabel", 2);
+  __decorateClass([
+    t$1()
+  ], SlSelect.prototype, "displayTags", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSelect.prototype, "multiple", 2);
+  __decorateClass([
+    e$1({ attribute: "max-tags-visible", type: Number })
+  ], SlSelect.prototype, "maxTagsVisible", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSelect.prototype, "disabled", 2);
+  __decorateClass([
+    e$1()
+  ], SlSelect.prototype, "name", 2);
+  __decorateClass([
+    e$1()
+  ], SlSelect.prototype, "placeholder", 2);
+  __decorateClass([
+    e$1()
+  ], SlSelect.prototype, "size", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlSelect.prototype, "hoist", 2);
+  __decorateClass([
+    e$1()
+  ], SlSelect.prototype, "value", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSelect.prototype, "filled", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSelect.prototype, "pill", 2);
+  __decorateClass([
+    e$1()
+  ], SlSelect.prototype, "label", 2);
+  __decorateClass([
+    e$1()
+  ], SlSelect.prototype, "placement", 2);
+  __decorateClass([
+    e$1({ attribute: "help-text" })
+  ], SlSelect.prototype, "helpText", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSelect.prototype, "required", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlSelect.prototype, "clearable", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlSelect.prototype, "invalid", 2);
+  __decorateClass([
+    defaultValue()
+  ], SlSelect.prototype, "defaultValue", 2);
+  __decorateClass([
+    watch("disabled", { waitUntilFirstUpdate: true })
+  ], SlSelect.prototype, "handleDisabledChange", 1);
+  __decorateClass([
+    watch("multiple")
+  ], SlSelect.prototype, "handleMultipleChange", 1);
+  __decorateClass([
+    watch("value", { waitUntilFirstUpdate: true })
+  ], SlSelect.prototype, "handleValueChange", 1);
+  SlSelect = __decorateClass([
+    n$1("sl-select")
+  ], SlSelect);
+
+  // src/components/tag/tag.styles.ts
+  var tag_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .tag {
+    display: flex;
+    align-items: center;
+    border: solid 1px;
+    line-height: 1;
+    white-space: nowrap;
+    user-select: none;
+    cursor: default;
+  }
+
+  .tag__remove::part(base) {
+    color: inherit;
+    padding: 0;
+  }
+
+  /*
+   * Variant modifiers
+   */
+
+  .tag--primary {
+    background-color: var(--sl-color-primary-50);
+    border-color: var(--sl-color-primary-200);
+    color: var(--sl-color-primary-800);
+  }
+
+  .tag--success {
+    background-color: var(--sl-color-success-50);
+    border-color: var(--sl-color-success-200);
+    color: var(--sl-color-success-800);
+  }
+
+  .tag--neutral {
+    background-color: var(--sl-color-neutral-50);
+    border-color: var(--sl-color-neutral-200);
+    color: var(--sl-color-neutral-800);
+  }
+
+  .tag--warning {
+    background-color: var(--sl-color-warning-50);
+    border-color: var(--sl-color-warning-200);
+    color: var(--sl-color-warning-800);
+  }
+
+  .tag--danger {
+    background-color: var(--sl-color-danger-50);
+    border-color: var(--sl-color-danger-200);
+    color: var(--sl-color-danger-800);
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .tag--small {
+    font-size: var(--sl-button-font-size-small);
+    height: calc(var(--sl-input-height-small) * 0.8);
+    line-height: calc(var(--sl-input-height-small) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-small);
+    padding: 0 var(--sl-spacing-x-small);
+  }
+
+  .tag--small .tag__remove {
+    margin-inline-start: var(--sl-spacing-2x-small);
+    margin-right: calc(-1 * var(--sl-spacing-3x-small));
+  }
+
+  .tag--medium {
+    font-size: var(--sl-button-font-size-medium);
+    height: calc(var(--sl-input-height-medium) * 0.8);
+    line-height: calc(var(--sl-input-height-medium) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-medium);
+    padding: 0 var(--sl-spacing-small);
+  }
+
+  .tag--large {
+    font-size: var(--sl-button-font-size-large);
+    height: calc(var(--sl-input-height-large) * 0.8);
+    line-height: calc(var(--sl-input-height-large) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-large);
+    padding: 0 var(--sl-spacing-medium);
+  }
+
+  .tag__remove {
+    font-size: 1.4em;
+    margin-inline-start: var(--sl-spacing-2x-small);
+    margin-inline-end: calc(-1 * var(--sl-spacing-x-small));
+  }
+
+  /*
+   * Pill modifier
+   */
+
+  .tag--pill {
+    border-radius: var(--sl-border-radius-pill);
+  }
+`;
+
+  // src/components/tag/tag.ts
+  var SlTag = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.variant = "neutral";
+      this.size = "medium";
+      this.pill = false;
+      this.removable = false;
+    }
+    handleRemoveClick() {
+      this.emit("sl-remove");
+    }
+    render() {
+      return $`
+      <span
+        part="base"
+        class=${o$3({
+      tag: true,
+      "tag--primary": this.variant === "primary",
+      "tag--success": this.variant === "success",
+      "tag--neutral": this.variant === "neutral",
+      "tag--warning": this.variant === "warning",
+      "tag--danger": this.variant === "danger",
+      "tag--text": this.variant === "text",
+      "tag--small": this.size === "small",
+      "tag--medium": this.size === "medium",
+      "tag--large": this.size === "large",
+      "tag--pill": this.pill,
+      "tag--removable": this.removable
+    })}
+      >
+        <span part="content" class="tag__content">
+          <slot></slot>
+        </span>
+
+        ${this.removable ? $`
+              <sl-icon-button
+                part="remove-button"
+                exportparts="base:remove-button__base"
+                name="x"
+                library="system"
+                label=${this.localize.term("remove")}
+                class="tag__remove"
+                @click=${this.handleRemoveClick}
+              ></sl-icon-button>
+            ` : ""}
+      </span>
+    `;
+    }
+  };
+  SlTag.styles = tag_styles_default;
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlTag.prototype, "variant", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlTag.prototype, "size", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlTag.prototype, "pill", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlTag.prototype, "removable", 2);
+  SlTag = __decorateClass([
+    n$1("sl-tag")
+  ], SlTag);
+
+  // src/components/skeleton/skeleton.styles.ts
+  var skeleton_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --border-radius: var(--sl-border-radius-pill);
+    --color: var(--sl-color-neutral-200);
+    --sheen-color: var(--sl-color-neutral-300);
+
+    display: block;
+    position: relative;
+  }
+
+  .skeleton {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    min-height: 1rem;
+  }
+
+  .skeleton__indicator {
+    flex: 1 1 auto;
+    background: var(--color);
+    border-radius: var(--border-radius);
+  }
+
+  .skeleton--sheen .skeleton__indicator {
+    background: linear-gradient(270deg, var(--sheen-color), var(--color), var(--color), var(--sheen-color));
+    background-size: 400% 100%;
+    background-size: 400% 100%;
+    animation: sheen 8s ease-in-out infinite;
+  }
+
+  .skeleton--pulse .skeleton__indicator {
+    animation: pulse 2s ease-in-out 0.5s infinite;
+  }
+
+  @keyframes sheen {
+    0% {
+      background-position: 200% 0;
+    }
+    to {
+      background-position: -200% 0;
+    }
+  }
+
+  @keyframes pulse {
+    0% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.4;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+`;
+
+  // src/components/skeleton/skeleton.ts
+  var SlSkeleton = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.effect = "none";
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      skeleton: true,
+      "skeleton--pulse": this.effect === "pulse",
+      "skeleton--sheen": this.effect === "sheen"
+    })}
+        aria-busy="true"
+        aria-live="polite"
+      >
+        <div part="indicator" class="skeleton__indicator"></div>
+      </div>
+    `;
+    }
+  };
+  SlSkeleton.styles = skeleton_styles_default;
+  __decorateClass([
+    e$1()
+  ], SlSkeleton.prototype, "effect", 2);
+  SlSkeleton = __decorateClass([
+    n$1("sl-skeleton")
+  ], SlSkeleton);
+
+  // src/components/button/button.styles.ts
+  var button_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+    position: relative;
+    width: auto;
+    cursor: pointer;
+  }
+
+  .button {
+    display: inline-flex;
+    align-items: stretch;
+    justify-content: center;
+    width: 100%;
+    border-style: solid;
+    border-width: var(--sl-input-border-width);
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-font-weight-semibold);
+    text-decoration: none;
+    user-select: none;
+    white-space: nowrap;
+    vertical-align: middle;
+    padding: 0;
+    transition: var(--sl-transition-x-fast) background-color, var(--sl-transition-x-fast) color,
+      var(--sl-transition-x-fast) border, var(--sl-transition-x-fast) box-shadow;
+    cursor: inherit;
+  }
+
+  .button::-moz-focus-inner {
+    border: 0;
+  }
+
+  .button:focus {
+    outline: none;
+  }
+
+  .button:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .button--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* When disabled, prevent mouse events from bubbling up */
+  .button--disabled * {
+    pointer-events: none;
+  }
+
+  .button__prefix,
+  .button__suffix {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    pointer-events: none;
+  }
+
+  .button__label ::slotted(sl-icon) {
+    vertical-align: -2px;
+  }
+
+  /*
+   * Standard buttons
+   */
+
+  /* Default */
+  .button--standard.button--default {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-neutral-300);
+    color: var(--sl-color-neutral-700);
+  }
+
+  .button--standard.button--default:hover:not(.button--disabled) {
+    background-color: var(--sl-color-primary-50);
+    border-color: var(--sl-color-primary-300);
+    color: var(--sl-color-primary-700);
+  }
+
+  .button--standard.button--default:active:not(.button--disabled) {
+    background-color: var(--sl-color-primary-100);
+    border-color: var(--sl-color-primary-400);
+    color: var(--sl-color-primary-700);
+  }
+
+  /* Primary */
+  .button--standard.button--primary {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--primary:hover:not(.button--disabled) {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--primary:active:not(.button--disabled) {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Success */
+  .button--standard.button--success {
+    background-color: var(--sl-color-success-600);
+    border-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--success:hover:not(.button--disabled) {
+    background-color: var(--sl-color-success-500);
+    border-color: var(--sl-color-success-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--success:active:not(.button--disabled) {
+    background-color: var(--sl-color-success-600);
+    border-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Neutral */
+  .button--standard.button--neutral {
+    background-color: var(--sl-color-neutral-600);
+    border-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--neutral:hover:not(.button--disabled) {
+    background-color: var(--sl-color-neutral-500);
+    border-color: var(--sl-color-neutral-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--neutral:active:not(.button--disabled) {
+    background-color: var(--sl-color-neutral-600);
+    border-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Warning */
+  .button--standard.button--warning {
+    background-color: var(--sl-color-warning-600);
+    border-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+  .button--standard.button--warning:hover:not(.button--disabled) {
+    background-color: var(--sl-color-warning-500);
+    border-color: var(--sl-color-warning-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--warning:active:not(.button--disabled) {
+    background-color: var(--sl-color-warning-600);
+    border-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Danger */
+  .button--standard.button--danger {
+    background-color: var(--sl-color-danger-600);
+    border-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--danger:hover:not(.button--disabled) {
+    background-color: var(--sl-color-danger-500);
+    border-color: var(--sl-color-danger-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--danger:active:not(.button--disabled) {
+    background-color: var(--sl-color-danger-600);
+    border-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /*
+   * Outline buttons
+   */
+
+  .button--outline {
+    background: none;
+    border: solid 1px;
+  }
+
+  /* Default */
+  .button--outline.button--default {
+    border-color: var(--sl-color-neutral-300);
+    color: var(--sl-color-neutral-700);
+  }
+
+  .button--outline.button--default:hover:not(.button--disabled),
+  .button--outline.button--default.button--checked:not(.button--disabled) {
+    border-color: var(--sl-color-primary-600);
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--default:active:not(.button--disabled) {
+    border-color: var(--sl-color-primary-700);
+    background-color: var(--sl-color-primary-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Primary */
+  .button--outline.button--primary {
+    border-color: var(--sl-color-primary-600);
+    color: var(--sl-color-primary-600);
+  }
+
+  .button--outline.button--primary:hover:not(.button--disabled),
+  .button--outline.button--primary.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--primary:active:not(.button--disabled) {
+    border-color: var(--sl-color-primary-700);
+    background-color: var(--sl-color-primary-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Success */
+  .button--outline.button--success {
+    border-color: var(--sl-color-success-600);
+    color: var(--sl-color-success-600);
+  }
+
+  .button--outline.button--success:hover:not(.button--disabled),
+  .button--outline.button--success.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--success:active:not(.button--disabled) {
+    border-color: var(--sl-color-success-700);
+    background-color: var(--sl-color-success-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Neutral */
+  .button--outline.button--neutral {
+    border-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-600);
+  }
+
+  .button--outline.button--neutral:hover:not(.button--disabled),
+  .button--outline.button--neutral.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--neutral:active:not(.button--disabled) {
+    border-color: var(--sl-color-neutral-700);
+    background-color: var(--sl-color-neutral-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Warning */
+  .button--outline.button--warning {
+    border-color: var(--sl-color-warning-600);
+    color: var(--sl-color-warning-600);
+  }
+
+  .button--outline.button--warning:hover:not(.button--disabled),
+  .button--outline.button--warning.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--warning:active:not(.button--disabled) {
+    border-color: var(--sl-color-warning-700);
+    background-color: var(--sl-color-warning-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Danger */
+  .button--outline.button--danger {
+    border-color: var(--sl-color-danger-600);
+    color: var(--sl-color-danger-600);
+  }
+
+  .button--outline.button--danger:hover:not(.button--disabled),
+  .button--outline.button--danger.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--danger:active:not(.button--disabled) {
+    border-color: var(--sl-color-danger-700);
+    background-color: var(--sl-color-danger-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /*
+   * Text buttons
+   */
+
+  .button--text {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-600);
+  }
+
+  .button--text:hover:not(.button--disabled) {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-500);
+  }
+
+  .button--text:focus-visible:not(.button--disabled) {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-500);
+  }
+
+  .button--text:active:not(.button--disabled) {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-700);
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .button--small {
+    font-size: var(--sl-button-font-size-small);
+    height: var(--sl-input-height-small);
+    line-height: calc(var(--sl-input-height-small) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-small);
+  }
+
+  .button--medium {
+    font-size: var(--sl-button-font-size-medium);
+    height: var(--sl-input-height-medium);
+    line-height: calc(var(--sl-input-height-medium) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-medium);
+  }
+
+  .button--large {
+    font-size: var(--sl-button-font-size-large);
+    height: var(--sl-input-height-large);
+    line-height: calc(var(--sl-input-height-large) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-large);
+  }
+
+  /*
+   * Pill modifier
+   */
+
+  .button--pill.button--small {
+    border-radius: var(--sl-input-height-small);
+  }
+
+  .button--pill.button--medium {
+    border-radius: var(--sl-input-height-medium);
+  }
+
+  .button--pill.button--large {
+    border-radius: var(--sl-input-height-large);
+  }
+
+  /*
+   * Circle modifier
+   */
+
+  .button--circle {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .button--circle.button--small {
+    width: var(--sl-input-height-small);
+    border-radius: 50%;
+  }
+
+  .button--circle.button--medium {
+    width: var(--sl-input-height-medium);
+    border-radius: 50%;
+  }
+
+  .button--circle.button--large {
+    width: var(--sl-input-height-large);
+    border-radius: 50%;
+  }
+
+  .button--circle .button__prefix,
+  .button--circle .button__suffix,
+  .button--circle .button__caret {
+    display: none;
+  }
+
+  /*
+   * Caret modifier
+   */
+
+  .button--caret .button__suffix {
+    display: none;
+  }
+
+  .button--caret .button__caret {
+    display: flex;
+    align-items: center;
+  }
+
+  .button--caret .button__caret svg {
+    width: 1em;
+    height: 1em;
+  }
+
+  /*
+   * Loading modifier
+   */
+
+  .button--loading {
+    position: relative;
+    cursor: wait;
+  }
+
+  .button--loading .button__prefix,
+  .button--loading .button__label,
+  .button--loading .button__suffix,
+  .button--loading .button__caret {
+    visibility: hidden;
+  }
+
+  .button--loading sl-spinner {
+    --indicator-color: currentColor;
+    position: absolute;
+    font-size: 1em;
+    height: 1em;
+    width: 1em;
+    top: calc(50% - 0.5em);
+    left: calc(50% - 0.5em);
+  }
+
+  /*
+   * Badges
+   */
+
+  .button ::slotted(sl-badge) {
+    position: absolute;
+    top: 0;
+    right: 0;
+    transform: translateY(-50%) translateX(50%);
+    pointer-events: none;
+  }
+
+  .button--rtl ::slotted(sl-badge) {
+    right: auto;
+    left: 0;
+    transform: translateY(-50%) translateX(-50%);
+  }
+
+  /*
+   * Button spacing
+   */
+
+  .button--has-label.button--small .button__label {
+    padding: 0 var(--sl-spacing-small);
+  }
+
+  .button--has-label.button--medium .button__label {
+    padding: 0 var(--sl-spacing-medium);
+  }
+
+  .button--has-label.button--large .button__label {
+    padding: 0 var(--sl-spacing-large);
+  }
+
+  .button--has-prefix.button--small {
+    padding-inline-start: var(--sl-spacing-x-small);
+  }
+
+  .button--has-prefix.button--small .button__label {
+    padding-inline-start: var(--sl-spacing-x-small);
+  }
+
+  .button--has-prefix.button--medium {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-prefix.button--medium .button__label {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-prefix.button--large {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-prefix.button--large .button__label {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--small,
+  .button--caret.button--small {
+    padding-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .button--has-suffix.button--small .button__label,
+  .button--caret.button--small .button__label {
+    padding-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .button--has-suffix.button--medium,
+  .button--caret.button--medium {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--medium .button__label,
+  .button--caret.button--medium .button__label {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--large,
+  .button--caret.button--large {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--large .button__label,
+  .button--caret.button--large .button__label {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  /*
+   * Button groups support a variety of button types (e.g. buttons with tooltips, buttons as dropdown triggers, etc.).
+   * This means buttons aren't always direct descendants of the button group, thus we can't target them with the
+   * ::slotted selector. To work around this, the button group component does some magic to add these special classes to
+   * buttons and we style them here instead.
+   */
+
+  :host(.sl-button-group__button--first:not(.sl-button-group__button--last)) .button {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+
+  :host(.sl-button-group__button--inner) .button {
+    border-radius: 0;
+  }
+
+  :host(.sl-button-group__button--last:not(.sl-button-group__button--first)) .button {
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+  }
+
+  /* All except the first */
+  :host(.sl-button-group__button:not(.sl-button-group__button--first)) {
+    margin-inline-start: calc(-1 * var(--sl-input-border-width));
+  }
+
+  /* Add a visual separator between solid buttons */
+  :host(.sl-button-group__button:not(.sl-button-group__button--focus, .sl-button-group__button--first, .sl-button-group__button--radio, [variant='default']):not(:hover, :active, :focus))
+    .button:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    inset-inline-start: 0;
+    bottom: 0;
+    border-left: solid 1px rgb(128 128 128 / 33%);
+    mix-blend-mode: multiply;
+  }
+
+  /* Bump hovered, focused, and checked buttons up so their focus ring isn't clipped */
+  :host(.sl-button-group__button--hover) {
+    z-index: 1;
+  }
+
+  :host(.sl-button-group__button--focus),
+  :host(.sl-button-group__button[checked]) {
+    z-index: 2;
+  }
+`;
+
+  // src/components/radio-button/radio-button.styles.ts
+  var radio_button_styles_default = r$2`
+  ${button_styles_default}
+
+  label {
+    display: inline-block;
+    position: relative;
+  }
+  /* We use a hidden input so constraint validation errors work, since they don't appear to show when used with buttons.
+    We can't actually hide it, though, otherwise the messages will be suppressed by the browser. */
+  .hidden-input {
+    all: unset;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    outline: dotted 1px red;
+    opacity: 0;
+    z-index: -1;
+  }
+`;
+
+  // node_modules/lit-html/static.js
+  var o$1 = Symbol.for("");
+  var e = (t) => {
+    var r, e2;
+    if ((null === (r = t) || void 0 === r ? void 0 : r.r) === o$1)
+      return null === (e2 = t) || void 0 === e2 ? void 0 : e2._$litStatic$;
+  };
+  var l$1 = (t, ...r) => ({ _$litStatic$: r.reduce((r2, o2, e2) => r2 + ((t2) => {
+    if (void 0 !== t2._$litStatic$)
+      return t2._$litStatic$;
+    throw Error(`Value passed to 'literal' function must be a 'literal' result: ${t2}. Use 'unsafeStatic' to pass non-literal values, but
+            take care to ensure page security.`);
+  })(o2) + t[e2 + 1], t[0]), r: o$1 });
+  var a$1 = /* @__PURE__ */ new Map();
+  var s$1 = (t) => (r, ...o2) => {
+    const i = o2.length;
+    let l2, s2;
+    const n2 = [], u2 = [];
+    let c, v = 0, $2 = false;
+    for (; v < i; ) {
+      for (c = r[v]; v < i && void 0 !== (s2 = o2[v], l2 = e(s2)); )
+        c += l2 + r[++v], $2 = true;
+      u2.push(s2), n2.push(c), v++;
+    }
+    if (v === i && n2.push(r[i]), $2) {
+      const t2 = n2.join("$$lit$$");
+      void 0 === (r = a$1.get(t2)) && (n2.raw = n2, a$1.set(t2, r = n2)), o2 = u2;
+    }
+    return t(r, ...o2);
+  };
+  var n = s$1($);
+  /**
+   * @license
+   * Copyright 2020 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+
+  // src/components/radio-button/radio-button.ts
+  var SlRadioButton = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.hasSlotController = new HasSlotController(this, "[default]", "prefix", "suffix");
+      this.hasFocus = false;
+      this.checked = false;
+      this.disabled = false;
+      this.size = "medium";
+      this.pill = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.setAttribute("role", "presentation");
+    }
+    handleDisabledChange() {
+      this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+    }
+    handleBlur() {
+      this.hasFocus = false;
+      this.emit("sl-blur");
+    }
+    handleClick(e2) {
+      if (this.disabled) {
+        e2.preventDefault();
+        e2.stopPropagation();
+        return;
+      }
+      this.checked = true;
+    }
+    handleFocus() {
+      this.hasFocus = true;
+      this.emit("sl-focus");
+    }
+    render() {
+      return n`
+      <div part="base" role="presentation">
+        <button
+          part="button"
+          role="radio"
+          aria-checked="${this.checked}"
+          class=${o$3({
+      button: true,
+      "button--default": true,
+      "button--small": this.size === "small",
+      "button--medium": this.size === "medium",
+      "button--large": this.size === "large",
+      "button--checked": this.checked,
+      "button--disabled": this.disabled,
+      "button--focused": this.hasFocus,
+      "button--outline": true,
+      "button--pill": this.pill,
+      "button--has-label": this.hasSlotController.test("[default]"),
+      "button--has-prefix": this.hasSlotController.test("prefix"),
+      "button--has-suffix": this.hasSlotController.test("suffix")
+    })}
+          aria-disabled=${this.disabled}
+          type="button"
+          value=${l$2(this.value)}
+          tabindex="${this.checked ? "0" : "-1"}"
+          @blur=${this.handleBlur}
+          @focus=${this.handleFocus}
+          @click=${this.handleClick}
+        >
+          <span part="prefix" class="button__prefix">
+            <slot name="prefix"></slot>
+          </span>
+          <span part="label" class="button__label">
+            <slot></slot>
+          </span>
+          <span part="suffix" class="button__suffix">
+            <slot name="suffix"></slot>
+          </span>
+        </button>
+      </div>
+    `;
+    }
+  };
+  SlRadioButton.styles = radio_button_styles_default;
+  __decorateClass([
+    i2$2(".button")
+  ], SlRadioButton.prototype, "input", 2);
+  __decorateClass([
+    i2$2(".hidden-input")
+  ], SlRadioButton.prototype, "hiddenInput", 2);
+  __decorateClass([
+    t$1()
+  ], SlRadioButton.prototype, "hasFocus", 2);
+  __decorateClass([
+    t$1()
+  ], SlRadioButton.prototype, "checked", 2);
+  __decorateClass([
+    e$1()
+  ], SlRadioButton.prototype, "value", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlRadioButton.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlRadioButton.prototype, "size", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlRadioButton.prototype, "pill", 2);
+  __decorateClass([
+    watch("disabled", { waitUntilFirstUpdate: true })
+  ], SlRadioButton.prototype, "handleDisabledChange", 1);
+  SlRadioButton = __decorateClass([
+    n$1("sl-radio-button")
+  ], SlRadioButton);
+
+  // src/components/radio-group/radio-group.styles.ts
+  var radio_group_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .radio-group {
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+    border-radius: var(--sl-border-radius-medium);
+    padding: var(--sl-spacing-large);
+    padding-top: var(--sl-spacing-x-small);
+  }
+
+  .radio-group .radio-group__label {
+    font-family: var(--sl-input-font-family);
+    font-size: var(--sl-input-font-size-medium);
+    font-weight: var(--sl-input-font-weight);
+    color: var(--sl-input-color);
+    padding: 0 var(--sl-spacing-2x-small);
+  }
+
+  ::slotted(sl-radio:not(:last-of-type)) {
+    margin-bottom: var(--sl-spacing-2x-small);
+  }
+
+  .radio-group:not(.radio-group--has-fieldset) {
+    border: none;
+    padding: 0;
+    margin: 0;
+    min-width: 0;
+  }
+
+  .radio-group:not(.radio-group--has-fieldset) .radio-group__label {
+    position: absolute;
+    width: 0;
+    height: 0;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .radio-group--required .radio-group__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+`;
+
+  // src/components/radio-group/radio-group.ts
+  var SlRadioGroup = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.formSubmitController = new FormSubmitController(this, {
+        defaultValue: (control) => control.defaultValue
+      });
+      this.hasButtonGroup = false;
+      this.errorMessage = "";
+      this.customErrorMessage = "";
+      this.defaultValue = "";
+      this.label = "";
+      this.value = "";
+      this.name = "option";
+      this.invalid = false;
+      this.fieldset = false;
+      this.required = false;
+    }
+    handleValueChange() {
+      if (this.hasUpdated) {
+        this.emit("sl-change");
+        this.updateCheckedRadio();
+      }
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.defaultValue = this.value;
+    }
+    setCustomValidity(message = "") {
+      this.customErrorMessage = message;
+      this.errorMessage = message;
+      if (!message) {
+        this.invalid = false;
+      } else {
+        this.invalid = true;
+        this.input.setCustomValidity(message);
+      }
+    }
+    get validity() {
+      const hasMissingData = !(this.value && this.required || !this.required);
+      const hasCustomError = this.customErrorMessage !== "";
+      return {
+        badInput: false,
+        customError: hasCustomError,
+        patternMismatch: false,
+        rangeOverflow: false,
+        rangeUnderflow: false,
+        stepMismatch: false,
+        tooLong: false,
+        tooShort: false,
+        typeMismatch: false,
+        valid: hasMissingData || hasCustomError ? false : true,
+        valueMissing: !hasMissingData
+      };
+    }
+    reportValidity() {
+      const validity = this.validity;
+      this.errorMessage = this.customErrorMessage || validity.valid ? "" : this.input.validationMessage;
+      this.invalid = !validity.valid;
+      if (!validity.valid) {
+        this.showNativeErrorMessage();
+      }
+      return !this.invalid;
+    }
+    getAllRadios() {
+      return [...this.querySelectorAll("sl-radio, sl-radio-button")];
+    }
+    handleRadioClick(event) {
+      const target = event.target;
+      if (target.disabled) {
+        return;
+      }
+      this.value = target.value;
+      const radios = this.getAllRadios();
+      radios.forEach((radio) => radio.checked = radio === target);
+    }
+    handleKeyDown(event) {
+      var _a;
+      if (!["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", " "].includes(event.key)) {
+        return;
+      }
+      const radios = this.getAllRadios().filter((radio) => !radio.disabled);
+      const checkedRadio = (_a = radios.find((radio) => radio.checked)) != null ? _a : radios[0];
+      const incr = event.key === " " ? 0 : ["ArrowUp", "ArrowLeft"].includes(event.key) ? -1 : 1;
+      let index = radios.indexOf(checkedRadio) + incr;
+      if (index < 0) {
+        index = radios.length - 1;
+      }
+      if (index > radios.length - 1) {
+        index = 0;
+      }
+      this.getAllRadios().forEach((radio) => {
+        radio.checked = false;
+        if (!this.hasButtonGroup) {
+          radio.tabIndex = -1;
+        }
+      });
+      this.value = radios[index].value;
+      radios[index].checked = true;
+      if (!this.hasButtonGroup) {
+        radios[index].tabIndex = 0;
+        radios[index].focus();
+      } else {
+        radios[index].shadowRoot.querySelector("button").focus();
+      }
+      event.preventDefault();
+    }
+    handleSlotChange() {
+      var _a;
+      const radios = this.getAllRadios();
+      radios.forEach((radio) => radio.checked = radio.value === this.value);
+      this.hasButtonGroup = radios.some((radio) => radio.tagName.toLowerCase() === "sl-radio-button");
+      if (!radios.some((radio) => radio.checked)) {
+        if (this.hasButtonGroup) {
+          const buttonRadio = radios[0].shadowRoot.querySelector("button");
+          buttonRadio.tabIndex = 0;
+        } else {
+          radios[0].tabIndex = 0;
+        }
+      }
+      if (this.hasButtonGroup) {
+        const buttonGroup = (_a = this.shadowRoot) == null ? void 0 : _a.querySelector("sl-button-group");
+        if (buttonGroup) {
+          buttonGroup.disableRole = true;
+        }
+      }
+    }
+    showNativeErrorMessage() {
+      this.input.hidden = false;
+      this.input.reportValidity();
+      setTimeout(() => this.input.hidden = true, 1e4);
+    }
+    updateCheckedRadio() {
+      const radios = this.getAllRadios();
+      radios.forEach((radio) => radio.checked = radio.value === this.value);
+    }
+    render() {
+      const defaultSlot = $`
+      <slot
+        @click=${this.handleRadioClick}
+        @keydown=${this.handleKeyDown}
+        @slotchange=${this.handleSlotChange}
+        role="presentation"
+      ></slot>
+    `;
+      return $`
+      <fieldset
+        part="base"
+        role="radiogroup"
+        aria-errormessage="radio-error-message"
+        aria-invalid="${this.invalid}"
+        class=${o$3({
+      "radio-group": true,
+      "radio-group--has-fieldset": this.fieldset,
+      "radio-group--required": this.required
+    })}
+      >
+        <legend part="label" class="radio-group__label">
+          <slot name="label">${this.label}</slot>
+        </legend>
+        <div class="visually-hidden">
+          <div id="radio-error-message" aria-live="assertive">${this.errorMessage}</div>
+          <label class="radio-group__validation visually-hidden">
+            <input type="text" class="radio-group__validation-input" ?required=${this.required} tabindex="-1" hidden />
+          </label>
+        </div>
+        ${this.hasButtonGroup ? $`
+              <sl-button-group part="button-group" exportparts="base:button-group__base">
+                ${defaultSlot}
+              </sl-button-group>
+            ` : defaultSlot}
+      </fieldset>
+    `;
+    }
+  };
+  SlRadioGroup.styles = radio_group_styles_default;
+  __decorateClass([
+    i2$2("slot:not([name])")
+  ], SlRadioGroup.prototype, "defaultSlot", 2);
+  __decorateClass([
+    i2$2(".radio-group__validation-input")
+  ], SlRadioGroup.prototype, "input", 2);
+  __decorateClass([
+    t$1()
+  ], SlRadioGroup.prototype, "hasButtonGroup", 2);
+  __decorateClass([
+    t$1()
+  ], SlRadioGroup.prototype, "errorMessage", 2);
+  __decorateClass([
+    t$1()
+  ], SlRadioGroup.prototype, "customErrorMessage", 2);
+  __decorateClass([
+    t$1()
+  ], SlRadioGroup.prototype, "defaultValue", 2);
+  __decorateClass([
+    e$1()
+  ], SlRadioGroup.prototype, "label", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlRadioGroup.prototype, "value", 2);
+  __decorateClass([
+    e$1()
+  ], SlRadioGroup.prototype, "name", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlRadioGroup.prototype, "invalid", 2);
+  __decorateClass([
+    e$1({ type: Boolean, attribute: "fieldset", reflect: true })
+  ], SlRadioGroup.prototype, "fieldset", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlRadioGroup.prototype, "required", 2);
+  __decorateClass([
+    watch("value")
+  ], SlRadioGroup.prototype, "handleValueChange", 1);
+  SlRadioGroup = __decorateClass([
+    n$1("sl-radio-group")
+  ], SlRadioGroup);
+
+  // src/components/range/range.styles.ts
+  var range_styles_default = r$2`
+  ${component_styles_default}
+  ${form_control_styles_default}
+
+  :host {
+    --thumb-size: 20px;
+    --tooltip-offset: 10px;
+    --track-color-active: var(--sl-color-neutral-200);
+    --track-color-inactive: var(--sl-color-neutral-200);
+    --track-active-offset: 0%;
+    --track-height: 6px;
+
+    display: block;
+  }
+
+  .range {
+    position: relative;
+  }
+
+  .range__control {
+    --percent: 0%;
+    -webkit-appearance: none;
+    border-radius: 3px;
+    width: 100%;
+    height: var(--track-height);
+    background: transparent;
+    line-height: var(--sl-input-height-medium);
+    vertical-align: middle;
+    margin: 0;
+
+    background-image: linear-gradient(
+      to right,
+      var(--track-color-inactive) 0%,
+      var(--track-color-inactive) min(var(--percent), var(--track-active-offset)),
+      var(--track-color-active) min(var(--percent), var(--track-active-offset)),
+      var(--track-color-active) max(var(--percent), var(--track-active-offset)),
+      var(--track-color-inactive) max(var(--percent), var(--track-active-offset)),
+      var(--track-color-inactive) 100%
+    );
+  }
+
+  .range--rtl .range__control {
+    background-image: linear-gradient(
+      to left,
+      var(--track-color-inactive) 0%,
+      var(--track-color-inactive) min(var(--percent), var(--track-active-offset)),
+      var(--track-color-active) min(var(--percent), var(--track-active-offset)),
+      var(--track-color-active) max(var(--percent), var(--track-active-offset)),
+      var(--track-color-inactive) max(var(--percent), var(--track-active-offset)),
+      var(--track-color-inactive) 100%
+    );
+  }
+
+  /* Webkit */
+  .range__control::-webkit-slider-runnable-track {
+    width: 100%;
+    height: var(--track-height);
+    border-radius: 3px;
+    border: none;
+  }
+
+  .range__control::-webkit-slider-thumb {
+    border: none;
+    width: var(--thumb-size);
+    height: var(--thumb-size);
+    border-radius: 50%;
+    background-color: var(--sl-color-primary-600);
+    border: solid var(--sl-input-border-width) var(--sl-color-primary-600);
+    -webkit-appearance: none;
+    margin-top: calc(var(--thumb-size) / -2 + var(--track-height) / 2);
+    transition: var(--sl-transition-fast) border-color, var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) color, var(--sl-transition-fast) box-shadow, var(--sl-transition-fast) transform;
+    cursor: pointer;
+  }
+
+  .range__control:enabled::-webkit-slider-thumb:hover {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+  }
+
+  .range__control:enabled:focus-visible::-webkit-slider-thumb {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .range__control:enabled::-webkit-slider-thumb:active {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+    cursor: grabbing;
+  }
+
+  /* Firefox */
+  .range__control::-moz-focus-outer {
+    border: 0;
+  }
+
+  .range__control::-moz-range-progress {
+    background-color: var(--track-color-active);
+    border-radius: 3px;
+    height: var(--track-height);
+  }
+
+  .range__control::-moz-range-track {
+    width: 100%;
+    height: var(--track-height);
+    background-color: var(--track-color-inactive);
+    border-radius: 3px;
+    border: none;
+  }
+
+  .range__control::-moz-range-thumb {
+    border: none;
+    height: var(--thumb-size);
+    width: var(--thumb-size);
+    border-radius: 50%;
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+    transition: var(--sl-transition-fast) border-color, var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) color, var(--sl-transition-fast) box-shadow, var(--sl-transition-fast) transform;
+    cursor: pointer;
+  }
+
+  .range__control:enabled::-moz-range-thumb:hover {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+  }
+
+  .range__control:enabled:focus-visible::-moz-range-thumb {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .range__control:enabled::-moz-range-thumb:active {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+    cursor: grabbing;
+  }
+
+  /* States */
+  .range__control:focus-visible {
+    outline: none;
+  }
+
+  .range__control:disabled {
+    opacity: 0.5;
+  }
+
+  .range__control:disabled::-webkit-slider-thumb {
+    cursor: not-allowed;
+  }
+
+  .range__control:disabled::-moz-range-thumb {
+    cursor: not-allowed;
+  }
+
+  /* Tooltip output */
+  .range__tooltip {
+    position: absolute;
+    z-index: var(--sl-z-index-tooltip);
+    left: 0;
+    border-radius: var(--sl-tooltip-border-radius);
+    background-color: var(--sl-tooltip-background-color);
+    font-family: var(--sl-tooltip-font-family);
+    font-size: var(--sl-tooltip-font-size);
+    font-weight: var(--sl-tooltip-font-weight);
+    line-height: var(--sl-tooltip-line-height);
+    color: var(--sl-tooltip-color);
+    opacity: 0;
+    padding: var(--sl-tooltip-padding);
+    transition: var(--sl-transition-fast) opacity;
+    pointer-events: none;
+  }
+
+  .range__tooltip:after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    left: 50%;
+    transform: translateX(calc(-1 * var(--sl-tooltip-arrow-size)));
+  }
+
+  .range--tooltip-visible .range__tooltip {
+    opacity: 1;
+  }
+
+  /* Tooltip on top */
+  .range--tooltip-top .range__tooltip {
+    top: calc(-1 * var(--thumb-size) - var(--tooltip-offset));
+  }
+
+  .range--tooltip-top .range__tooltip:after {
+    border-top: var(--sl-tooltip-arrow-size) solid var(--sl-tooltip-background-color);
+    border-left: var(--sl-tooltip-arrow-size) solid transparent;
+    border-right: var(--sl-tooltip-arrow-size) solid transparent;
+    top: 100%;
+  }
+
+  /* Tooltip on bottom */
+  .range--tooltip-bottom .range__tooltip {
+    bottom: calc(-1 * var(--thumb-size) - var(--tooltip-offset));
+  }
+
+  .range--tooltip-bottom .range__tooltip:after {
+    border-bottom: var(--sl-tooltip-arrow-size) solid var(--sl-tooltip-background-color);
+    border-left: var(--sl-tooltip-arrow-size) solid transparent;
+    border-right: var(--sl-tooltip-arrow-size) solid transparent;
+    bottom: 100%;
+  }
+`;
+
+  // src/components/range/range.ts
+  var SlRange = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.formSubmitController = new FormSubmitController(this);
+      this.hasSlotController = new HasSlotController(this, "help-text", "label");
+      this.localize = new LocalizeController2(this);
+      this.hasFocus = false;
+      this.hasTooltip = false;
+      this.name = "";
+      this.value = 0;
+      this.label = "";
+      this.helpText = "";
+      this.disabled = false;
+      this.invalid = false;
+      this.min = 0;
+      this.max = 100;
+      this.step = 1;
+      this.tooltip = "top";
+      this.tooltipFormatter = (value) => value.toString();
+      this.defaultValue = 0;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.resizeObserver = new ResizeObserver(() => this.syncRange());
+      if (this.value < this.min) {
+        this.value = this.min;
+      }
+      if (this.value > this.max) {
+        this.value = this.max;
+      }
+      this.updateComplete.then(() => {
+        this.syncRange();
+        this.resizeObserver.observe(this.input);
+      });
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.resizeObserver.unobserve(this.input);
+    }
+    focus(options) {
+      this.input.focus(options);
+    }
+    blur() {
+      this.input.blur();
+    }
+    setCustomValidity(message) {
+      this.input.setCustomValidity(message);
+      this.invalid = !this.input.checkValidity();
+    }
+    handleInput() {
+      this.value = parseFloat(this.input.value);
+      this.emit("sl-change");
+      this.syncRange();
+    }
+    handleBlur() {
+      this.hasFocus = false;
+      this.hasTooltip = false;
+      this.emit("sl-blur");
+    }
+    handleValueChange() {
+      this.invalid = !this.input.checkValidity();
+      this.input.value = this.value.toString();
+      this.value = parseFloat(this.input.value);
+      this.syncRange();
+    }
+    handleDisabledChange() {
+      this.input.disabled = this.disabled;
+      this.invalid = !this.input.checkValidity();
+    }
+    handleFocus() {
+      this.hasFocus = true;
+      this.hasTooltip = true;
+      this.emit("sl-focus");
+    }
+    handleThumbDragStart() {
+      this.hasTooltip = true;
+    }
+    handleThumbDragEnd() {
+      this.hasTooltip = false;
+    }
+    syncRange() {
+      const percent = Math.max(0, (this.value - this.min) / (this.max - this.min));
+      this.syncProgress(percent);
+      if (this.tooltip !== "none") {
+        this.syncTooltip(percent);
+      }
+    }
+    syncProgress(percent) {
+      this.input.style.setProperty("--percent", `${percent * 100}%`);
+    }
+    syncTooltip(percent) {
+      if (this.output !== null) {
+        const inputWidth = this.input.offsetWidth;
+        const tooltipWidth = this.output.offsetWidth;
+        const thumbSize = getComputedStyle(this.input).getPropertyValue("--thumb-size");
+        const isRtl = this.localize.dir() === "rtl";
+        const percentAsWidth = inputWidth * percent;
+        if (isRtl) {
+          const x = `${inputWidth - percentAsWidth}px + ${percent} * ${thumbSize}`;
+          this.output.style.transform = `translateX(calc((${x} - ${tooltipWidth / 2}px - ${thumbSize} / 2)))`;
+        } else {
+          const x = `${percentAsWidth}px - ${percent} * ${thumbSize}`;
+          this.output.style.transform = `translateX(calc(${x} - ${tooltipWidth / 2}px + ${thumbSize} / 2))`;
+        }
+      }
+    }
+    render() {
+      const hasLabelSlot = this.hasSlotController.test("label");
+      const hasHelpTextSlot = this.hasSlotController.test("help-text");
+      const hasLabel = this.label ? true : !!hasLabelSlot;
+      const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
+      return $`
+      <div
+        part="form-control"
+        class=${o$3({
+      "form-control": true,
+      "form-control--medium": true,
+      "form-control--has-label": hasLabel,
+      "form-control--has-help-text": hasHelpText
+    })}
+      >
+        <label
+          part="form-control-label"
+          class="form-control__label"
+          for="input"
+          aria-hidden=${hasLabel ? "false" : "true"}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <div
+            part="base"
+            class=${o$3({
+      range: true,
+      "range--disabled": this.disabled,
+      "range--focused": this.hasFocus,
+      "range--rtl": this.localize.dir() === "rtl",
+      "range--tooltip-visible": this.hasTooltip,
+      "range--tooltip-top": this.tooltip === "top",
+      "range--tooltip-bottom": this.tooltip === "bottom"
+    })}
+            @mousedown=${this.handleThumbDragStart}
+            @mouseup=${this.handleThumbDragEnd}
+            @touchstart=${this.handleThumbDragStart}
+            @touchend=${this.handleThumbDragEnd}
+          >
+            <input
+              part="input"
+              id="input"
+              type="range"
+              class="range__control"
+              name=${l$2(this.name)}
+              ?disabled=${this.disabled}
+              min=${l$2(this.min)}
+              max=${l$2(this.max)}
+              step=${l$2(this.step)}
+              .value=${l$3(this.value.toString())}
+              aria-describedby="help-text"
+              @input=${this.handleInput}
+              @focus=${this.handleFocus}
+              @blur=${this.handleBlur}
+            />
+            ${this.tooltip !== "none" && !this.disabled ? $`
+                  <output part="tooltip" class="range__tooltip">
+                    ${typeof this.tooltipFormatter === "function" ? this.tooltipFormatter(this.value) : this.value}
+                  </output>
+                ` : ""}
+          </div>
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${hasHelpText ? "false" : "true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlRange.styles = range_styles_default;
+  __decorateClass([
+    i2$2(".range__control")
+  ], SlRange.prototype, "input", 2);
+  __decorateClass([
+    i2$2(".range__tooltip")
+  ], SlRange.prototype, "output", 2);
+  __decorateClass([
+    t$1()
+  ], SlRange.prototype, "hasFocus", 2);
+  __decorateClass([
+    t$1()
+  ], SlRange.prototype, "hasTooltip", 2);
+  __decorateClass([
+    e$1()
+  ], SlRange.prototype, "name", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlRange.prototype, "value", 2);
+  __decorateClass([
+    e$1()
+  ], SlRange.prototype, "label", 2);
+  __decorateClass([
+    e$1({ attribute: "help-text" })
+  ], SlRange.prototype, "helpText", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlRange.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlRange.prototype, "invalid", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlRange.prototype, "min", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlRange.prototype, "max", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlRange.prototype, "step", 2);
+  __decorateClass([
+    e$1()
+  ], SlRange.prototype, "tooltip", 2);
+  __decorateClass([
+    e$1({ attribute: false })
+  ], SlRange.prototype, "tooltipFormatter", 2);
+  __decorateClass([
+    defaultValue()
+  ], SlRange.prototype, "defaultValue", 2);
+  __decorateClass([
+    watch("value", { waitUntilFirstUpdate: true })
+  ], SlRange.prototype, "handleValueChange", 1);
+  __decorateClass([
+    watch("disabled", { waitUntilFirstUpdate: true })
+  ], SlRange.prototype, "handleDisabledChange", 1);
+  __decorateClass([
+    watch("hasTooltip", { waitUntilFirstUpdate: true })
+  ], SlRange.prototype, "syncRange", 1);
+  SlRange = __decorateClass([
+    n$1("sl-range")
+  ], SlRange);
+
+  // src/components/rating/rating.styles.ts
+  var rating_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --symbol-color: var(--sl-color-neutral-300);
+    --symbol-color-active: var(--sl-color-amber-500);
+    --symbol-size: 1.2rem;
+    --symbol-spacing: var(--sl-spacing-3x-small);
+
+    display: inline-flex;
+  }
+
+  .rating {
+    position: relative;
+    display: inline-flex;
+    border-radius: var(--sl-border-radius-medium);
+    vertical-align: middle;
+  }
+
+  .rating:focus {
+    outline: none;
+  }
+
+  .rating:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .rating__symbols {
+    display: inline-flex;
+    position: relative;
+    font-size: var(--symbol-size);
+    line-height: 0;
+    color: var(--symbol-color);
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .rating__symbols > * {
+    padding: var(--symbol-spacing);
+  }
+
+  .rating__symbols--indicator {
+    position: absolute;
+    top: 0;
+    left: 0;
+    color: var(--symbol-color-active);
+    pointer-events: none;
+  }
+
+  .rating__symbol {
+    transition: var(--sl-transition-fast) transform;
+  }
+
+  .rating__symbol--hover {
+    transform: scale(1.2);
+  }
+
+  .rating--disabled .rating__symbols,
+  .rating--readonly .rating__symbols {
+    cursor: default;
+  }
+
+  .rating--disabled .rating__symbol--hover,
+  .rating--readonly .rating__symbol--hover {
+    transform: none;
+  }
+
+  .rating--disabled {
+    opacity: 0.5;
+  }
+
+  .rating--disabled .rating__symbols {
+    cursor: not-allowed;
+  }
+`;
+
+  // node_modules/lit-html/directives/style-map.js
+  var i2$1 = e$2(class extends i$1 {
+    constructor(t2) {
+      var e2;
+      if (super(t2), t2.type !== t$2.ATTRIBUTE || "style" !== t2.name || (null === (e2 = t2.strings) || void 0 === e2 ? void 0 : e2.length) > 2)
+        throw Error("The `styleMap` directive must be used in the `style` attribute and must be the only part in the attribute.");
+    }
+    render(t2) {
+      return Object.keys(t2).reduce((e2, r) => {
+        const s = t2[r];
+        return null == s ? e2 : e2 + `${r = r.replace(/(?:^(webkit|moz|ms|o)|)(?=[A-Z])/g, "-$&").toLowerCase()}:${s};`;
+      }, "");
+    }
+    update(e2, [r]) {
+      const { style: s } = e2.element;
+      if (void 0 === this.ct) {
+        this.ct = /* @__PURE__ */ new Set();
+        for (const t2 in r)
+          this.ct.add(t2);
+        return this.render(r);
+      }
+      this.ct.forEach((t2) => {
+        null == r[t2] && (this.ct.delete(t2), t2.includes("-") ? s.removeProperty(t2) : s[t2] = "");
+      });
+      for (const t2 in r) {
+        const e3 = r[t2];
+        null != e3 && (this.ct.add(t2), t2.includes("-") ? s.setProperty(t2, e3) : s[t2] = e3);
+      }
+      return b$1;
+    }
+  });
+  /**
+   * @license
+   * Copyright 2018 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+
+  // src/utilities/base-path.ts
+  var basePath = "";
+  function setBasePath(path) {
+    basePath = path;
+  }
+  function getBasePath() {
+    if (!basePath) {
+      const scripts = [...document.getElementsByTagName("script")];
+      const configScript = scripts.find((script) => script.hasAttribute("data-shoelace"));
+      if (configScript) {
+        setBasePath(configScript.getAttribute("data-shoelace"));
+      } else {
+        const fallbackScript = scripts.find((s) => /shoelace(\.min)?\.js($|\?)/.test(s.src));
+        let path = "";
+        if (fallbackScript) {
+          path = fallbackScript.getAttribute("src");
+        }
+        setBasePath(path.split("/").slice(0, -1).join("/"));
+      }
+    }
+    return basePath.replace(/\/$/, "");
+  }
+
+  // src/components/icon/library.default.ts
+  var library = {
+    name: "default",
+    resolver: (name) => `${getBasePath()}/assets/icons/${name}.svg`
+  };
+  var library_default_default = library;
+
+  // src/components/icon/library.system.ts
+  var icons = {
+    "check-lg": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-lg" viewBox="0 0 16 16">
+      <path d="M12.736 3.97a.733.733 0 0 1 1.047 0c.286.289.29.756.01 1.05L7.88 12.01a.733.733 0 0 1-1.065.02L3.217 8.384a.757.757 0 0 1 0-1.06.733.733 0 0 1 1.047 0l3.052 3.093 5.4-6.425a.247.247 0 0 1 .02-.022Z"></path>
+    </svg>
+  `,
+    "chevron-down": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+    </svg>
+  `,
+    "chevron-left": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
+    </svg>
+  `,
+    "chevron-right": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
+    </svg>
+  `,
+    eye: `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye" viewBox="0 0 16 16">
+      <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.134 13.134 0 0 1 1.172 8z"/>
+      <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/>
+    </svg>
+  `,
+    "eye-slash": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-slash" viewBox="0 0 16 16">
+      <path d="M13.359 11.238C15.06 9.72 16 8 16 8s-3-5.5-8-5.5a7.028 7.028 0 0 0-2.79.588l.77.771A5.944 5.944 0 0 1 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.134 13.134 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755-.165.165-.337.328-.517.486l.708.709z"/>
+      <path d="M11.297 9.176a3.5 3.5 0 0 0-4.474-4.474l.823.823a2.5 2.5 0 0 1 2.829 2.829l.822.822zm-2.943 1.299.822.822a3.5 3.5 0 0 1-4.474-4.474l.823.823a2.5 2.5 0 0 0 2.829 2.829z"/>
+      <path d="M3.35 5.47c-.18.16-.353.322-.518.487A13.134 13.134 0 0 0 1.172 8l.195.288c.335.48.83 1.12 1.465 1.755C4.121 11.332 5.881 12.5 8 12.5c.716 0 1.39-.133 2.02-.36l.77.772A7.029 7.029 0 0 1 8 13.5C3 13.5 0 8 0 8s.939-1.721 2.641-3.238l.708.709zm10.296 8.884-12-12 .708-.708 12 12-.708.708z"/>
+    </svg>
+  `,
+    eyedropper: `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eyedropper" viewBox="0 0 16 16">
+      <path d="M13.354.646a1.207 1.207 0 0 0-1.708 0L8.5 3.793l-.646-.647a.5.5 0 1 0-.708.708L8.293 5l-7.147 7.146A.5.5 0 0 0 1 12.5v1.793l-.854.853a.5.5 0 1 0 .708.707L1.707 15H3.5a.5.5 0 0 0 .354-.146L11 7.707l1.146 1.147a.5.5 0 0 0 .708-.708l-.647-.646 3.147-3.146a1.207 1.207 0 0 0 0-1.708l-2-2zM2 12.707l7-7L10.293 7l-7 7H2v-1.293z"></path>
+    </svg>
+  `,
+    "person-fill": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-person-fill" viewBox="0 0 16 16">
+      <path d="M3 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H3zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/>
+    </svg>
+  `,
+    "play-fill": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-fill" viewBox="0 0 16 16">
+      <path d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z"></path>
+    </svg>
+  `,
+    "pause-fill": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pause-fill" viewBox="0 0 16 16">
+      <path d="M5.5 3.5A1.5 1.5 0 0 1 7 5v6a1.5 1.5 0 0 1-3 0V5a1.5 1.5 0 0 1 1.5-1.5zm5 0A1.5 1.5 0 0 1 12 5v6a1.5 1.5 0 0 1-3 0V5a1.5 1.5 0 0 1 1.5-1.5z"></path>
+    </svg>
+  `,
+    "star-fill": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-star-fill" viewBox="0 0 16 16">
+      <path d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z"/>
+    </svg>
+  `,
+    x: `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x" viewBox="0 0 16 16">
+      <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
+    </svg>
+  `,
+    "x-circle-fill": `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-circle-fill" viewBox="0 0 16 16">
+      <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.354 4.646a.5.5 0 1 0-.708.708L7.293 8l-2.647 2.646a.5.5 0 0 0 .708.708L8 8.707l2.646 2.647a.5.5 0 0 0 .708-.708L8.707 8l2.647-2.646a.5.5 0 0 0-.708-.708L8 7.293 5.354 4.646z"></path>
+    </svg>
+  `
+  };
+  var systemLibrary = {
+    name: "system",
+    resolver: (name) => {
+      if (name in icons) {
+        return `data:image/svg+xml,${encodeURIComponent(icons[name])}`;
+      }
+      return "";
+    }
+  };
+  var library_system_default = systemLibrary;
+
+  // src/components/icon/library.ts
+  var registry = [library_default_default, library_system_default];
+  var watchedIcons = [];
+  function watchIcon(icon) {
+    watchedIcons.push(icon);
+  }
+  function unwatchIcon(icon) {
+    watchedIcons = watchedIcons.filter((el) => el !== icon);
+  }
+  function getIconLibrary(name) {
+    return registry.find((lib) => lib.name === name);
+  }
+
+  // src/components/include/request.ts
+  var includeFiles = /* @__PURE__ */ new Map();
+  function requestInclude(src, mode = "cors") {
+    if (includeFiles.has(src)) {
+      return includeFiles.get(src);
+    }
+    const fileDataPromise = fetch(src, { mode }).then(async (response) => {
+      return {
+        ok: response.ok,
+        status: response.status,
+        html: await response.text()
+      };
+    });
+    includeFiles.set(src, fileDataPromise);
+    return fileDataPromise;
+  }
+
+  // src/components/icon/request.ts
+  var iconFiles = /* @__PURE__ */ new Map();
+  async function requestIcon(url) {
+    if (iconFiles.has(url)) {
+      return iconFiles.get(url);
+    }
+    const fileData = await requestInclude(url);
+    const iconFileData = {
+      ok: fileData.ok,
+      status: fileData.status,
+      svg: null
+    };
+    if (fileData.ok) {
+      const div = document.createElement("div");
+      div.innerHTML = fileData.html;
+      const svg = div.firstElementChild;
+      iconFileData.svg = (svg == null ? void 0 : svg.tagName.toLowerCase()) === "svg" ? svg.outerHTML : "";
+    }
+    iconFiles.set(url, iconFileData);
+    return iconFileData;
+  }
+
+  // src/components/icon/icon.styles.ts
+  var icon_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    contain: strict;
+    box-sizing: content-box !important;
+  }
+
+  .icon,
+  svg {
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+`;
+
+  // node_modules/lit-html/directives/unsafe-html.js
+  var e3 = class extends i$1 {
+    constructor(i2) {
+      if (super(i2), this.it = w, i2.type !== t$2.CHILD)
+        throw Error(this.constructor.directiveName + "() can only be used in child bindings");
+    }
+    render(r) {
+      if (r === w || null == r)
+        return this.ft = void 0, this.it = r;
+      if (r === b$1)
+        return r;
+      if ("string" != typeof r)
+        throw Error(this.constructor.directiveName + "() called with a non-string value");
+      if (r === this.it)
+        return this.ft;
+      this.it = r;
+      const s = [r];
+      return s.raw = s, this.ft = { _$litType$: this.constructor.resultType, strings: s, values: [] };
+    }
+  };
+  e3.directiveName = "unsafeHTML", e3.resultType = 1;
+  var o = e$2(e3);
+
+  // node_modules/lit-html/directives/unsafe-svg.js
+  var t3 = class extends e3 {
+  };
+  t3.directiveName = "unsafeSVG", t3.resultType = 2;
+  var o2$1 = e$2(t3);
+
+  // src/components/icon/icon.ts
+  var parser;
+  var SlIcon = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.svg = "";
+      this.label = "";
+      this.library = "default";
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      watchIcon(this);
+    }
+    firstUpdated() {
+      this.setIcon();
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      unwatchIcon(this);
+    }
+    getUrl() {
+      const library = getIconLibrary(this.library);
+      if (this.name && library) {
+        return library.resolver(this.name);
+      }
+      return this.src;
+    }
+    redraw() {
+      this.setIcon();
+    }
+    async setIcon() {
+      var _a;
+      const library = getIconLibrary(this.library);
+      const url = this.getUrl();
+      if (!parser) {
+        parser = new DOMParser();
+      }
+      if (url) {
+        try {
+          const file = await requestIcon(url);
+          if (url !== this.getUrl()) {
+            return;
+          } else if (file.ok) {
+            const doc = parser.parseFromString(file.svg, "text/html");
+            const svgEl = doc.body.querySelector("svg");
+            if (svgEl !== null) {
+              (_a = library == null ? void 0 : library.mutator) == null ? void 0 : _a.call(library, svgEl);
+              this.svg = svgEl.outerHTML;
+              this.emit("sl-load");
+            } else {
+              this.svg = "";
+              this.emit("sl-error");
+            }
+          } else {
+            this.svg = "";
+            this.emit("sl-error");
+          }
+        } catch (e4) {
+          this.emit("sl-error");
+        }
+      } else if (this.svg.length > 0) {
+        this.svg = "";
+      }
+    }
+    handleChange() {
+      this.setIcon();
+    }
+    render() {
+      const hasLabel = typeof this.label === "string" && this.label.length > 0;
+      return $` <div
+      part="base"
+      class="icon"
+      role=${l$2(hasLabel ? "img" : void 0)}
+      aria-label=${l$2(hasLabel ? this.label : void 0)}
+      aria-hidden=${l$2(hasLabel ? void 0 : "true")}
+    >
+      ${o2$1(this.svg)}
+    </div>`;
+    }
+  };
+  SlIcon.styles = icon_styles_default;
+  __decorateClass([
+    t$1()
+  ], SlIcon.prototype, "svg", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlIcon.prototype, "name", 2);
+  __decorateClass([
+    e$1()
+  ], SlIcon.prototype, "src", 2);
+  __decorateClass([
+    e$1()
+  ], SlIcon.prototype, "label", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlIcon.prototype, "library", 2);
+  __decorateClass([
+    watch("name"),
+    watch("src"),
+    watch("library")
+  ], SlIcon.prototype, "setIcon", 1);
+  SlIcon = __decorateClass([
+    n$1("sl-icon")
+  ], SlIcon);
+  /**
+   * @license
+   * Copyright 2017 Google LLC
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+
+  // src/components/rating/rating.ts
+  var SlRating = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.hoverValue = 0;
+      this.isHovering = false;
+      this.label = "";
+      this.value = 0;
+      this.max = 5;
+      this.precision = 1;
+      this.readonly = false;
+      this.disabled = false;
+      this.getSymbol = () => '<sl-icon name="star-fill" library="system"></sl-icon>';
+    }
+    focus(options) {
+      this.rating.focus(options);
+    }
+    blur() {
+      this.rating.blur();
+    }
+    getValueFromMousePosition(event) {
+      return this.getValueFromXCoordinate(event.clientX);
+    }
+    getValueFromTouchPosition(event) {
+      return this.getValueFromXCoordinate(event.touches[0].clientX);
+    }
+    getValueFromXCoordinate(coordinate) {
+      const isRtl = this.localize.dir() === "rtl";
+      const { left, right, width } = this.rating.getBoundingClientRect();
+      const value = isRtl ? this.roundToPrecision((right - coordinate) / width * this.max, this.precision) : this.roundToPrecision((coordinate - left) / width * this.max, this.precision);
+      return clamp(value, 0, this.max);
+    }
+    handleClick(event) {
+      this.setValue(this.getValueFromMousePosition(event));
+    }
+    setValue(newValue) {
+      if (this.disabled || this.readonly) {
+        return;
+      }
+      this.value = newValue === this.value ? 0 : newValue;
+      this.isHovering = false;
+    }
+    handleKeyDown(event) {
+      const isLtr = this.localize.dir() === "ltr";
+      const isRtl = this.localize.dir() === "rtl";
+      if (this.disabled || this.readonly) {
+        return;
+      }
+      if (event.key === "ArrowDown" || isLtr && event.key === "ArrowLeft" || isRtl && event.key === "ArrowRight") {
+        const decrement = event.shiftKey ? 1 : this.precision;
+        this.value = Math.max(0, this.value - decrement);
+        event.preventDefault();
+      }
+      if (event.key === "ArrowUp" || isLtr && event.key === "ArrowRight" || isRtl && event.key === "ArrowLeft") {
+        const increment = event.shiftKey ? 1 : this.precision;
+        this.value = Math.min(this.max, this.value + increment);
+        event.preventDefault();
+      }
+      if (event.key === "Home") {
+        this.value = 0;
+        event.preventDefault();
+      }
+      if (event.key === "End") {
+        this.value = this.max;
+        event.preventDefault();
+      }
+    }
+    handleMouseEnter() {
+      this.isHovering = true;
+    }
+    handleMouseMove(event) {
+      this.hoverValue = this.getValueFromMousePosition(event);
+    }
+    handleMouseLeave() {
+      this.isHovering = false;
+    }
+    handleTouchStart(event) {
+      this.hoverValue = this.getValueFromTouchPosition(event);
+      event.preventDefault();
+    }
+    handleTouchMove(event) {
+      this.isHovering = true;
+      this.hoverValue = this.getValueFromTouchPosition(event);
+    }
+    handleTouchEnd(event) {
+      this.isHovering = false;
+      this.setValue(this.hoverValue);
+      event.preventDefault();
+    }
+    handleValueChange() {
+      this.emit("sl-change");
+    }
+    roundToPrecision(numberToRound, precision = 0.5) {
+      const multiplier = 1 / precision;
+      return Math.ceil(numberToRound * multiplier) / multiplier;
+    }
+    render() {
+      const isRtl = this.localize.dir() === "rtl";
+      const counter = Array.from(Array(this.max).keys());
+      let displayValue = 0;
+      if (this.disabled || this.readonly) {
+        displayValue = this.value;
+      } else {
+        displayValue = this.isHovering ? this.hoverValue : this.value;
+      }
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      rating: true,
+      "rating--readonly": this.readonly,
+      "rating--disabled": this.disabled,
+      "rating--rtl": isRtl
+    })}
+        role="slider"
+        aria-label=${this.label}
+        aria-disabled=${this.disabled ? "true" : "false"}
+        aria-readonly=${this.readonly ? "true" : "false"}
+        aria-valuenow=${this.value}
+        aria-valuemin=${0}
+        aria-valuemax=${this.max}
+        tabindex=${this.disabled ? "-1" : "0"}
+        @click=${this.handleClick}
+        @keydown=${this.handleKeyDown}
+        @mouseenter=${this.handleMouseEnter}
+        @touchstart=${this.handleTouchStart}
+        @mouseleave=${this.handleMouseLeave}
+        @touchend=${this.handleTouchEnd}
+        @mousemove=${this.handleMouseMove}
+        @touchmove=${this.handleTouchMove}
+      >
+        <span class="rating__symbols rating__symbols--inactive">
+          ${counter.map((index) => {
+      return $`
+              <span
+                class=${o$3({
+        rating__symbol: true,
+        "rating__symbol--hover": this.isHovering && Math.ceil(displayValue) === index + 1
+      })}
+                role="presentation"
+                @mouseenter=${this.handleMouseEnter}
+              >
+                ${o(this.getSymbol(index + 1))}
+              </span>
+            `;
+    })}
+        </span>
+
+        <span class="rating__symbols rating__symbols--indicator">
+          ${counter.map((index) => {
+      return $`
+              <span
+                class=${o$3({
+        rating__symbol: true,
+        "rating__symbol--hover": this.isHovering && Math.ceil(displayValue) === index + 1
+      })}
+                style=${i2$1({
+        clipPath: displayValue > index + 1 ? "none" : isRtl ? `inset(0 0 0 ${100 - (displayValue - index) / 1 * 100}%)` : `inset(0 ${100 - (displayValue - index) / 1 * 100}% 0 0)`
+      })}
+                role="presentation"
+              >
+                ${o(this.getSymbol(index + 1))}
+              </span>
+            `;
+    })}
+        </span>
+      </div>
+    `;
+    }
+  };
+  SlRating.styles = rating_styles_default;
+  __decorateClass([
+    i2$2(".rating")
+  ], SlRating.prototype, "rating", 2);
+  __decorateClass([
+    t$1()
+  ], SlRating.prototype, "hoverValue", 2);
+  __decorateClass([
+    t$1()
+  ], SlRating.prototype, "isHovering", 2);
+  __decorateClass([
+    e$1()
+  ], SlRating.prototype, "label", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlRating.prototype, "value", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlRating.prototype, "max", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlRating.prototype, "precision", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlRating.prototype, "readonly", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlRating.prototype, "disabled", 2);
+  __decorateClass([
+    e$1()
+  ], SlRating.prototype, "getSymbol", 2);
+  __decorateClass([
+    watch("value", { waitUntilFirstUpdate: true })
+  ], SlRating.prototype, "handleValueChange", 1);
+  SlRating = __decorateClass([
+    n$1("sl-rating")
+  ], SlRating);
+
+  // src/components/progress-bar/progress-bar.styles.ts
+  var progress_bar_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --height: 1rem;
+    --track-color: var(--sl-color-neutral-200);
+    --indicator-color: var(--sl-color-primary-600);
+    --label-color: var(--sl-color-neutral-0);
+
+    display: block;
+  }
+
+  .progress-bar {
+    position: relative;
+    background-color: var(--track-color);
+    height: var(--height);
+    border-radius: var(--sl-border-radius-pill);
+    box-shadow: inset var(--sl-shadow-small);
+    overflow: hidden;
+  }
+
+  .progress-bar__indicator {
+    height: 100%;
+    font-family: var(--sl-font-sans);
+    font-size: 12px;
+    font-weight: var(--sl-font-weight-normal);
+    background-color: var(--indicator-color);
+    color: var(--label-color);
+    text-align: center;
+    line-height: var(--height);
+    white-space: nowrap;
+    overflow: hidden;
+    transition: 400ms width, 400ms background-color;
+    user-select: none;
+  }
+
+  /* Indeterminate */
+  .progress-bar--indeterminate .progress-bar__indicator {
+    position: absolute;
+    animation: indeterminate 2.5s infinite cubic-bezier(0.37, 0, 0.63, 1);
+  }
+
+  .progress-bar--indeterminate.progress-bar--rtl .progress-bar__indicator {
+    animation-name: indeterminate-rtl;
+  }
+
+  @keyframes indeterminate {
+    0% {
+      left: -50%;
+      width: 50%;
+    }
+    75%,
+    100% {
+      left: 100%;
+      width: 50%;
+    }
+  }
+
+  @keyframes indeterminate-rtl {
+    0% {
+      right: -50%;
+      width: 50%;
+    }
+    75%,
+    100% {
+      right: 100%;
+      width: 50%;
+    }
+  }
+`;
+
+  // src/components/progress-bar/progress-bar.ts
+  var SlProgressBar = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.value = 0;
+      this.indeterminate = false;
+      this.label = "";
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      "progress-bar": true,
+      "progress-bar--indeterminate": this.indeterminate,
+      "progress-bar--rtl": this.localize.dir() === "rtl"
+    })}
+        role="progressbar"
+        title=${l$2(this.title)}
+        aria-label=${this.label.length > 0 ? this.label : this.localize.term("progress")}
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow=${this.indeterminate ? 0 : this.value}
+      >
+        <div part="indicator" class="progress-bar__indicator" style=${i2$1({ width: `${this.value}%` })}>
+          ${!this.indeterminate ? $`
+                <span part="label" class="progress-bar__label">
+                  <slot></slot>
+                </span>
+              ` : ""}
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlProgressBar.styles = progress_bar_styles_default;
+  __decorateClass([
+    e$1({ type: Number, reflect: true })
+  ], SlProgressBar.prototype, "value", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlProgressBar.prototype, "indeterminate", 2);
+  __decorateClass([
+    e$1()
+  ], SlProgressBar.prototype, "label", 2);
+  SlProgressBar = __decorateClass([
+    n$1("sl-progress-bar")
+  ], SlProgressBar);
+
+  // src/components/progress-ring/progress-ring.styles.ts
+  var progress_ring_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --size: 128px;
+    --track-width: 4px;
+    --track-color: var(--sl-color-neutral-200);
+    --indicator-width: var(--track-width);
+    --indicator-color: var(--sl-color-primary-600);
+
+    display: inline-flex;
+  }
+
+  .progress-ring {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+  }
+
+  .progress-ring__image {
+    width: var(--size);
+    height: var(--size);
+    transform: rotate(-90deg);
+    transform-origin: 50% 50%;
+  }
+
+  .progress-ring__track,
+  .progress-ring__indicator {
+    --radius: calc(var(--size) / 2 - max(var(--track-width), var(--indicator-width)) * 0.5);
+    --circumference: calc(var(--radius) * 2 * 3.141592654);
+
+    fill: none;
+    r: var(--radius);
+    cx: calc(var(--size) / 2);
+    cy: calc(var(--size) / 2);
+  }
+
+  .progress-ring__track {
+    stroke: var(--track-color);
+    stroke-width: var(--track-width);
+  }
+
+  .progress-ring__indicator {
+    stroke: var(--indicator-color);
+    stroke-width: var(--indicator-width);
+    stroke-linecap: round;
+    transition: 0.35s stroke-dashoffset;
+    stroke-dasharray: var(--circumference) var(--circumference);
+    stroke-dashoffset: calc(var(--circumference) - var(--percentage) * var(--circumference));
+  }
+
+  .progress-ring__label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    user-select: none;
+  }
+`;
+
+  // src/components/progress-ring/progress-ring.ts
+  var SlProgressRing = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.value = 0;
+      this.label = "";
+    }
+    updated(changedProps) {
+      super.updated(changedProps);
+      if (changedProps.has("value")) {
+        const radius = parseFloat(getComputedStyle(this.indicator).getPropertyValue("r"));
+        const circumference = 2 * Math.PI * radius;
+        const offset = circumference - this.value / 100 * circumference;
+        this.indicatorOffset = `${offset}px`;
+      }
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class="progress-ring"
+        role="progressbar"
+        aria-label=${this.label.length > 0 ? this.label : this.localize.term("progress")}
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="${this.value}"
+        style="--percentage: ${this.value / 100}"
+      >
+        <svg class="progress-ring__image">
+          <circle class="progress-ring__track"></circle>
+          <circle class="progress-ring__indicator" style="stroke-dashoffset: ${this.indicatorOffset}"></circle>
+        </svg>
+
+        <span part="label" class="progress-ring__label">
+          <slot></slot>
+        </span>
+      </div>
+    `;
+    }
+  };
+  SlProgressRing.styles = progress_ring_styles_default;
+  __decorateClass([
+    i2$2(".progress-ring__indicator")
+  ], SlProgressRing.prototype, "indicator", 2);
+  __decorateClass([
+    t$1()
+  ], SlProgressRing.prototype, "indicatorOffset", 2);
+  __decorateClass([
+    e$1({ type: Number, reflect: true })
+  ], SlProgressRing.prototype, "value", 2);
+  __decorateClass([
+    e$1()
+  ], SlProgressRing.prototype, "label", 2);
+  SlProgressRing = __decorateClass([
+    n$1("sl-progress-ring")
+  ], SlProgressRing);
+
+  // src/components/qr-code/qr-code.styles.ts
+  var qr_code_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .qr-code {
+    position: relative;
+  }
+
+  canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+  // node_modules/qr-creator/dist/qr-creator.es6.min.js
+  var G = null;
+  var H$1 = class {
+  };
+  H$1.render = function(w, B) {
+    G(w, B);
+  };
+  self.QrCreator = H$1;
+  (function(w) {
+    function B(t, c, a, e2) {
+      var b = {}, h = w(a, c);
+      h.u(t);
+      h.J();
+      e2 = e2 || 0;
+      var r = h.h(), d = h.h() + 2 * e2;
+      b.text = t;
+      b.level = c;
+      b.version = a;
+      b.O = d;
+      b.a = function(b2, a2) {
+        b2 -= e2;
+        a2 -= e2;
+        return 0 > b2 || b2 >= r || 0 > a2 || a2 >= r ? false : h.a(b2, a2);
+      };
+      return b;
+    }
+    function C(t, c, a, e2, b, h, r, d, g, x) {
+      function u(b2, a2, f, c2, d2, r2, g2) {
+        b2 ? (t.lineTo(a2 + r2, f + g2), t.arcTo(a2, f, c2, d2, h)) : t.lineTo(a2, f);
+      }
+      r ? t.moveTo(c + h, a) : t.moveTo(c, a);
+      u(d, e2, a, e2, b, -h, 0);
+      u(g, e2, b, c, b, 0, -h);
+      u(x, c, b, c, a, h, 0);
+      u(r, c, a, e2, a, 0, h);
+    }
+    function z(t, c, a, e2, b, h, r, d, g, x) {
+      function u(b2, a2, c2, d2) {
+        t.moveTo(b2 + c2, a2);
+        t.lineTo(
+          b2,
+          a2
+        );
+        t.lineTo(b2, a2 + d2);
+        t.arcTo(b2, a2, b2 + c2, a2, h);
+      }
+      r && u(c, a, h, h);
+      d && u(e2, a, -h, h);
+      g && u(e2, b, -h, -h);
+      x && u(c, b, h, -h);
+    }
+    function A(t, c) {
+      var a = c.fill;
+      if ("string" === typeof a)
+        t.fillStyle = a;
+      else {
+        var e2 = a.type, b = a.colorStops;
+        a = a.position.map((b2) => Math.round(b2 * c.size));
+        if ("linear-gradient" === e2)
+          var h = t.createLinearGradient.apply(t, a);
+        else if ("radial-gradient" === e2)
+          h = t.createRadialGradient.apply(t, a);
+        else
+          throw Error("Unsupported fill");
+        b.forEach(([b2, a2]) => {
+          h.addColorStop(b2, a2);
+        });
+        t.fillStyle = h;
+      }
+    }
+    function y(t, c) {
+      a: {
+        var a = c.text, e2 = c.v, b = c.N, h = c.K, r = c.P;
+        b = Math.max(1, b || 1);
+        for (h = Math.min(40, h || 40); b <= h; b += 1)
+          try {
+            var d = B(a, e2, b, r);
+            break a;
+          } catch (J) {
+          }
+        d = void 0;
+      }
+      if (!d)
+        return null;
+      a = t.getContext("2d");
+      c.background && (a.fillStyle = c.background, a.fillRect(c.left, c.top, c.size, c.size));
+      e2 = d.O;
+      h = c.size / e2;
+      a.beginPath();
+      for (r = 0; r < e2; r += 1)
+        for (b = 0; b < e2; b += 1) {
+          var g = a, x = c.left + b * h, u = c.top + r * h, p = r, q = b, f = d.a, k = x + h, m = u + h, D = p - 1, E = p + 1, n2 = q - 1, l = q + 1, y2 = Math.floor(Math.min(0.5, Math.max(0, c.R)) * h), v2 = f(p, q), I = f(D, n2), w2 = f(D, q);
+          D = f(D, l);
+          var F = f(p, l);
+          l = f(E, l);
+          q = f(
+            E,
+            q
+          );
+          E = f(E, n2);
+          p = f(p, n2);
+          x = Math.round(x);
+          u = Math.round(u);
+          k = Math.round(k);
+          m = Math.round(m);
+          v2 ? C(g, x, u, k, m, y2, !w2 && !p, !w2 && !F, !q && !F, !q && !p) : z(g, x, u, k, m, y2, w2 && p && I, w2 && F && D, q && F && l, q && p && E);
+        }
+      A(a, c);
+      a.fill();
+      return t;
+    }
+    var v = { minVersion: 1, maxVersion: 40, ecLevel: "L", left: 0, top: 0, size: 200, fill: "#000", background: null, text: "no text", radius: 0.5, quiet: 0 };
+    G = function(t, c) {
+      var a = {};
+      Object.assign(a, v, t);
+      a.N = a.minVersion;
+      a.K = a.maxVersion;
+      a.v = a.ecLevel;
+      a.left = a.left;
+      a.top = a.top;
+      a.size = a.size;
+      a.fill = a.fill;
+      a.background = a.background;
+      a.text = a.text;
+      a.R = a.radius;
+      a.P = a.quiet;
+      if (c instanceof HTMLCanvasElement) {
+        if (c.width !== a.size || c.height !== a.size)
+          c.width = a.size, c.height = a.size;
+        c.getContext("2d").clearRect(0, 0, c.width, c.height);
+        y(c, a);
+      } else
+        t = document.createElement("canvas"), t.width = a.size, t.height = a.size, a = y(t, a), c.appendChild(a);
+    };
+  })(function() {
+    function w(c) {
+      var a = C.s(c);
+      return { S: function() {
+        return 4;
+      }, b: function() {
+        return a.length;
+      }, write: function(c2) {
+        for (var b = 0; b < a.length; b += 1)
+          c2.put(a[b], 8);
+      } };
+    }
+    function B() {
+      var c = [], a = 0, e2 = {
+        B: function() {
+          return c;
+        },
+        c: function(b) {
+          return 1 == (c[Math.floor(b / 8)] >>> 7 - b % 8 & 1);
+        },
+        put: function(b, h) {
+          for (var a2 = 0; a2 < h; a2 += 1)
+            e2.m(1 == (b >>> h - a2 - 1 & 1));
+        },
+        f: function() {
+          return a;
+        },
+        m: function(b) {
+          var h = Math.floor(a / 8);
+          c.length <= h && c.push(0);
+          b && (c[h] |= 128 >>> a % 8);
+          a += 1;
+        }
+      };
+      return e2;
+    }
+    function C(c, a) {
+      function e2(b2, h2) {
+        for (var a2 = -1; 7 >= a2; a2 += 1)
+          if (!(-1 >= b2 + a2 || d <= b2 + a2))
+            for (var c2 = -1; 7 >= c2; c2 += 1)
+              -1 >= h2 + c2 || d <= h2 + c2 || (r[b2 + a2][h2 + c2] = 0 <= a2 && 6 >= a2 && (0 == c2 || 6 == c2) || 0 <= c2 && 6 >= c2 && (0 == a2 || 6 == a2) || 2 <= a2 && 4 >= a2 && 2 <= c2 && 4 >= c2 ? true : false);
+      }
+      function b(b2, a2) {
+        for (var f = d = 4 * c + 17, k = Array(f), m = 0; m < f; m += 1) {
+          k[m] = Array(f);
+          for (var p = 0; p < f; p += 1)
+            k[m][p] = null;
+        }
+        r = k;
+        e2(0, 0);
+        e2(d - 7, 0);
+        e2(0, d - 7);
+        f = y.G(c);
+        for (k = 0; k < f.length; k += 1)
+          for (m = 0; m < f.length; m += 1) {
+            p = f[k];
+            var q = f[m];
+            if (null == r[p][q])
+              for (var n2 = -2; 2 >= n2; n2 += 1)
+                for (var l = -2; 2 >= l; l += 1)
+                  r[p + n2][q + l] = -2 == n2 || 2 == n2 || -2 == l || 2 == l || 0 == n2 && 0 == l;
+          }
+        for (f = 8; f < d - 8; f += 1)
+          null == r[f][6] && (r[f][6] = 0 == f % 2);
+        for (f = 8; f < d - 8; f += 1)
+          null == r[6][f] && (r[6][f] = 0 == f % 2);
+        f = y.w(h << 3 | a2);
+        for (k = 0; 15 > k; k += 1)
+          m = !b2 && 1 == (f >> k & 1), r[6 > k ? k : 8 > k ? k + 1 : d - 15 + k][8] = m, r[8][8 > k ? d - k - 1 : 9 > k ? 15 - k : 14 - k] = m;
+        r[d - 8][8] = !b2;
+        if (7 <= c) {
+          f = y.A(c);
+          for (k = 0; 18 > k; k += 1)
+            m = !b2 && 1 == (f >> k & 1), r[Math.floor(k / 3)][k % 3 + d - 8 - 3] = m;
+          for (k = 0; 18 > k; k += 1)
+            m = !b2 && 1 == (f >> k & 1), r[k % 3 + d - 8 - 3][Math.floor(k / 3)] = m;
+        }
+        if (null == g) {
+          b2 = t.I(c, h);
+          f = B();
+          for (k = 0; k < x.length; k += 1)
+            m = x[k], f.put(4, 4), f.put(m.b(), y.f(4, c)), m.write(f);
+          for (k = m = 0; k < b2.length; k += 1)
+            m += b2[k].j;
+          if (f.f() > 8 * m)
+            throw Error("code length overflow. (" + f.f() + ">" + 8 * m + ")");
+          for (f.f() + 4 <= 8 * m && f.put(0, 4); 0 != f.f() % 8; )
+            f.m(false);
+          for (; !(f.f() >= 8 * m); ) {
+            f.put(236, 8);
+            if (f.f() >= 8 * m)
+              break;
+            f.put(17, 8);
+          }
+          var u2 = 0;
+          m = k = 0;
+          p = Array(b2.length);
+          q = Array(b2.length);
+          for (n2 = 0; n2 < b2.length; n2 += 1) {
+            var v2 = b2[n2].j, w2 = b2[n2].o - v2;
+            k = Math.max(k, v2);
+            m = Math.max(m, w2);
+            p[n2] = Array(v2);
+            for (l = 0; l < p[n2].length; l += 1)
+              p[n2][l] = 255 & f.B()[l + u2];
+            u2 += v2;
+            l = y.C(w2);
+            v2 = z(p[n2], l.b() - 1).l(l);
+            q[n2] = Array(l.b() - 1);
+            for (l = 0; l < q[n2].length; l += 1)
+              w2 = l + v2.b() - q[n2].length, q[n2][l] = 0 <= w2 ? v2.c(w2) : 0;
+          }
+          for (l = f = 0; l < b2.length; l += 1)
+            f += b2[l].o;
+          f = Array(f);
+          for (l = u2 = 0; l < k; l += 1)
+            for (n2 = 0; n2 < b2.length; n2 += 1)
+              l < p[n2].length && (f[u2] = p[n2][l], u2 += 1);
+          for (l = 0; l < m; l += 1)
+            for (n2 = 0; n2 < b2.length; n2 += 1)
+              l < q[n2].length && (f[u2] = q[n2][l], u2 += 1);
+          g = f;
+        }
+        b2 = g;
+        f = -1;
+        k = d - 1;
+        m = 7;
+        p = 0;
+        a2 = y.F(a2);
+        for (q = d - 1; 0 < q; q -= 2)
+          for (6 == q && --q; ; ) {
+            for (n2 = 0; 2 > n2; n2 += 1)
+              null == r[k][q - n2] && (l = false, p < b2.length && (l = 1 == (b2[p] >>> m & 1)), a2(k, q - n2) && (l = !l), r[k][q - n2] = l, --m, -1 == m && (p += 1, m = 7));
+            k += f;
+            if (0 > k || d <= k) {
+              k -= f;
+              f = -f;
+              break;
+            }
+          }
+      }
+      var h = A[a], r = null, d = 0, g = null, x = [], u = { u: function(b2) {
+        b2 = w(b2);
+        x.push(b2);
+        g = null;
+      }, a: function(b2, a2) {
+        if (0 > b2 || d <= b2 || 0 > a2 || d <= a2)
+          throw Error(b2 + "," + a2);
+        return r[b2][a2];
+      }, h: function() {
+        return d;
+      }, J: function() {
+        for (var a2 = 0, h2 = 0, c2 = 0; 8 > c2; c2 += 1) {
+          b(true, c2);
+          var d2 = y.D(u);
+          if (0 == c2 || a2 > d2)
+            a2 = d2, h2 = c2;
+        }
+        b(false, h2);
+      } };
+      return u;
+    }
+    function z(c, a) {
+      if ("undefined" == typeof c.length)
+        throw Error(c.length + "/" + a);
+      var e2 = function() {
+        for (var b2 = 0; b2 < c.length && 0 == c[b2]; )
+          b2 += 1;
+        for (var r = Array(c.length - b2 + a), d = 0; d < c.length - b2; d += 1)
+          r[d] = c[d + b2];
+        return r;
+      }(), b = { c: function(b2) {
+        return e2[b2];
+      }, b: function() {
+        return e2.length;
+      }, multiply: function(a2) {
+        for (var h = Array(b.b() + a2.b() - 1), c2 = 0; c2 < b.b(); c2 += 1)
+          for (var g = 0; g < a2.b(); g += 1)
+            h[c2 + g] ^= v.i(v.g(b.c(c2)) + v.g(a2.c(g)));
+        return z(h, 0);
+      }, l: function(a2) {
+        if (0 > b.b() - a2.b())
+          return b;
+        for (var c2 = v.g(b.c(0)) - v.g(a2.c(0)), h = Array(b.b()), g = 0; g < b.b(); g += 1)
+          h[g] = b.c(g);
+        for (g = 0; g < a2.b(); g += 1)
+          h[g] ^= v.i(v.g(a2.c(g)) + c2);
+        return z(h, 0).l(a2);
+      } };
+      return b;
+    }
+    C.s = function(c) {
+      for (var a = [], e2 = 0; e2 < c.length; e2++) {
+        var b = c.charCodeAt(e2);
+        128 > b ? a.push(b) : 2048 > b ? a.push(192 | b >> 6, 128 | b & 63) : 55296 > b || 57344 <= b ? a.push(224 | b >> 12, 128 | b >> 6 & 63, 128 | b & 63) : (e2++, b = 65536 + ((b & 1023) << 10 | c.charCodeAt(e2) & 1023), a.push(240 | b >> 18, 128 | b >> 12 & 63, 128 | b >> 6 & 63, 128 | b & 63));
+      }
+      return a;
+    };
+    var A = { L: 1, M: 0, Q: 3, H: 2 }, y = function() {
+      function c(b) {
+        for (var a2 = 0; 0 != b; )
+          a2 += 1, b >>>= 1;
+        return a2;
+      }
+      var a = [
+        [],
+        [6, 18],
+        [6, 22],
+        [6, 26],
+        [6, 30],
+        [6, 34],
+        [6, 22, 38],
+        [6, 24, 42],
+        [6, 26, 46],
+        [6, 28, 50],
+        [6, 30, 54],
+        [6, 32, 58],
+        [6, 34, 62],
+        [6, 26, 46, 66],
+        [6, 26, 48, 70],
+        [6, 26, 50, 74],
+        [6, 30, 54, 78],
+        [6, 30, 56, 82],
+        [6, 30, 58, 86],
+        [6, 34, 62, 90],
+        [6, 28, 50, 72, 94],
+        [6, 26, 50, 74, 98],
+        [6, 30, 54, 78, 102],
+        [6, 28, 54, 80, 106],
+        [6, 32, 58, 84, 110],
+        [6, 30, 58, 86, 114],
+        [6, 34, 62, 90, 118],
+        [6, 26, 50, 74, 98, 122],
+        [6, 30, 54, 78, 102, 126],
+        [6, 26, 52, 78, 104, 130],
+        [6, 30, 56, 82, 108, 134],
+        [6, 34, 60, 86, 112, 138],
+        [6, 30, 58, 86, 114, 142],
+        [6, 34, 62, 90, 118, 146],
+        [6, 30, 54, 78, 102, 126, 150],
+        [6, 24, 50, 76, 102, 128, 154],
+        [6, 28, 54, 80, 106, 132, 158],
+        [6, 32, 58, 84, 110, 136, 162],
+        [6, 26, 54, 82, 110, 138, 166],
+        [6, 30, 58, 86, 114, 142, 170]
+      ], e2 = { w: function(b) {
+        for (var a2 = b << 10; 0 <= c(a2) - c(1335); )
+          a2 ^= 1335 << c(a2) - c(1335);
+        return (b << 10 | a2) ^ 21522;
+      }, A: function(b) {
+        for (var a2 = b << 12; 0 <= c(a2) - c(7973); )
+          a2 ^= 7973 << c(a2) - c(7973);
+        return b << 12 | a2;
+      }, G: function(b) {
+        return a[b - 1];
+      }, F: function(b) {
+        switch (b) {
+          case 0:
+            return function(b2, a2) {
+              return 0 == (b2 + a2) % 2;
+            };
+          case 1:
+            return function(b2) {
+              return 0 == b2 % 2;
+            };
+          case 2:
+            return function(b2, a2) {
+              return 0 == a2 % 3;
+            };
+          case 3:
+            return function(b2, a2) {
+              return 0 == (b2 + a2) % 3;
+            };
+          case 4:
+            return function(b2, a2) {
+              return 0 == (Math.floor(b2 / 2) + Math.floor(a2 / 3)) % 2;
+            };
+          case 5:
+            return function(b2, a2) {
+              return 0 == b2 * a2 % 2 + b2 * a2 % 3;
+            };
+          case 6:
+            return function(b2, a2) {
+              return 0 == (b2 * a2 % 2 + b2 * a2 % 3) % 2;
+            };
+          case 7:
+            return function(b2, a2) {
+              return 0 == (b2 * a2 % 3 + (b2 + a2) % 2) % 2;
+            };
+          default:
+            throw Error("bad maskPattern:" + b);
+        }
+      }, C: function(b) {
+        for (var a2 = z([1], 0), c2 = 0; c2 < b; c2 += 1)
+          a2 = a2.multiply(z([1, v.i(c2)], 0));
+        return a2;
+      }, f: function(b, a2) {
+        if (4 != b || 1 > a2 || 40 < a2)
+          throw Error("mode: " + b + "; type: " + a2);
+        return 10 > a2 ? 8 : 16;
+      }, D: function(b) {
+        for (var a2 = b.h(), c2 = 0, d = 0; d < a2; d += 1)
+          for (var g = 0; g < a2; g += 1) {
+            for (var e3 = 0, t2 = b.a(d, g), p = -1; 1 >= p; p += 1)
+              if (!(0 > d + p || a2 <= d + p))
+                for (var q = -1; 1 >= q; q += 1)
+                  0 > g + q || a2 <= g + q || (0 != p || 0 != q) && t2 == b.a(d + p, g + q) && (e3 += 1);
+            5 < e3 && (c2 += 3 + e3 - 5);
+          }
+        for (d = 0; d < a2 - 1; d += 1)
+          for (g = 0; g < a2 - 1; g += 1)
+            if (e3 = 0, b.a(d, g) && (e3 += 1), b.a(d + 1, g) && (e3 += 1), b.a(d, g + 1) && (e3 += 1), b.a(d + 1, g + 1) && (e3 += 1), 0 == e3 || 4 == e3)
+              c2 += 3;
+        for (d = 0; d < a2; d += 1)
+          for (g = 0; g < a2 - 6; g += 1)
+            b.a(d, g) && !b.a(d, g + 1) && b.a(d, g + 2) && b.a(d, g + 3) && b.a(d, g + 4) && !b.a(d, g + 5) && b.a(d, g + 6) && (c2 += 40);
+        for (g = 0; g < a2; g += 1)
+          for (d = 0; d < a2 - 6; d += 1)
+            b.a(d, g) && !b.a(d + 1, g) && b.a(d + 2, g) && b.a(d + 3, g) && b.a(d + 4, g) && !b.a(d + 5, g) && b.a(d + 6, g) && (c2 += 40);
+        for (g = e3 = 0; g < a2; g += 1)
+          for (d = 0; d < a2; d += 1)
+            b.a(d, g) && (e3 += 1);
+        return c2 += Math.abs(100 * e3 / a2 / a2 - 50) / 5 * 10;
+      } };
+      return e2;
+    }(), v = function() {
+      for (var c = Array(256), a = Array(256), e2 = 0; 8 > e2; e2 += 1)
+        c[e2] = 1 << e2;
+      for (e2 = 8; 256 > e2; e2 += 1)
+        c[e2] = c[e2 - 4] ^ c[e2 - 5] ^ c[e2 - 6] ^ c[e2 - 8];
+      for (e2 = 0; 255 > e2; e2 += 1)
+        a[c[e2]] = e2;
+      return { g: function(b) {
+        if (1 > b)
+          throw Error("glog(" + b + ")");
+        return a[b];
+      }, i: function(b) {
+        for (; 0 > b; )
+          b += 255;
+        for (; 256 <= b; )
+          b -= 255;
+        return c[b];
+      } };
+    }(), t = function() {
+      function c(b, c2) {
+        switch (c2) {
+          case A.L:
+            return a[4 * (b - 1)];
+          case A.M:
+            return a[4 * (b - 1) + 1];
+          case A.Q:
+            return a[4 * (b - 1) + 2];
+          case A.H:
+            return a[4 * (b - 1) + 3];
+        }
+      }
+      var a = [
+        [1, 26, 19],
+        [1, 26, 16],
+        [1, 26, 13],
+        [1, 26, 9],
+        [1, 44, 34],
+        [1, 44, 28],
+        [1, 44, 22],
+        [1, 44, 16],
+        [1, 70, 55],
+        [1, 70, 44],
+        [2, 35, 17],
+        [2, 35, 13],
+        [1, 100, 80],
+        [2, 50, 32],
+        [2, 50, 24],
+        [4, 25, 9],
+        [1, 134, 108],
+        [2, 67, 43],
+        [2, 33, 15, 2, 34, 16],
+        [2, 33, 11, 2, 34, 12],
+        [2, 86, 68],
+        [4, 43, 27],
+        [4, 43, 19],
+        [4, 43, 15],
+        [2, 98, 78],
+        [4, 49, 31],
+        [2, 32, 14, 4, 33, 15],
+        [4, 39, 13, 1, 40, 14],
+        [2, 121, 97],
+        [2, 60, 38, 2, 61, 39],
+        [4, 40, 18, 2, 41, 19],
+        [4, 40, 14, 2, 41, 15],
+        [2, 146, 116],
+        [
+          3,
+          58,
+          36,
+          2,
+          59,
+          37
+        ],
+        [4, 36, 16, 4, 37, 17],
+        [4, 36, 12, 4, 37, 13],
+        [2, 86, 68, 2, 87, 69],
+        [4, 69, 43, 1, 70, 44],
+        [6, 43, 19, 2, 44, 20],
+        [6, 43, 15, 2, 44, 16],
+        [4, 101, 81],
+        [1, 80, 50, 4, 81, 51],
+        [4, 50, 22, 4, 51, 23],
+        [3, 36, 12, 8, 37, 13],
+        [2, 116, 92, 2, 117, 93],
+        [6, 58, 36, 2, 59, 37],
+        [4, 46, 20, 6, 47, 21],
+        [7, 42, 14, 4, 43, 15],
+        [4, 133, 107],
+        [8, 59, 37, 1, 60, 38],
+        [8, 44, 20, 4, 45, 21],
+        [12, 33, 11, 4, 34, 12],
+        [3, 145, 115, 1, 146, 116],
+        [4, 64, 40, 5, 65, 41],
+        [11, 36, 16, 5, 37, 17],
+        [11, 36, 12, 5, 37, 13],
+        [5, 109, 87, 1, 110, 88],
+        [5, 65, 41, 5, 66, 42],
+        [5, 54, 24, 7, 55, 25],
+        [11, 36, 12, 7, 37, 13],
+        [5, 122, 98, 1, 123, 99],
+        [
+          7,
+          73,
+          45,
+          3,
+          74,
+          46
+        ],
+        [15, 43, 19, 2, 44, 20],
+        [3, 45, 15, 13, 46, 16],
+        [1, 135, 107, 5, 136, 108],
+        [10, 74, 46, 1, 75, 47],
+        [1, 50, 22, 15, 51, 23],
+        [2, 42, 14, 17, 43, 15],
+        [5, 150, 120, 1, 151, 121],
+        [9, 69, 43, 4, 70, 44],
+        [17, 50, 22, 1, 51, 23],
+        [2, 42, 14, 19, 43, 15],
+        [3, 141, 113, 4, 142, 114],
+        [3, 70, 44, 11, 71, 45],
+        [17, 47, 21, 4, 48, 22],
+        [9, 39, 13, 16, 40, 14],
+        [3, 135, 107, 5, 136, 108],
+        [3, 67, 41, 13, 68, 42],
+        [15, 54, 24, 5, 55, 25],
+        [15, 43, 15, 10, 44, 16],
+        [4, 144, 116, 4, 145, 117],
+        [17, 68, 42],
+        [17, 50, 22, 6, 51, 23],
+        [19, 46, 16, 6, 47, 17],
+        [2, 139, 111, 7, 140, 112],
+        [17, 74, 46],
+        [7, 54, 24, 16, 55, 25],
+        [34, 37, 13],
+        [
+          4,
+          151,
+          121,
+          5,
+          152,
+          122
+        ],
+        [4, 75, 47, 14, 76, 48],
+        [11, 54, 24, 14, 55, 25],
+        [16, 45, 15, 14, 46, 16],
+        [6, 147, 117, 4, 148, 118],
+        [6, 73, 45, 14, 74, 46],
+        [11, 54, 24, 16, 55, 25],
+        [30, 46, 16, 2, 47, 17],
+        [8, 132, 106, 4, 133, 107],
+        [8, 75, 47, 13, 76, 48],
+        [7, 54, 24, 22, 55, 25],
+        [22, 45, 15, 13, 46, 16],
+        [10, 142, 114, 2, 143, 115],
+        [19, 74, 46, 4, 75, 47],
+        [28, 50, 22, 6, 51, 23],
+        [33, 46, 16, 4, 47, 17],
+        [8, 152, 122, 4, 153, 123],
+        [22, 73, 45, 3, 74, 46],
+        [8, 53, 23, 26, 54, 24],
+        [12, 45, 15, 28, 46, 16],
+        [3, 147, 117, 10, 148, 118],
+        [3, 73, 45, 23, 74, 46],
+        [4, 54, 24, 31, 55, 25],
+        [11, 45, 15, 31, 46, 16],
+        [7, 146, 116, 7, 147, 117],
+        [21, 73, 45, 7, 74, 46],
+        [1, 53, 23, 37, 54, 24],
+        [19, 45, 15, 26, 46, 16],
+        [5, 145, 115, 10, 146, 116],
+        [19, 75, 47, 10, 76, 48],
+        [15, 54, 24, 25, 55, 25],
+        [23, 45, 15, 25, 46, 16],
+        [13, 145, 115, 3, 146, 116],
+        [2, 74, 46, 29, 75, 47],
+        [42, 54, 24, 1, 55, 25],
+        [23, 45, 15, 28, 46, 16],
+        [17, 145, 115],
+        [10, 74, 46, 23, 75, 47],
+        [10, 54, 24, 35, 55, 25],
+        [19, 45, 15, 35, 46, 16],
+        [17, 145, 115, 1, 146, 116],
+        [14, 74, 46, 21, 75, 47],
+        [29, 54, 24, 19, 55, 25],
+        [11, 45, 15, 46, 46, 16],
+        [13, 145, 115, 6, 146, 116],
+        [14, 74, 46, 23, 75, 47],
+        [44, 54, 24, 7, 55, 25],
+        [59, 46, 16, 1, 47, 17],
+        [12, 151, 121, 7, 152, 122],
+        [12, 75, 47, 26, 76, 48],
+        [39, 54, 24, 14, 55, 25],
+        [22, 45, 15, 41, 46, 16],
+        [6, 151, 121, 14, 152, 122],
+        [6, 75, 47, 34, 76, 48],
+        [46, 54, 24, 10, 55, 25],
+        [2, 45, 15, 64, 46, 16],
+        [17, 152, 122, 4, 153, 123],
+        [29, 74, 46, 14, 75, 47],
+        [49, 54, 24, 10, 55, 25],
+        [24, 45, 15, 46, 46, 16],
+        [4, 152, 122, 18, 153, 123],
+        [13, 74, 46, 32, 75, 47],
+        [48, 54, 24, 14, 55, 25],
+        [42, 45, 15, 32, 46, 16],
+        [20, 147, 117, 4, 148, 118],
+        [40, 75, 47, 7, 76, 48],
+        [43, 54, 24, 22, 55, 25],
+        [10, 45, 15, 67, 46, 16],
+        [19, 148, 118, 6, 149, 119],
+        [18, 75, 47, 31, 76, 48],
+        [34, 54, 24, 34, 55, 25],
+        [20, 45, 15, 61, 46, 16]
+      ], e2 = { I: function(b, a2) {
+        var e3 = c(b, a2);
+        if ("undefined" == typeof e3)
+          throw Error("bad rs block @ typeNumber:" + b + "/errorCorrectLevel:" + a2);
+        b = e3.length / 3;
+        a2 = [];
+        for (var d = 0; d < b; d += 1)
+          for (var g = e3[3 * d], h = e3[3 * d + 1], t2 = e3[3 * d + 2], p = 0; p < g; p += 1) {
+            var q = t2, f = {};
+            f.o = h;
+            f.j = q;
+            a2.push(f);
+          }
+        return a2;
+      } };
+      return e2;
+    }();
+    return C;
+  }());
+  var qr_creator_es6_min_default = QrCreator;
+
+  // src/components/qr-code/qr-code.ts
+  var SlQrCode = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.value = "";
+      this.label = "";
+      this.size = 128;
+      this.fill = "#000";
+      this.background = "#fff";
+      this.radius = 0;
+      this.errorCorrection = "H";
+    }
+    firstUpdated() {
+      this.generate();
+    }
+    generate() {
+      if (!this.hasUpdated) {
+        return;
+      }
+      qr_creator_es6_min_default.render(
+        {
+          text: this.value,
+          radius: this.radius,
+          ecLevel: this.errorCorrection,
+          fill: this.fill,
+          background: this.background === "transparent" ? null : this.background,
+          size: this.size * 2
+        },
+        this.canvas
+      );
+    }
+    render() {
+      return $`
+      <div
+        class="qr-code"
+        part="base"
+        style=${i2$1({
+      width: `${this.size}px`,
+      height: `${this.size}px`
+    })}
+      >
+        <canvas role="img" aria-label=${this.label.length > 0 ? this.label : this.value}></canvas>
+      </div>
+    `;
+    }
+  };
+  SlQrCode.styles = qr_code_styles_default;
+  __decorateClass([
+    i2$2("canvas")
+  ], SlQrCode.prototype, "canvas", 2);
+  __decorateClass([
+    e$1()
+  ], SlQrCode.prototype, "value", 2);
+  __decorateClass([
+    e$1()
+  ], SlQrCode.prototype, "label", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlQrCode.prototype, "size", 2);
+  __decorateClass([
+    e$1()
+  ], SlQrCode.prototype, "fill", 2);
+  __decorateClass([
+    e$1()
+  ], SlQrCode.prototype, "background", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlQrCode.prototype, "radius", 2);
+  __decorateClass([
+    e$1({ attribute: "error-correction" })
+  ], SlQrCode.prototype, "errorCorrection", 2);
+  __decorateClass([
+    watch("background"),
+    watch("errorCorrection"),
+    watch("fill"),
+    watch("radius"),
+    watch("size"),
+    watch("value")
+  ], SlQrCode.prototype, "generate", 1);
+  SlQrCode = __decorateClass([
+    n$1("sl-qr-code")
+  ], SlQrCode);
+
+  // src/components/radio/radio.styles.ts
+  var radio_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  :host(:focus-visible) {
+    outline: 0px;
+  }
+
+  .radio {
+    display: inline-flex;
+    align-items: top;
+    font-family: var(--sl-input-font-family);
+    font-size: var(--sl-input-font-size-medium);
+    font-weight: var(--sl-input-font-weight);
+    color: var(--sl-input-color);
+    vertical-align: middle;
+    cursor: pointer;
+  }
+
+  .radio__icon {
+    display: inline-flex;
+    width: var(--sl-toggle-size);
+    height: var(--sl-toggle-size);
+  }
+
+  .radio__icon svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  .radio__control {
+    flex: 0 0 auto;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--sl-toggle-size);
+    height: var(--sl-toggle-size);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+    border-radius: 50%;
+    background-color: var(--sl-input-background-color);
+    color: transparent;
+    transition: var(--sl-transition-fast) border-color, var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) color, var(--sl-transition-fast) box-shadow;
+  }
+
+  .radio__input {
+    position: absolute;
+    opacity: 0;
+    padding: 0;
+    margin: 0;
+    pointer-events: none;
+  }
+
+  /* Hover */
+  .radio:not(.radio--checked):not(.radio--disabled) .radio__control:hover {
+    border-color: var(--sl-input-border-color-hover);
+    background-color: var(--sl-input-background-color-hover);
+  }
+
+  /* Checked */
+  .radio--checked .radio__control {
+    color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-primary-600);
+    background-color: var(--sl-color-primary-600);
+  }
+
+  /* Checked + hover */
+  .radio.radio--checked:not(.radio--disabled) .radio__control:hover {
+    border-color: var(--sl-color-primary-500);
+    background-color: var(--sl-color-primary-500);
+  }
+
+  /* Checked + focus */
+  :host(:focus-visible) .radio__control {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Disabled */
+  .radio--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* When the control isn't checked, hide the circle for Windows High Contrast mode a11y */
+  .radio:not(.radio--checked) svg circle {
+    opacity: 0;
+  }
+
+  .radio__label {
+    color: var(--sl-input-label-color);
+    line-height: var(--sl-toggle-size);
+    margin-inline-start: 0.5em;
+    user-select: none;
+  }
+`;
+
+  // src/components/radio/radio.ts
+  var SlRadio = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.checked = false;
+      this.hasFocus = false;
+      this.disabled = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.setInitialAttributes();
+      this.addEventListeners();
+    }
+    handleCheckedChange() {
+      this.setAttribute("aria-checked", this.checked ? "true" : "false");
+      this.setAttribute("tabindex", this.checked ? "0" : "-1");
+    }
+    handleDisabledChange() {
+      this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+    }
+    handleBlur() {
+      this.hasFocus = false;
+      this.emit("sl-blur");
+    }
+    handleClick() {
+      if (!this.disabled) {
+        this.checked = true;
+      }
+    }
+    handleFocus() {
+      this.hasFocus = true;
+      this.emit("sl-focus");
+    }
+    addEventListeners() {
+      this.addEventListener("blur", () => this.handleBlur());
+      this.addEventListener("click", () => this.handleClick());
+      this.addEventListener("focus", () => this.handleFocus());
+    }
+    setInitialAttributes() {
+      this.setAttribute("role", "radio");
+      this.setAttribute("tabindex", "-1");
+      this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+    }
+    render() {
+      return $`
+      <span
+        part="base"
+        class=${o$3({
+      radio: true,
+      "radio--checked": this.checked,
+      "radio--disabled": this.disabled,
+      "radio--focused": this.hasFocus
+    })}
+      >
+        <span part="control" class="radio__control">
+          <svg part="checked-icon" class="radio__icon" viewBox="0 0 16 16">
+            <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+              <g fill="currentColor">
+                <circle cx="8" cy="8" r="3.42857143"></circle>
+              </g>
+            </g>
+          </svg>
+        </span>
+
+        <span part="label" class="radio__label">
+          <slot></slot>
+        </span>
+      </span>
+    `;
+    }
+  };
+  SlRadio.styles = radio_styles_default;
+  __decorateClass([
+    t$1()
+  ], SlRadio.prototype, "checked", 2);
+  __decorateClass([
+    t$1()
+  ], SlRadio.prototype, "hasFocus", 2);
+  __decorateClass([
+    e$1()
+  ], SlRadio.prototype, "value", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlRadio.prototype, "disabled", 2);
+  __decorateClass([
+    watch("checked")
+  ], SlRadio.prototype, "handleCheckedChange", 1);
+  __decorateClass([
+    watch("disabled", { waitUntilFirstUpdate: true })
+  ], SlRadio.prototype, "handleDisabledChange", 1);
+  SlRadio = __decorateClass([
+    n$1("sl-radio")
+  ], SlRadio);
+
+  // src/components/menu-item/menu-item.styles.ts
+  var menu_item_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .menu-item {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+    font-weight: var(--sl-font-weight-normal);
+    line-height: var(--sl-line-height-normal);
+    letter-spacing: var(--sl-letter-spacing-normal);
+    color: var(--sl-color-neutral-700);
+    padding: var(--sl-spacing-2x-small) var(--sl-spacing-2x-small);
+    transition: var(--sl-transition-fast) fill;
+    user-select: none;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .menu-item.menu-item--disabled {
+    outline: none;
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .menu-item .menu-item__label {
+    flex: 1 1 auto;
+  }
+
+  .menu-item .menu-item__prefix {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .menu-item .menu-item__prefix ::slotted(*) {
+    margin-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .menu-item .menu-item__suffix {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .menu-item .menu-item__suffix ::slotted(*) {
+    margin-inline-start: var(--sl-spacing-x-small);
+  }
+
+  :host(:focus) {
+    outline: none;
+  }
+
+  :host(:hover:not([aria-disabled='true'])) .menu-item,
+  :host(:focus-visible:not(.sl-focus-invisible):not([aria-disabled='true'])) .menu-item {
+    outline: none;
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .menu-item .menu-item__check,
+  .menu-item .menu-item__chevron {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5em;
+    visibility: hidden;
+  }
+
+  .menu-item--checked .menu-item__check,
+  .menu-item--has-submenu .menu-item__chevron {
+    visibility: visible;
+  }
+`;
+
+  // src/components/menu-item/menu-item.ts
+  var SlMenuItem = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.checked = false;
+      this.value = "";
+      this.disabled = false;
+    }
+    firstUpdated() {
+      this.setAttribute("role", "menuitem");
+    }
+    getTextLabel() {
+      return getTextContent(this.defaultSlot);
+    }
+    handleCheckedChange() {
+      this.setAttribute("aria-checked", this.checked ? "true" : "false");
+    }
+    handleDisabledChange() {
+      this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
+    }
+    handleDefaultSlotChange() {
+      const textLabel = this.getTextLabel();
+      if (typeof this.cachedTextLabel === "undefined") {
+        this.cachedTextLabel = textLabel;
+        return;
+      }
+      if (textLabel !== this.cachedTextLabel) {
+        this.cachedTextLabel = textLabel;
+        this.emit("sl-label-change");
+      }
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      "menu-item": true,
+      "menu-item--checked": this.checked,
+      "menu-item--disabled": this.disabled,
+      "menu-item--has-submenu": false
+    })}
+      >
+        <span part="checked-icon" class="menu-item__check">
+          <sl-icon name="check-lg" library="system" aria-hidden="true"></sl-icon>
+        </span>
+
+        <span part="prefix" class="menu-item__prefix">
+          <slot name="prefix"></slot>
+        </span>
+
+        <span part="label" class="menu-item__label">
+          <slot @slotchange=${this.handleDefaultSlotChange}></slot>
+        </span>
+
+        <span part="suffix" class="menu-item__suffix">
+          <slot name="suffix"></slot>
+        </span>
+
+        <span class="menu-item__chevron">
+          <sl-icon name="chevron-right" library="system" aria-hidden="true"></sl-icon>
+        </span>
+      </div>
+    `;
+    }
+  };
+  SlMenuItem.styles = menu_item_styles_default;
+  __decorateClass([
+    i2$2("slot:not([name])")
+  ], SlMenuItem.prototype, "defaultSlot", 2);
+  __decorateClass([
+    i2$2(".menu-item")
+  ], SlMenuItem.prototype, "menuItem", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlMenuItem.prototype, "checked", 2);
+  __decorateClass([
+    e$1()
+  ], SlMenuItem.prototype, "value", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlMenuItem.prototype, "disabled", 2);
+  __decorateClass([
+    watch("checked")
+  ], SlMenuItem.prototype, "handleCheckedChange", 1);
+  __decorateClass([
+    watch("disabled")
+  ], SlMenuItem.prototype, "handleDisabledChange", 1);
+  SlMenuItem = __decorateClass([
+    n$1("sl-menu-item")
+  ], SlMenuItem);
+
+  // src/components/menu-label/menu-label.styles.ts
+  var menu_label_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .menu-label {
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-small);
+    font-weight: var(--sl-font-weight-semibold);
+    line-height: var(--sl-line-height-normal);
+    letter-spacing: var(--sl-letter-spacing-normal);
+    color: var(--sl-color-neutral-500);
+    padding: var(--sl-spacing-2x-small) var(--sl-spacing-x-large);
+    user-select: none;
+  }
+`;
+
+  // src/components/menu-label/menu-label.ts
+  var SlMenuLabel = class extends ShoelaceElement {
+    render() {
+      return $`
+      <div part="base" class="menu-label">
+        <slot></slot>
+      </div>
+    `;
+    }
+  };
+  SlMenuLabel.styles = menu_label_styles_default;
+  SlMenuLabel = __decorateClass([
+    n$1("sl-menu-label")
+  ], SlMenuLabel);
+
+  // src/components/mutation-observer/mutation-observer.styles.ts
+  var mutation_observer_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: contents;
+  }
+`;
+
+  // src/components/mutation-observer/mutation-observer.ts
+  var SlMutationObserver = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.attrOldValue = false;
+      this.charData = false;
+      this.charDataOldValue = false;
+      this.childList = false;
+      this.disabled = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.handleMutation = this.handleMutation.bind(this);
+      this.mutationObserver = new MutationObserver(this.handleMutation);
+      if (!this.disabled) {
+        this.startObserver();
+      }
+    }
+    disconnectedCallback() {
+      this.stopObserver();
+    }
+    handleDisabledChange() {
+      if (this.disabled) {
+        this.stopObserver();
+      } else {
+        this.startObserver();
+      }
+    }
+    handleChange() {
+      this.stopObserver();
+      this.startObserver();
+    }
+    handleMutation(mutationList) {
+      this.emit("sl-mutation", {
+        detail: { mutationList }
+      });
+    }
+    startObserver() {
+      const observeAttributes = typeof this.attr === "string" && this.attr.length > 0;
+      const attributeFilter = observeAttributes && this.attr !== "*" ? this.attr.split(" ") : void 0;
+      try {
+        this.mutationObserver.observe(this, {
+          subtree: true,
+          childList: this.childList,
+          attributes: observeAttributes,
+          attributeFilter,
+          attributeOldValue: this.attrOldValue,
+          characterData: this.charData,
+          characterDataOldValue: this.charDataOldValue
+        });
+      } catch (e2) {
+      }
+    }
+    stopObserver() {
+      this.mutationObserver.disconnect();
+    }
+    render() {
+      return $` <slot></slot> `;
+    }
+  };
+  SlMutationObserver.styles = mutation_observer_styles_default;
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlMutationObserver.prototype, "attr", 2);
+  __decorateClass([
+    e$1({ attribute: "attr-old-value", type: Boolean, reflect: true })
+  ], SlMutationObserver.prototype, "attrOldValue", 2);
+  __decorateClass([
+    e$1({ attribute: "char-data", type: Boolean, reflect: true })
+  ], SlMutationObserver.prototype, "charData", 2);
+  __decorateClass([
+    e$1({ attribute: "char-data-old-value", type: Boolean, reflect: true })
+  ], SlMutationObserver.prototype, "charDataOldValue", 2);
+  __decorateClass([
+    e$1({ attribute: "child-list", type: Boolean, reflect: true })
+  ], SlMutationObserver.prototype, "childList", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlMutationObserver.prototype, "disabled", 2);
+  __decorateClass([
+    watch("disabled")
+  ], SlMutationObserver.prototype, "handleDisabledChange", 1);
+  __decorateClass([
+    watch("attr", { waitUntilFirstUpdate: true }),
+    watch("attr-old-value", { waitUntilFirstUpdate: true }),
+    watch("char-data", { waitUntilFirstUpdate: true }),
+    watch("char-data-old-value", { waitUntilFirstUpdate: true }),
+    watch("childList", { waitUntilFirstUpdate: true })
+  ], SlMutationObserver.prototype, "handleChange", 1);
+  SlMutationObserver = __decorateClass([
+    n$1("sl-mutation-observer")
+  ], SlMutationObserver);
+
+  // src/components/image-comparer/image-comparer.styles.ts
+  var image_comparer_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --divider-width: 2px;
+    --handle-size: 2.5rem;
+
+    display: inline-block;
+    position: relative;
+  }
+
+  .image-comparer {
+    max-width: 100%;
+    max-height: 100%;
+    overflow: hidden;
+  }
+
+  .image-comparer__before,
+  .image-comparer__after {
+    pointer-events: none;
+  }
+
+  .image-comparer__before ::slotted(img),
+  .image-comparer__after ::slotted(img),
+  .image-comparer__before ::slotted(svg),
+  .image-comparer__after ::slotted(svg) {
+    display: block;
+    max-width: 100% !important;
+    height: auto;
+  }
+
+  .image-comparer__after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+  }
+
+  .image-comparer__divider {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0;
+    width: var(--divider-width);
+    height: 100%;
+    background-color: var(--sl-color-neutral-0);
+    transform: translateX(calc(var(--divider-width) / -2));
+    cursor: ew-resize;
+  }
+
+  .image-comparer__handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: calc(50% - (var(--handle-size) / 2));
+    width: var(--handle-size);
+    height: var(--handle-size);
+    background-color: var(--sl-color-neutral-0);
+    border-radius: var(--sl-border-radius-circle);
+    font-size: calc(var(--handle-size) * 0.5);
+    color: var(--sl-color-neutral-600);
+    cursor: inherit;
+    z-index: 10;
+  }
+
+  .image-comparer__handle:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+`;
+
+  // src/components/image-comparer/image-comparer.ts
+  var SlImageComparer = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.position = 50;
+    }
+    handleDrag(event) {
+      const { width } = this.base.getBoundingClientRect();
+      const isRtl = this.localize.dir() === "rtl";
+      event.preventDefault();
+      drag(this.base, {
+        onMove: (x) => {
+          this.position = parseFloat(clamp(x / width * 100, 0, 100).toFixed(2));
+          if (isRtl)
+            this.position = 100 - this.position;
+        },
+        initialEvent: event
+      });
+    }
+    handleKeyDown(event) {
+      const isLtr = this.localize.dir() === "ltr";
+      const isRtl = this.localize.dir() === "rtl";
+      if (["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
+        const incr = event.shiftKey ? 10 : 1;
+        let newPosition = this.position;
+        event.preventDefault();
+        if (isLtr && event.key === "ArrowLeft" || isRtl && event.key === "ArrowRight") {
+          newPosition -= incr;
+        }
+        if (isLtr && event.key === "ArrowRight" || isRtl && event.key === "ArrowLeft") {
+          newPosition += incr;
+        }
+        if (event.key === "Home") {
+          newPosition = 0;
+        }
+        if (event.key === "End") {
+          newPosition = 100;
+        }
+        newPosition = clamp(newPosition, 0, 100);
+        this.position = newPosition;
+      }
+    }
+    handlePositionChange() {
+      this.emit("sl-change");
+    }
+    render() {
+      const isRtl = this.localize.dir() === "rtl";
+      return $`
+      <div
+        part="base"
+        id="image-comparer"
+        class=${o$3({
+      "image-comparer": true,
+      "image-comparer--rtl": isRtl
+    })}
+        @keydown=${this.handleKeyDown}
+      >
+        <div class="image-comparer__image">
+          <div part="before" class="image-comparer__before">
+            <slot name="before"></slot>
+          </div>
+
+          <div
+            part="after"
+            class="image-comparer__after"
+            style=${i2$1({
+      clipPath: isRtl ? `inset(0 0 0 ${100 - this.position}%)` : `inset(0 ${100 - this.position}% 0 0)`
+    })}
+          >
+            <slot name="after"></slot>
+          </div>
+        </div>
+
+        <div
+          part="divider"
+          class="image-comparer__divider"
+          style=${i2$1({
+      left: isRtl ? `${100 - this.position}%` : `${this.position}%`
+    })}
+          @mousedown=${this.handleDrag}
+          @touchstart=${this.handleDrag}
+        >
+          <div
+            part="handle"
+            class="image-comparer__handle"
+            role="scrollbar"
+            aria-valuenow=${this.position}
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-controls="image-comparer"
+            tabindex="0"
+          >
+            <slot name="handle-icon">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <g fill="currentColor" fill-rule="nonzero">
+                  <path
+                    d="m21.14 12.55-5.482 4.796c-.646.566-1.658.106-1.658-.753V7a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506h.001ZM2.341 12.55l5.482 4.796c.646.566 1.658.106 1.658-.753V7a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506h-.001Z"
+                  />
+                </g>
+              </svg>
+            </slot>
+          </div>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlImageComparer.styles = image_comparer_styles_default;
+  __decorateClass([
+    i2$2(".image-comparer")
+  ], SlImageComparer.prototype, "base", 2);
+  __decorateClass([
+    i2$2(".image-comparer__handle")
+  ], SlImageComparer.prototype, "handle", 2);
+  __decorateClass([
+    e$1({ type: Number, reflect: true })
+  ], SlImageComparer.prototype, "position", 2);
+  __decorateClass([
+    watch("position", { waitUntilFirstUpdate: true })
+  ], SlImageComparer.prototype, "handlePositionChange", 1);
+  SlImageComparer = __decorateClass([
+    n$1("sl-image-comparer")
+  ], SlImageComparer);
+
+  // src/components/include/include.styles.ts
+  var include_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+`;
+
+  // src/components/include/include.ts
+  var SlInclude = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.mode = "cors";
+      this.allowScripts = false;
+    }
+    executeScript(script) {
+      const newScript = document.createElement("script");
+      [...script.attributes].forEach((attr) => newScript.setAttribute(attr.name, attr.value));
+      newScript.textContent = script.textContent;
+      script.parentNode.replaceChild(newScript, script);
+    }
+    async handleSrcChange() {
+      try {
+        const src = this.src;
+        const file = await requestInclude(src, this.mode);
+        if (src !== this.src) {
+          return;
+        }
+        if (!file.ok) {
+          this.emit("sl-error", { detail: { status: file.status } });
+          return;
+        }
+        this.innerHTML = file.html;
+        if (this.allowScripts) {
+          [...this.querySelectorAll("script")].forEach((script) => this.executeScript(script));
+        }
+        this.emit("sl-load");
+      } catch (e2) {
+        this.emit("sl-error", { detail: { status: -1 } });
+      }
+    }
+    render() {
+      return $`<slot></slot>`;
+    }
+  };
+  SlInclude.styles = include_styles_default;
+  __decorateClass([
+    e$1()
+  ], SlInclude.prototype, "src", 2);
+  __decorateClass([
+    e$1()
+  ], SlInclude.prototype, "mode", 2);
+  __decorateClass([
+    e$1({ attribute: "allow-scripts", type: Boolean })
+  ], SlInclude.prototype, "allowScripts", 2);
+  __decorateClass([
+    watch("src")
+  ], SlInclude.prototype, "handleSrcChange", 1);
+  SlInclude = __decorateClass([
+    n$1("sl-include")
+  ], SlInclude);
+
+  // src/components/menu/menu.styles.ts
+  var menu_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+    position: relative;
+    background: var(--sl-panel-background-color);
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+    border-radius: var(--sl-border-radius-medium);
+    padding: var(--sl-spacing-x-small) 0;
+    overflow: auto;
+    overscroll-behavior: none;
+  }
+
+  ::slotted(sl-divider) {
+    --spacing: var(--sl-spacing-x-small);
+  }
+`;
+
+  // src/components/menu/menu.ts
+  var SlMenu = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.typeToSelectString = "";
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.setAttribute("role", "menu");
+    }
+    getAllItems(options = { includeDisabled: true }) {
+      return [...this.defaultSlot.assignedElements({ flatten: true })].filter((el) => {
+        if (el.getAttribute("role") !== "menuitem") {
+          return false;
+        }
+        if (!options.includeDisabled && el.disabled) {
+          return false;
+        }
+        return true;
+      });
+    }
+    getCurrentItem() {
+      return this.getAllItems({ includeDisabled: false }).find((i2) => i2.getAttribute("tabindex") === "0");
+    }
+    setCurrentItem(item) {
+      const items = this.getAllItems({ includeDisabled: false });
+      const activeItem = item.disabled ? items[0] : item;
+      items.forEach((i2) => {
+        i2.setAttribute("tabindex", i2 === activeItem ? "0" : "-1");
+      });
+    }
+    typeToSelect(event) {
+      var _a;
+      const items = this.getAllItems({ includeDisabled: false });
+      clearTimeout(this.typeToSelectTimeout);
+      this.typeToSelectTimeout = window.setTimeout(() => this.typeToSelectString = "", 1e3);
+      if (event.key === "Backspace") {
+        if (event.metaKey || event.ctrlKey) {
+          this.typeToSelectString = "";
+        } else {
+          this.typeToSelectString = this.typeToSelectString.slice(0, -1);
+        }
+      } else {
+        this.typeToSelectString += event.key.toLowerCase();
+      }
+      for (const item of items) {
+        const slot = (_a = item.shadowRoot) == null ? void 0 : _a.querySelector("slot:not([name])");
+        const label = getTextContent(slot).toLowerCase().trim();
+        if (label.startsWith(this.typeToSelectString)) {
+          this.setCurrentItem(item);
+          item.focus();
+          break;
+        }
+      }
+    }
+    handleClick(event) {
+      const target = event.target;
+      const item = target.closest("sl-menu-item");
+      if ((item == null ? void 0 : item.disabled) === false) {
+        this.emit("sl-select", { detail: { item } });
+      }
+    }
+    handleKeyDown(event) {
+      if (event.key === "Enter") {
+        const item = this.getCurrentItem();
+        event.preventDefault();
+        item == null ? void 0 : item.click();
+      }
+      if (event.key === " ") {
+        event.preventDefault();
+      }
+      if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+        const items = this.getAllItems({ includeDisabled: false });
+        const activeItem = this.getCurrentItem();
+        let index = activeItem ? items.indexOf(activeItem) : 0;
+        if (items.length > 0) {
+          event.preventDefault();
+          if (event.key === "ArrowDown") {
+            index++;
+          } else if (event.key === "ArrowUp") {
+            index--;
+          } else if (event.key === "Home") {
+            index = 0;
+          } else if (event.key === "End") {
+            index = items.length - 1;
+          }
+          if (index < 0) {
+            index = items.length - 1;
+          }
+          if (index > items.length - 1) {
+            index = 0;
+          }
+          this.setCurrentItem(items[index]);
+          items[index].focus();
+          return;
+        }
+      }
+      this.typeToSelect(event);
+    }
+    handleMouseDown(event) {
+      const target = event.target;
+      if (target.getAttribute("role") === "menuitem") {
+        this.setCurrentItem(target);
+      }
+    }
+    handleSlotChange() {
+      const items = this.getAllItems({ includeDisabled: false });
+      if (items.length > 0) {
+        this.setCurrentItem(items[0]);
+      }
+    }
+    render() {
+      return $`
+      <slot
+        @slotchange=${this.handleSlotChange}
+        @click=${this.handleClick}
+        @keydown=${this.handleKeyDown}
+        @mousedown=${this.handleMouseDown}
+      ></slot>
+    `;
+    }
+  };
+  SlMenu.styles = menu_styles_default;
+  __decorateClass([
+    i2$2("slot")
+  ], SlMenu.prototype, "defaultSlot", 2);
+  SlMenu = __decorateClass([
+    n$1("sl-menu")
+  ], SlMenu);
+
+  // src/components/drawer/drawer.styles.ts
+  var drawer_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --size: 25rem;
+    --header-spacing: var(--sl-spacing-large);
+    --body-spacing: var(--sl-spacing-large);
+    --footer-spacing: var(--sl-spacing-large);
+
+    display: contents;
+  }
+
+  .drawer {
+    top: 0;
+    inset-inline-start: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .drawer--contained {
+    position: absolute;
+    z-index: initial;
+  }
+
+  .drawer--fixed {
+    position: fixed;
+    z-index: var(--sl-z-index-drawer);
+  }
+
+  .drawer__panel {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    z-index: 2;
+    max-width: 100%;
+    max-height: 100%;
+    background-color: var(--sl-panel-background-color);
+    box-shadow: var(--sl-shadow-x-large);
+    transition: var(--sl-transition-medium) transform;
+    overflow: auto;
+    pointer-events: all;
+  }
+
+  .drawer__panel:focus {
+    outline: none;
+  }
+
+  .drawer--top .drawer__panel {
+    top: 0;
+    inset-inline-end: auto;
+    bottom: auto;
+    inset-inline-start: 0;
+    width: 100%;
+    height: var(--size);
+  }
+
+  .drawer--end .drawer__panel {
+    top: 0;
+    inset-inline-end: 0;
+    bottom: auto;
+    inset-inline-start: auto;
+    width: var(--size);
+    height: 100%;
+  }
+
+  .drawer--bottom .drawer__panel {
+    top: auto;
+    inset-inline-end: auto;
+    bottom: 0;
+    inset-inline-start: 0;
+    width: 100%;
+    height: var(--size);
+  }
+
+  .drawer--start .drawer__panel {
+    top: 0;
+    inset-inline-end: auto;
+    bottom: auto;
+    inset-inline-start: 0;
+    width: var(--size);
+    height: 100%;
+  }
+
+  .drawer__header {
+    display: flex;
+  }
+
+  .drawer__title {
+    flex: 1 1 auto;
+    font: inherit;
+    font-size: var(--sl-font-size-large);
+    line-height: var(--sl-line-height-dense);
+    padding: var(--header-spacing);
+    margin: 0;
+  }
+
+  .drawer__close {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    font-size: var(--sl-font-size-x-large);
+    padding: 0 var(--header-spacing);
+  }
+
+  .drawer__body {
+    flex: 1 1 auto;
+    padding: var(--body-spacing);
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .drawer__footer {
+    text-align: right;
+    padding: var(--footer-spacing);
+  }
+
+  .drawer__footer ::slotted(sl-button:not(:last-of-type)) {
+    margin-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .drawer:not(.drawer--has-footer) .drawer__footer {
+    display: none;
+  }
+
+  .drawer__overlay {
+    display: block;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: var(--sl-overlay-background-color);
+    pointer-events: all;
+  }
+
+  .drawer--contained .drawer__overlay {
+    position: absolute;
+  }
+`;
+
+  // src/internal/tabbable.ts
+  function isTabbable(el) {
+    const tag = el.tagName.toLowerCase();
+    if (el.getAttribute("tabindex") === "-1") {
+      return false;
+    }
+    if (el.hasAttribute("disabled")) {
+      return false;
+    }
+    if (el.hasAttribute("aria-disabled") && el.getAttribute("aria-disabled") !== "false") {
+      return false;
+    }
+    if (tag === "input" && el.getAttribute("type") === "radio" && !el.hasAttribute("checked")) {
+      return false;
+    }
+    if (el.offsetParent === null) {
+      return false;
+    }
+    if (window.getComputedStyle(el).visibility === "hidden") {
+      return false;
+    }
+    if ((tag === "audio" || tag === "video") && el.hasAttribute("controls")) {
+      return true;
+    }
+    if (el.hasAttribute("tabindex")) {
+      return true;
+    }
+    if (el.hasAttribute("contenteditable") && el.getAttribute("contenteditable") !== "false") {
+      return true;
+    }
+    return ["button", "input", "select", "textarea", "a", "audio", "video", "summary"].includes(tag);
+  }
+  function getTabbableBoundary(root) {
+    var _a, _b;
+    const allElements = [];
+    function walk(el) {
+      if (el instanceof HTMLElement) {
+        allElements.push(el);
+        if (el.shadowRoot !== null && el.shadowRoot.mode === "open") {
+          walk(el.shadowRoot);
+        }
+      }
+      [...el.children].forEach((e) => walk(e));
+    }
+    walk(root);
+    const start = (_a = allElements.find((el) => isTabbable(el))) != null ? _a : null;
+    const end = (_b = allElements.reverse().find((el) => isTabbable(el))) != null ? _b : null;
+    return { start, end };
+  }
+
+  // src/internal/modal.ts
+  var activeModals = [];
+  var Modal = class {
+    constructor(element) {
+      this.tabDirection = "forward";
+      this.element = element;
+      this.handleFocusIn = this.handleFocusIn.bind(this);
+      this.handleKeyDown = this.handleKeyDown.bind(this);
+      this.handleKeyUp = this.handleKeyUp.bind(this);
+    }
+    activate() {
+      activeModals.push(this.element);
+      document.addEventListener("focusin", this.handleFocusIn);
+      document.addEventListener("keydown", this.handleKeyDown);
+      document.addEventListener("keyup", this.handleKeyUp);
+    }
+    deactivate() {
+      activeModals = activeModals.filter((modal) => modal !== this.element);
+      document.removeEventListener("focusin", this.handleFocusIn);
+      document.removeEventListener("keydown", this.handleKeyDown);
+      document.removeEventListener("keyup", this.handleKeyUp);
+    }
+    isActive() {
+      return activeModals[activeModals.length - 1] === this.element;
+    }
+    checkFocus() {
+      if (this.isActive()) {
+        if (!this.element.matches(":focus-within")) {
+          const { start, end } = getTabbableBoundary(this.element);
+          const target = this.tabDirection === "forward" ? start : end;
+          if (typeof (target == null ? void 0 : target.focus) === "function") {
+            target.focus({ preventScroll: true });
+          }
+        }
+      }
+    }
+    handleFocusIn() {
+      this.checkFocus();
+    }
+    handleKeyDown(event) {
+      if (event.key === "Tab" && event.shiftKey) {
+        this.tabDirection = "backward";
+      }
+      requestAnimationFrame(() => this.checkFocus());
+    }
+    handleKeyUp() {
+      this.tabDirection = "forward";
+    }
+  };
+
+  // src/internal/string.ts
+  function uppercaseFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  }
+
+  // src/components/drawer/drawer.ts
+  var SlDrawer = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.hasSlotController = new HasSlotController(this, "footer");
+      this.localize = new LocalizeController2(this);
+      this.open = false;
+      this.label = "";
+      this.placement = "end";
+      this.contained = false;
+      this.noHeader = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.modal = new Modal(this);
+    }
+    firstUpdated() {
+      this.drawer.hidden = !this.open;
+      if (this.open && !this.contained) {
+        this.modal.activate();
+        lockBodyScrolling(this);
+      }
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      unlockBodyScrolling(this);
+    }
+    async show() {
+      if (this.open) {
+        return void 0;
+      }
+      this.open = true;
+      return waitForEvent(this, "sl-after-show");
+    }
+    async hide() {
+      if (!this.open) {
+        return void 0;
+      }
+      this.open = false;
+      return waitForEvent(this, "sl-after-hide");
+    }
+    requestClose(source) {
+      const slRequestClose = this.emit("sl-request-close", {
+        cancelable: true,
+        detail: { source }
+      });
+      if (slRequestClose.defaultPrevented) {
+        const animation = getAnimation(this, "drawer.denyClose", { dir: this.localize.dir() });
+        animateTo(this.panel, animation.keyframes, animation.options);
+        return;
+      }
+      this.hide();
+    }
+    handleKeyDown(event) {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        this.requestClose("keyboard");
+      }
+    }
+    async handleOpenChange() {
+      if (this.open) {
+        this.emit("sl-show");
+        this.originalTrigger = document.activeElement;
+        if (!this.contained) {
+          this.modal.activate();
+          lockBodyScrolling(this);
+        }
+        const autoFocusTarget = this.querySelector("[autofocus]");
+        if (autoFocusTarget) {
+          autoFocusTarget.removeAttribute("autofocus");
+        }
+        await Promise.all([stopAnimations(this.drawer), stopAnimations(this.overlay)]);
+        this.drawer.hidden = false;
+        requestAnimationFrame(() => {
+          const slInitialFocus = this.emit("sl-initial-focus", { cancelable: true });
+          if (!slInitialFocus.defaultPrevented) {
+            if (autoFocusTarget) {
+              autoFocusTarget.focus({ preventScroll: true });
+            } else {
+              this.panel.focus({ preventScroll: true });
+            }
+          }
+          if (autoFocusTarget) {
+            autoFocusTarget.setAttribute("autofocus", "");
+          }
+        });
+        const panelAnimation = getAnimation(this, `drawer.show${uppercaseFirstLetter(this.placement)}`, {
+          dir: this.localize.dir()
+        });
+        const overlayAnimation = getAnimation(this, "drawer.overlay.show", { dir: this.localize.dir() });
+        await Promise.all([
+          animateTo(this.panel, panelAnimation.keyframes, panelAnimation.options),
+          animateTo(this.overlay, overlayAnimation.keyframes, overlayAnimation.options)
+        ]);
+        this.emit("sl-after-show");
+      } else {
+        this.emit("sl-hide");
+        this.modal.deactivate();
+        unlockBodyScrolling(this);
+        await Promise.all([stopAnimations(this.drawer), stopAnimations(this.overlay)]);
+        const panelAnimation = getAnimation(this, `drawer.hide${uppercaseFirstLetter(this.placement)}`, {
+          dir: this.localize.dir()
+        });
+        const overlayAnimation = getAnimation(this, "drawer.overlay.hide", { dir: this.localize.dir() });
+        await Promise.all([
+          animateTo(this.overlay, overlayAnimation.keyframes, overlayAnimation.options).then(() => {
+            this.overlay.hidden = true;
+          }),
+          animateTo(this.panel, panelAnimation.keyframes, panelAnimation.options).then(() => {
+            this.panel.hidden = true;
+          })
+        ]);
+        this.drawer.hidden = true;
+        this.overlay.hidden = false;
+        this.panel.hidden = false;
+        const trigger = this.originalTrigger;
+        if (typeof (trigger == null ? void 0 : trigger.focus) === "function") {
+          setTimeout(() => trigger.focus());
+        }
+        this.emit("sl-after-hide");
+      }
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      drawer: true,
+      "drawer--open": this.open,
+      "drawer--top": this.placement === "top",
+      "drawer--end": this.placement === "end",
+      "drawer--bottom": this.placement === "bottom",
+      "drawer--start": this.placement === "start",
+      "drawer--contained": this.contained,
+      "drawer--fixed": !this.contained,
+      "drawer--rtl": this.localize.dir() === "rtl",
+      "drawer--has-footer": this.hasSlotController.test("footer")
+    })}
+        @keydown=${this.handleKeyDown}
+      >
+        <div part="overlay" class="drawer__overlay" @click=${() => this.requestClose("overlay")} tabindex="-1"></div>
+
+        <div
+          part="panel"
+          class="drawer__panel"
+          role="dialog"
+          aria-modal="true"
+          aria-hidden=${this.open ? "false" : "true"}
+          aria-label=${l$2(this.noHeader ? this.label : void 0)}
+          aria-labelledby=${l$2(!this.noHeader ? "title" : void 0)}
+          tabindex="0"
+        >
+          ${!this.noHeader ? $`
+                <header part="header" class="drawer__header">
+                  <h2 part="title" class="drawer__title" id="title">
+                    <!-- If there's no label, use an invisible character to prevent the header from collapsing -->
+                    <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(65279)} </slot>
+                  </h2>
+                  <sl-icon-button
+                    part="close-button"
+                    exportparts="base:close-button__base"
+                    class="drawer__close"
+                    name="x"
+                    label=${this.localize.term("close")}
+                    library="system"
+                    @click=${() => this.requestClose("close-button")}
+                  ></sl-icon-button>
+                </header>
+              ` : ""}
+
+          <div part="body" class="drawer__body">
+            <slot></slot>
+          </div>
+
+          <footer part="footer" class="drawer__footer">
+            <slot name="footer"></slot>
+          </footer>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlDrawer.styles = drawer_styles_default;
+  __decorateClass([
+    i2$2(".drawer")
+  ], SlDrawer.prototype, "drawer", 2);
+  __decorateClass([
+    i2$2(".drawer__panel")
+  ], SlDrawer.prototype, "panel", 2);
+  __decorateClass([
+    i2$2(".drawer__overlay")
+  ], SlDrawer.prototype, "overlay", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlDrawer.prototype, "open", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlDrawer.prototype, "label", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlDrawer.prototype, "placement", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlDrawer.prototype, "contained", 2);
+  __decorateClass([
+    e$1({ attribute: "no-header", type: Boolean, reflect: true })
+  ], SlDrawer.prototype, "noHeader", 2);
+  __decorateClass([
+    watch("open", { waitUntilFirstUpdate: true })
+  ], SlDrawer.prototype, "handleOpenChange", 1);
+  SlDrawer = __decorateClass([
+    n$1("sl-drawer")
+  ], SlDrawer);
+  setDefaultAnimation("drawer.showTop", {
+    keyframes: [
+      { opacity: 0, transform: "translateY(-100%)" },
+      { opacity: 1, transform: "translateY(0)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("drawer.hideTop", {
+    keyframes: [
+      { opacity: 1, transform: "translateY(0)" },
+      { opacity: 0, transform: "translateY(-100%)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("drawer.showEnd", {
+    keyframes: [
+      { opacity: 0, transform: "translateX(100%)" },
+      { opacity: 1, transform: "translateX(0)" }
+    ],
+    rtlKeyframes: [
+      { opacity: 0, transform: "translateX(-100%)" },
+      { opacity: 1, transform: "translateX(0)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("drawer.hideEnd", {
+    keyframes: [
+      { opacity: 1, transform: "translateX(0)" },
+      { opacity: 0, transform: "translateX(100%)" }
+    ],
+    rtlKeyframes: [
+      { opacity: 1, transform: "translateX(0)" },
+      { opacity: 0, transform: "translateX(-100%)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("drawer.showBottom", {
+    keyframes: [
+      { opacity: 0, transform: "translateY(100%)" },
+      { opacity: 1, transform: "translateY(0)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("drawer.hideBottom", {
+    keyframes: [
+      { opacity: 1, transform: "translateY(0)" },
+      { opacity: 0, transform: "translateY(100%)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("drawer.showStart", {
+    keyframes: [
+      { opacity: 0, transform: "translateX(-100%)" },
+      { opacity: 1, transform: "translateX(0)" }
+    ],
+    rtlKeyframes: [
+      { opacity: 0, transform: "translateX(100%)" },
+      { opacity: 1, transform: "translateX(0)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("drawer.hideStart", {
+    keyframes: [
+      { opacity: 1, transform: "translateX(0)" },
+      { opacity: 0, transform: "translateX(-100%)" }
+    ],
+    rtlKeyframes: [
+      { opacity: 1, transform: "translateX(0)" },
+      { opacity: 0, transform: "translateX(100%)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("drawer.denyClose", {
+    keyframes: [{ transform: "scale(1)" }, { transform: "scale(1.01)" }, { transform: "scale(1)" }],
+    options: { duration: 250 }
+  });
+  setDefaultAnimation("drawer.overlay.show", {
+    keyframes: [{ opacity: 0 }, { opacity: 1 }],
+    options: { duration: 250 }
+  });
+  setDefaultAnimation("drawer.overlay.hide", {
+    keyframes: [{ opacity: 1 }, { opacity: 0 }],
+    options: { duration: 250 }
+  });
+
+  // src/components/format-bytes/format-bytes.ts
+  var SlFormatBytes = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.value = 0;
+      this.unit = "byte";
+      this.display = "short";
+    }
+    render() {
+      if (isNaN(this.value)) {
+        return "";
+      }
+      const bitPrefixes = ["", "kilo", "mega", "giga", "tera"];
+      const bytePrefixes = ["", "kilo", "mega", "giga", "tera", "peta"];
+      const prefix = this.unit === "bit" ? bitPrefixes : bytePrefixes;
+      const index = Math.max(0, Math.min(Math.floor(Math.log10(this.value) / 3), prefix.length - 1));
+      const unit = prefix[index] + this.unit;
+      const valueToFormat = parseFloat((this.value / Math.pow(1e3, index)).toPrecision(3));
+      return this.localize.number(valueToFormat, {
+        style: "unit",
+        unit,
+        unitDisplay: this.display
+      });
+    }
+  };
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlFormatBytes.prototype, "value", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatBytes.prototype, "unit", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatBytes.prototype, "display", 2);
+  SlFormatBytes = __decorateClass([
+    n$1("sl-format-bytes")
+  ], SlFormatBytes);
+
+  // src/components/format-date/format-date.ts
+  var SlFormatDate = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.date = new Date();
+      this.hourFormat = "auto";
+    }
+    render() {
+      const date = new Date(this.date);
+      const hour12 = this.hourFormat === "auto" ? void 0 : this.hourFormat === "12";
+      if (isNaN(date.getMilliseconds())) {
+        return void 0;
+      }
+      return $`
+      <time datetime=${date.toISOString()}>
+        ${this.localize.date(date, {
+      weekday: this.weekday,
+      era: this.era,
+      year: this.year,
+      month: this.month,
+      day: this.day,
+      hour: this.hour,
+      minute: this.minute,
+      second: this.second,
+      timeZoneName: this.timeZoneName,
+      timeZone: this.timeZone,
+      hour12
+    })}
+      </time>
+    `;
+    }
+  };
+  __decorateClass([
+    e$1()
+  ], SlFormatDate.prototype, "date", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatDate.prototype, "weekday", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatDate.prototype, "era", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatDate.prototype, "year", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatDate.prototype, "month", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatDate.prototype, "day", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatDate.prototype, "hour", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatDate.prototype, "minute", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatDate.prototype, "second", 2);
+  __decorateClass([
+    e$1({ attribute: "time-zone-name" })
+  ], SlFormatDate.prototype, "timeZoneName", 2);
+  __decorateClass([
+    e$1({ attribute: "time-zone" })
+  ], SlFormatDate.prototype, "timeZone", 2);
+  __decorateClass([
+    e$1({ attribute: "hour-format" })
+  ], SlFormatDate.prototype, "hourFormat", 2);
+  SlFormatDate = __decorateClass([
+    n$1("sl-format-date")
+  ], SlFormatDate);
+
+  // src/components/format-number/format-number.ts
+  var SlFormatNumber = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.value = 0;
+      this.type = "decimal";
+      this.noGrouping = false;
+      this.currency = "USD";
+      this.currencyDisplay = "symbol";
+    }
+    render() {
+      if (isNaN(this.value)) {
+        return "";
+      }
+      return this.localize.number(this.value, {
+        style: this.type,
+        currency: this.currency,
+        currencyDisplay: this.currencyDisplay,
+        useGrouping: !this.noGrouping,
+        minimumIntegerDigits: this.minimumIntegerDigits,
+        minimumFractionDigits: this.minimumFractionDigits,
+        maximumFractionDigits: this.maximumFractionDigits,
+        minimumSignificantDigits: this.minimumSignificantDigits,
+        maximumSignificantDigits: this.maximumSignificantDigits
+      });
+    }
+  };
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlFormatNumber.prototype, "value", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatNumber.prototype, "type", 2);
+  __decorateClass([
+    e$1({ attribute: "no-grouping", type: Boolean })
+  ], SlFormatNumber.prototype, "noGrouping", 2);
+  __decorateClass([
+    e$1()
+  ], SlFormatNumber.prototype, "currency", 2);
+  __decorateClass([
+    e$1({ attribute: "currency-display" })
+  ], SlFormatNumber.prototype, "currencyDisplay", 2);
+  __decorateClass([
+    e$1({ attribute: "minimum-integer-digits", type: Number })
+  ], SlFormatNumber.prototype, "minimumIntegerDigits", 2);
+  __decorateClass([
+    e$1({ attribute: "minimum-fraction-digits", type: Number })
+  ], SlFormatNumber.prototype, "minimumFractionDigits", 2);
+  __decorateClass([
+    e$1({ attribute: "maximum-fraction-digits", type: Number })
+  ], SlFormatNumber.prototype, "maximumFractionDigits", 2);
+  __decorateClass([
+    e$1({ attribute: "minimum-significant-digits", type: Number })
+  ], SlFormatNumber.prototype, "minimumSignificantDigits", 2);
+  __decorateClass([
+    e$1({ attribute: "maximum-significant-digits", type: Number })
+  ], SlFormatNumber.prototype, "maximumSignificantDigits", 2);
+  SlFormatNumber = __decorateClass([
+    n$1("sl-format-number")
+  ], SlFormatNumber);
+
+  // src/components/color-picker/color-picker.styles.ts
+  var color_picker_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --grid-width: 280px;
+    --grid-height: 200px;
+    --grid-handle-size: 16px;
+    --slider-height: 15px;
+    --slider-handle-size: 17px;
+    --swatch-size: 25px;
+
+    display: inline-block;
+  }
+
+  .color-picker {
+    width: var(--grid-width);
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+    font-weight: var(--sl-font-weight-normal);
+    color: var(--color);
+    background-color: var(--sl-panel-background-color);
+    border-radius: var(--sl-border-radius-medium);
+    user-select: none;
+  }
+
+  .color-picker--inline {
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+  }
+
+  .color-picker--inline:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .color-picker__grid {
+    position: relative;
+    height: var(--grid-height);
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%),
+      linear-gradient(to right, #fff 0%, rgba(255, 255, 255, 0) 100%);
+    border-top-left-radius: var(--sl-border-radius-medium);
+    border-top-right-radius: var(--sl-border-radius-medium);
+    cursor: crosshair;
+  }
+
+  .color-picker__grid-handle {
+    position: absolute;
+    width: var(--grid-handle-size);
+    height: var(--grid-handle-size);
+    border-radius: 50%;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+    border: solid 2px white;
+    margin-top: calc(var(--grid-handle-size) / -2);
+    margin-left: calc(var(--grid-handle-size) / -2);
+    transition: var(--sl-transition-fast) transform;
+  }
+
+  .color-picker__grid-handle--dragging {
+    cursor: none;
+    transform: scale(1.5);
+  }
+
+  .color-picker__grid-handle:focus-visible {
+    outline: var(--sl-focus-ring);
+  }
+
+  .color-picker__controls {
+    padding: var(--sl-spacing-small);
+    display: flex;
+    align-items: center;
+  }
+
+  .color-picker__sliders {
+    flex: 1 1 auto;
+  }
+
+  .color-picker__slider {
+    position: relative;
+    height: var(--slider-height);
+    border-radius: var(--sl-border-radius-pill);
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+  }
+
+  .color-picker__slider:not(:last-of-type) {
+    margin-bottom: var(--sl-spacing-small);
+  }
+
+  .color-picker__slider-handle {
+    position: absolute;
+    top: calc(50% - var(--slider-handle-size) / 2);
+    width: var(--slider-handle-size);
+    height: var(--slider-handle-size);
+    background-color: white;
+    border-radius: 50%;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+    margin-left: calc(var(--slider-handle-size) / -2);
+  }
+
+  .color-picker__slider-handle:focus-visible {
+    outline: var(--sl-focus-ring);
+  }
+
+  .color-picker__hue {
+    background-image: linear-gradient(
+      to right,
+      rgb(255, 0, 0) 0%,
+      rgb(255, 255, 0) 17%,
+      rgb(0, 255, 0) 33%,
+      rgb(0, 255, 255) 50%,
+      rgb(0, 0, 255) 67%,
+      rgb(255, 0, 255) 83%,
+      rgb(255, 0, 0) 100%
+    );
+  }
+
+  .color-picker__alpha .color-picker__alpha-gradient {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+  }
+
+  .color-picker__preview {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    width: 2.25rem;
+    height: 2.25rem;
+    border: none;
+    border-radius: var(--sl-border-radius-circle);
+    background: none;
+    margin-left: var(--sl-spacing-small);
+    cursor: copy;
+  }
+
+  .color-picker__preview:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+
+    /* We use a custom property in lieu of currentColor because of https://bugs.webkit.org/show_bug.cgi?id=216780 */
+    background-color: var(--preview-color);
+  }
+
+  .color-picker__preview:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .color-picker__preview-color {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: solid 1px rgba(0, 0, 0, 0.125);
+  }
+
+  .color-picker__preview-color--copied {
+    animation: pulse 0.75s;
+  }
+
+  @keyframes pulse {
+    0% {
+      box-shadow: 0 0 0 0 var(--sl-color-primary-500);
+    }
+    70% {
+      box-shadow: 0 0 0 0.5rem transparent;
+    }
+    100% {
+      box-shadow: 0 0 0 0 transparent;
+    }
+  }
+
+  .color-picker__user-input {
+    display: flex;
+    padding: 0 var(--sl-spacing-small) var(--sl-spacing-small) var(--sl-spacing-small);
+  }
+
+  .color-picker__user-input sl-input {
+    min-width: 0; /* fix input width in Safari */
+    flex: 1 1 auto;
+  }
+
+  .color-picker__user-input sl-button-group {
+    margin-left: var(--sl-spacing-small);
+  }
+
+  .color-picker__user-input sl-button {
+    min-width: 3.25rem;
+    max-width: 3.25rem;
+    font-size: 1rem;
+  }
+
+  .color-picker__swatches {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    grid-gap: 0.5rem;
+    justify-items: center;
+    border-top: solid 1px var(--sl-color-neutral-200);
+    padding: var(--sl-spacing-small);
+  }
+
+  .color-picker__swatch {
+    position: relative;
+    width: var(--swatch-size);
+    height: var(--swatch-size);
+    border-radius: var(--sl-border-radius-small);
+  }
+
+  .color-picker__swatch .color-picker__swatch-color {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: solid 1px rgba(0, 0, 0, 0.125);
+    border-radius: inherit;
+    cursor: pointer;
+  }
+
+  .color-picker__swatch:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .color-picker__transparent-bg {
+    background-image: linear-gradient(45deg, var(--sl-color-neutral-300) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--sl-color-neutral-300) 75%),
+      linear-gradient(45deg, transparent 75%, var(--sl-color-neutral-300) 75%),
+      linear-gradient(45deg, var(--sl-color-neutral-300) 25%, transparent 25%);
+    background-size: 10px 10px;
+    background-position: 0 0, 0 0, -5px -5px, 5px 5px;
+  }
+
+  .color-picker--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .color-picker--disabled .color-picker__grid,
+  .color-picker--disabled .color-picker__grid-handle,
+  .color-picker--disabled .color-picker__slider,
+  .color-picker--disabled .color-picker__slider-handle,
+  .color-picker--disabled .color-picker__preview,
+  .color-picker--disabled .color-picker__swatch,
+  .color-picker--disabled .color-picker__swatch-color {
+    pointer-events: none;
+  }
+
+  /*
+   * Color dropdown
+   */
+
+  .color-dropdown::part(panel) {
+    max-height: none;
+    background-color: var(--sl-panel-background-color);
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+    border-radius: var(--sl-border-radius-medium);
+    overflow: visible;
+  }
+
+  .color-dropdown__trigger {
+    display: inline-block;
+    position: relative;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+  }
+
+  .color-dropdown__trigger.color-dropdown__trigger--small {
+    width: var(--sl-input-height-small);
+    height: var(--sl-input-height-small);
+    border-radius: var(--sl-border-radius-circle);
+  }
+
+  .color-dropdown__trigger.color-dropdown__trigger--medium {
+    width: var(--sl-input-height-medium);
+    height: var(--sl-input-height-medium);
+    border-radius: var(--sl-border-radius-circle);
+  }
+
+  .color-dropdown__trigger.color-dropdown__trigger--large {
+    width: var(--sl-input-height-large);
+    height: var(--sl-input-height-large);
+    border-radius: var(--sl-border-radius-circle);
+  }
+
+  .color-dropdown__trigger:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    background-color: currentColor;
+    box-shadow: inset 0 0 0 2px var(--sl-input-border-color), inset 0 0 0 4px var(--sl-color-neutral-0);
+  }
+
+  .color-dropdown__trigger--empty:before {
+    background-color: transparent;
+  }
+
+  .color-dropdown__trigger:focus-visible {
+    outline: none;
+  }
+
+  .color-dropdown__trigger:focus-visible:not(.color-dropdown__trigger--disabled) {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .color-dropdown__trigger.color-dropdown__trigger--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+  // node_modules/color-name/index.js
+  var require_color_name = __commonJS({
+    "node_modules/color-name/index.js"(exports, module) {
+      module.exports = {
+        "aliceblue": [240, 248, 255],
+        "antiquewhite": [250, 235, 215],
+        "aqua": [0, 255, 255],
+        "aquamarine": [127, 255, 212],
+        "azure": [240, 255, 255],
+        "beige": [245, 245, 220],
+        "bisque": [255, 228, 196],
+        "black": [0, 0, 0],
+        "blanchedalmond": [255, 235, 205],
+        "blue": [0, 0, 255],
+        "blueviolet": [138, 43, 226],
+        "brown": [165, 42, 42],
+        "burlywood": [222, 184, 135],
+        "cadetblue": [95, 158, 160],
+        "chartreuse": [127, 255, 0],
+        "chocolate": [210, 105, 30],
+        "coral": [255, 127, 80],
+        "cornflowerblue": [100, 149, 237],
+        "cornsilk": [255, 248, 220],
+        "crimson": [220, 20, 60],
+        "cyan": [0, 255, 255],
+        "darkblue": [0, 0, 139],
+        "darkcyan": [0, 139, 139],
+        "darkgoldenrod": [184, 134, 11],
+        "darkgray": [169, 169, 169],
+        "darkgreen": [0, 100, 0],
+        "darkgrey": [169, 169, 169],
+        "darkkhaki": [189, 183, 107],
+        "darkmagenta": [139, 0, 139],
+        "darkolivegreen": [85, 107, 47],
+        "darkorange": [255, 140, 0],
+        "darkorchid": [153, 50, 204],
+        "darkred": [139, 0, 0],
+        "darksalmon": [233, 150, 122],
+        "darkseagreen": [143, 188, 143],
+        "darkslateblue": [72, 61, 139],
+        "darkslategray": [47, 79, 79],
+        "darkslategrey": [47, 79, 79],
+        "darkturquoise": [0, 206, 209],
+        "darkviolet": [148, 0, 211],
+        "deeppink": [255, 20, 147],
+        "deepskyblue": [0, 191, 255],
+        "dimgray": [105, 105, 105],
+        "dimgrey": [105, 105, 105],
+        "dodgerblue": [30, 144, 255],
+        "firebrick": [178, 34, 34],
+        "floralwhite": [255, 250, 240],
+        "forestgreen": [34, 139, 34],
+        "fuchsia": [255, 0, 255],
+        "gainsboro": [220, 220, 220],
+        "ghostwhite": [248, 248, 255],
+        "gold": [255, 215, 0],
+        "goldenrod": [218, 165, 32],
+        "gray": [128, 128, 128],
+        "green": [0, 128, 0],
+        "greenyellow": [173, 255, 47],
+        "grey": [128, 128, 128],
+        "honeydew": [240, 255, 240],
+        "hotpink": [255, 105, 180],
+        "indianred": [205, 92, 92],
+        "indigo": [75, 0, 130],
+        "ivory": [255, 255, 240],
+        "khaki": [240, 230, 140],
+        "lavender": [230, 230, 250],
+        "lavenderblush": [255, 240, 245],
+        "lawngreen": [124, 252, 0],
+        "lemonchiffon": [255, 250, 205],
+        "lightblue": [173, 216, 230],
+        "lightcoral": [240, 128, 128],
+        "lightcyan": [224, 255, 255],
+        "lightgoldenrodyellow": [250, 250, 210],
+        "lightgray": [211, 211, 211],
+        "lightgreen": [144, 238, 144],
+        "lightgrey": [211, 211, 211],
+        "lightpink": [255, 182, 193],
+        "lightsalmon": [255, 160, 122],
+        "lightseagreen": [32, 178, 170],
+        "lightskyblue": [135, 206, 250],
+        "lightslategray": [119, 136, 153],
+        "lightslategrey": [119, 136, 153],
+        "lightsteelblue": [176, 196, 222],
+        "lightyellow": [255, 255, 224],
+        "lime": [0, 255, 0],
+        "limegreen": [50, 205, 50],
+        "linen": [250, 240, 230],
+        "magenta": [255, 0, 255],
+        "maroon": [128, 0, 0],
+        "mediumaquamarine": [102, 205, 170],
+        "mediumblue": [0, 0, 205],
+        "mediumorchid": [186, 85, 211],
+        "mediumpurple": [147, 112, 219],
+        "mediumseagreen": [60, 179, 113],
+        "mediumslateblue": [123, 104, 238],
+        "mediumspringgreen": [0, 250, 154],
+        "mediumturquoise": [72, 209, 204],
+        "mediumvioletred": [199, 21, 133],
+        "midnightblue": [25, 25, 112],
+        "mintcream": [245, 255, 250],
+        "mistyrose": [255, 228, 225],
+        "moccasin": [255, 228, 181],
+        "navajowhite": [255, 222, 173],
+        "navy": [0, 0, 128],
+        "oldlace": [253, 245, 230],
+        "olive": [128, 128, 0],
+        "olivedrab": [107, 142, 35],
+        "orange": [255, 165, 0],
+        "orangered": [255, 69, 0],
+        "orchid": [218, 112, 214],
+        "palegoldenrod": [238, 232, 170],
+        "palegreen": [152, 251, 152],
+        "paleturquoise": [175, 238, 238],
+        "palevioletred": [219, 112, 147],
+        "papayawhip": [255, 239, 213],
+        "peachpuff": [255, 218, 185],
+        "peru": [205, 133, 63],
+        "pink": [255, 192, 203],
+        "plum": [221, 160, 221],
+        "powderblue": [176, 224, 230],
+        "purple": [128, 0, 128],
+        "rebeccapurple": [102, 51, 153],
+        "red": [255, 0, 0],
+        "rosybrown": [188, 143, 143],
+        "royalblue": [65, 105, 225],
+        "saddlebrown": [139, 69, 19],
+        "salmon": [250, 128, 114],
+        "sandybrown": [244, 164, 96],
+        "seagreen": [46, 139, 87],
+        "seashell": [255, 245, 238],
+        "sienna": [160, 82, 45],
+        "silver": [192, 192, 192],
+        "skyblue": [135, 206, 235],
+        "slateblue": [106, 90, 205],
+        "slategray": [112, 128, 144],
+        "slategrey": [112, 128, 144],
+        "snow": [255, 250, 250],
+        "springgreen": [0, 255, 127],
+        "steelblue": [70, 130, 180],
+        "tan": [210, 180, 140],
+        "teal": [0, 128, 128],
+        "thistle": [216, 191, 216],
+        "tomato": [255, 99, 71],
+        "turquoise": [64, 224, 208],
+        "violet": [238, 130, 238],
+        "wheat": [245, 222, 179],
+        "white": [255, 255, 255],
+        "whitesmoke": [245, 245, 245],
+        "yellow": [255, 255, 0],
+        "yellowgreen": [154, 205, 50]
+      };
+    }
+  });
+
+  // node_modules/simple-swizzle/node_modules/is-arrayish/index.js
+  var require_is_arrayish = __commonJS({
+    "node_modules/simple-swizzle/node_modules/is-arrayish/index.js"(exports, module) {
+      module.exports = function isArrayish(obj) {
+        if (!obj || typeof obj === "string") {
+          return false;
+        }
+        return obj instanceof Array || Array.isArray(obj) || obj.length >= 0 && (obj.splice instanceof Function || Object.getOwnPropertyDescriptor(obj, obj.length - 1) && obj.constructor.name !== "String");
+      };
+    }
+  });
+
+  // node_modules/simple-swizzle/index.js
+  var require_simple_swizzle = __commonJS({
+    "node_modules/simple-swizzle/index.js"(exports, module) {
+      var isArrayish = require_is_arrayish();
+      var concat = Array.prototype.concat;
+      var slice = Array.prototype.slice;
+      var swizzle = module.exports = function swizzle2(args) {
+        var results = [];
+        for (var i3 = 0, len = args.length; i3 < len; i3++) {
+          var arg = args[i3];
+          if (isArrayish(arg)) {
+            results = concat.call(results, slice.call(arg));
+          } else {
+            results.push(arg);
+          }
+        }
+        return results;
+      };
+      swizzle.wrap = function(fn) {
+        return function() {
+          return fn(swizzle(arguments));
+        };
+      };
+    }
+  });
+
+  // node_modules/color-string/index.js
+  var require_color_string = __commonJS({
+    "node_modules/color-string/index.js"(exports, module) {
+      var colorNames = require_color_name();
+      var swizzle = require_simple_swizzle();
+      var hasOwnProperty = Object.hasOwnProperty;
+      var reverseNames = {};
+      for (name in colorNames) {
+        if (hasOwnProperty.call(colorNames, name)) {
+          reverseNames[colorNames[name]] = name;
+        }
+      }
+      var name;
+      var cs = module.exports = {
+        to: {},
+        get: {}
+      };
+      cs.get = function(string) {
+        var prefix = string.substring(0, 3).toLowerCase();
+        var val;
+        var model;
+        switch (prefix) {
+          case "hsl":
+            val = cs.get.hsl(string);
+            model = "hsl";
+            break;
+          case "hwb":
+            val = cs.get.hwb(string);
+            model = "hwb";
+            break;
+          default:
+            val = cs.get.rgb(string);
+            model = "rgb";
+            break;
+        }
+        if (!val) {
+          return null;
+        }
+        return { model, value: val };
+      };
+      cs.get.rgb = function(string) {
+        if (!string) {
+          return null;
+        }
+        var abbr = /^#([a-f0-9]{3,4})$/i;
+        var hex = /^#([a-f0-9]{6})([a-f0-9]{2})?$/i;
+        var rgba = /^rgba?\(\s*([+-]?\d+)(?=[\s,])\s*(?:,\s*)?([+-]?\d+)(?=[\s,])\s*(?:,\s*)?([+-]?\d+)\s*(?:[,|\/]\s*([+-]?[\d\.]+)(%?)\s*)?\)$/;
+        var per = /^rgba?\(\s*([+-]?[\d\.]+)\%\s*,?\s*([+-]?[\d\.]+)\%\s*,?\s*([+-]?[\d\.]+)\%\s*(?:[,|\/]\s*([+-]?[\d\.]+)(%?)\s*)?\)$/;
+        var keyword = /^(\w+)$/;
+        var rgb = [0, 0, 0, 1];
+        var match;
+        var i3;
+        var hexAlpha;
+        if (match = string.match(hex)) {
+          hexAlpha = match[2];
+          match = match[1];
+          for (i3 = 0; i3 < 3; i3++) {
+            var i22 = i3 * 2;
+            rgb[i3] = parseInt(match.slice(i22, i22 + 2), 16);
+          }
+          if (hexAlpha) {
+            rgb[3] = parseInt(hexAlpha, 16) / 255;
+          }
+        } else if (match = string.match(abbr)) {
+          match = match[1];
+          hexAlpha = match[3];
+          for (i3 = 0; i3 < 3; i3++) {
+            rgb[i3] = parseInt(match[i3] + match[i3], 16);
+          }
+          if (hexAlpha) {
+            rgb[3] = parseInt(hexAlpha + hexAlpha, 16) / 255;
+          }
+        } else if (match = string.match(rgba)) {
+          for (i3 = 0; i3 < 3; i3++) {
+            rgb[i3] = parseInt(match[i3 + 1], 0);
+          }
+          if (match[4]) {
+            if (match[5]) {
+              rgb[3] = parseFloat(match[4]) * 0.01;
+            } else {
+              rgb[3] = parseFloat(match[4]);
+            }
+          }
+        } else if (match = string.match(per)) {
+          for (i3 = 0; i3 < 3; i3++) {
+            rgb[i3] = Math.round(parseFloat(match[i3 + 1]) * 2.55);
+          }
+          if (match[4]) {
+            if (match[5]) {
+              rgb[3] = parseFloat(match[4]) * 0.01;
+            } else {
+              rgb[3] = parseFloat(match[4]);
+            }
+          }
+        } else if (match = string.match(keyword)) {
+          if (match[1] === "transparent") {
+            return [0, 0, 0, 0];
+          }
+          if (!hasOwnProperty.call(colorNames, match[1])) {
+            return null;
+          }
+          rgb = colorNames[match[1]];
+          rgb[3] = 1;
+          return rgb;
+        } else {
+          return null;
+        }
+        for (i3 = 0; i3 < 3; i3++) {
+          rgb[i3] = clamp2(rgb[i3], 0, 255);
+        }
+        rgb[3] = clamp2(rgb[3], 0, 1);
+        return rgb;
+      };
+      cs.get.hsl = function(string) {
+        if (!string) {
+          return null;
+        }
+        var hsl = /^hsla?\(\s*([+-]?(?:\d{0,3}\.)?\d+)(?:deg)?\s*,?\s*([+-]?[\d\.]+)%\s*,?\s*([+-]?[\d\.]+)%\s*(?:[,|\/]\s*([+-]?(?=\.\d|\d)(?:0|[1-9]\d*)?(?:\.\d*)?(?:[eE][+-]?\d+)?)\s*)?\)$/;
+        var match = string.match(hsl);
+        if (match) {
+          var alpha = parseFloat(match[4]);
+          var h = (parseFloat(match[1]) % 360 + 360) % 360;
+          var s = clamp2(parseFloat(match[2]), 0, 100);
+          var l3 = clamp2(parseFloat(match[3]), 0, 100);
+          var a = clamp2(isNaN(alpha) ? 1 : alpha, 0, 1);
+          return [h, s, l3, a];
+        }
+        return null;
+      };
+      cs.get.hwb = function(string) {
+        if (!string) {
+          return null;
+        }
+        var hwb = /^hwb\(\s*([+-]?\d{0,3}(?:\.\d+)?)(?:deg)?\s*,\s*([+-]?[\d\.]+)%\s*,\s*([+-]?[\d\.]+)%\s*(?:,\s*([+-]?(?=\.\d|\d)(?:0|[1-9]\d*)?(?:\.\d*)?(?:[eE][+-]?\d+)?)\s*)?\)$/;
+        var match = string.match(hwb);
+        if (match) {
+          var alpha = parseFloat(match[4]);
+          var h = (parseFloat(match[1]) % 360 + 360) % 360;
+          var w = clamp2(parseFloat(match[2]), 0, 100);
+          var b = clamp2(parseFloat(match[3]), 0, 100);
+          var a = clamp2(isNaN(alpha) ? 1 : alpha, 0, 1);
+          return [h, w, b, a];
+        }
+        return null;
+      };
+      cs.to.hex = function() {
+        var rgba = swizzle(arguments);
+        return "#" + hexDouble(rgba[0]) + hexDouble(rgba[1]) + hexDouble(rgba[2]) + (rgba[3] < 1 ? hexDouble(Math.round(rgba[3] * 255)) : "");
+      };
+      cs.to.rgb = function() {
+        var rgba = swizzle(arguments);
+        return rgba.length < 4 || rgba[3] === 1 ? "rgb(" + Math.round(rgba[0]) + ", " + Math.round(rgba[1]) + ", " + Math.round(rgba[2]) + ")" : "rgba(" + Math.round(rgba[0]) + ", " + Math.round(rgba[1]) + ", " + Math.round(rgba[2]) + ", " + rgba[3] + ")";
+      };
+      cs.to.rgb.percent = function() {
+        var rgba = swizzle(arguments);
+        var r = Math.round(rgba[0] / 255 * 100);
+        var g = Math.round(rgba[1] / 255 * 100);
+        var b = Math.round(rgba[2] / 255 * 100);
+        return rgba.length < 4 || rgba[3] === 1 ? "rgb(" + r + "%, " + g + "%, " + b + "%)" : "rgba(" + r + "%, " + g + "%, " + b + "%, " + rgba[3] + ")";
+      };
+      cs.to.hsl = function() {
+        var hsla = swizzle(arguments);
+        return hsla.length < 4 || hsla[3] === 1 ? "hsl(" + hsla[0] + ", " + hsla[1] + "%, " + hsla[2] + "%)" : "hsla(" + hsla[0] + ", " + hsla[1] + "%, " + hsla[2] + "%, " + hsla[3] + ")";
+      };
+      cs.to.hwb = function() {
+        var hwba = swizzle(arguments);
+        var a = "";
+        if (hwba.length >= 4 && hwba[3] !== 1) {
+          a = ", " + hwba[3];
+        }
+        return "hwb(" + hwba[0] + ", " + hwba[1] + "%, " + hwba[2] + "%" + a + ")";
+      };
+      cs.to.keyword = function(rgb) {
+        return reverseNames[rgb.slice(0, 3)];
+      };
+      function clamp2(num, min, max) {
+        return Math.min(Math.max(min, num), max);
+      }
+      function hexDouble(num) {
+        var str = Math.round(num).toString(16).toUpperCase();
+        return str.length < 2 ? "0" + str : str;
+      }
+    }
+  });
+
+  // node_modules/color-convert/conversions.js
+  var require_conversions = __commonJS({
+    "node_modules/color-convert/conversions.js"(exports, module) {
+      var cssKeywords = require_color_name();
+      var reverseKeywords = {};
+      for (const key of Object.keys(cssKeywords)) {
+        reverseKeywords[cssKeywords[key]] = key;
+      }
+      var convert = {
+        rgb: { channels: 3, labels: "rgb" },
+        hsl: { channels: 3, labels: "hsl" },
+        hsv: { channels: 3, labels: "hsv" },
+        hwb: { channels: 3, labels: "hwb" },
+        cmyk: { channels: 4, labels: "cmyk" },
+        xyz: { channels: 3, labels: "xyz" },
+        lab: { channels: 3, labels: "lab" },
+        lch: { channels: 3, labels: "lch" },
+        hex: { channels: 1, labels: ["hex"] },
+        keyword: { channels: 1, labels: ["keyword"] },
+        ansi16: { channels: 1, labels: ["ansi16"] },
+        ansi256: { channels: 1, labels: ["ansi256"] },
+        hcg: { channels: 3, labels: ["h", "c", "g"] },
+        apple: { channels: 3, labels: ["r16", "g16", "b16"] },
+        gray: { channels: 1, labels: ["gray"] }
+      };
+      module.exports = convert;
+      for (const model of Object.keys(convert)) {
+        if (!("channels" in convert[model])) {
+          throw new Error("missing channels property: " + model);
+        }
+        if (!("labels" in convert[model])) {
+          throw new Error("missing channel labels property: " + model);
+        }
+        if (convert[model].labels.length !== convert[model].channels) {
+          throw new Error("channel and label counts mismatch: " + model);
+        }
+        const { channels, labels } = convert[model];
+        delete convert[model].channels;
+        delete convert[model].labels;
+        Object.defineProperty(convert[model], "channels", { value: channels });
+        Object.defineProperty(convert[model], "labels", { value: labels });
+      }
+      convert.rgb.hsl = function(rgb) {
+        const r = rgb[0] / 255;
+        const g = rgb[1] / 255;
+        const b = rgb[2] / 255;
+        const min = Math.min(r, g, b);
+        const max = Math.max(r, g, b);
+        const delta = max - min;
+        let h;
+        let s;
+        if (max === min) {
+          h = 0;
+        } else if (r === max) {
+          h = (g - b) / delta;
+        } else if (g === max) {
+          h = 2 + (b - r) / delta;
+        } else if (b === max) {
+          h = 4 + (r - g) / delta;
+        }
+        h = Math.min(h * 60, 360);
+        if (h < 0) {
+          h += 360;
+        }
+        const l3 = (min + max) / 2;
+        if (max === min) {
+          s = 0;
+        } else if (l3 <= 0.5) {
+          s = delta / (max + min);
+        } else {
+          s = delta / (2 - max - min);
+        }
+        return [h, s * 100, l3 * 100];
+      };
+      convert.rgb.hsv = function(rgb) {
+        let rdif;
+        let gdif;
+        let bdif;
+        let h;
+        let s;
+        const r = rgb[0] / 255;
+        const g = rgb[1] / 255;
+        const b = rgb[2] / 255;
+        const v = Math.max(r, g, b);
+        const diff = v - Math.min(r, g, b);
+        const diffc = function(c) {
+          return (v - c) / 6 / diff + 1 / 2;
+        };
+        if (diff === 0) {
+          h = 0;
+          s = 0;
+        } else {
+          s = diff / v;
+          rdif = diffc(r);
+          gdif = diffc(g);
+          bdif = diffc(b);
+          if (r === v) {
+            h = bdif - gdif;
+          } else if (g === v) {
+            h = 1 / 3 + rdif - bdif;
+          } else if (b === v) {
+            h = 2 / 3 + gdif - rdif;
+          }
+          if (h < 0) {
+            h += 1;
+          } else if (h > 1) {
+            h -= 1;
+          }
+        }
+        return [
+          h * 360,
+          s * 100,
+          v * 100
+        ];
+      };
+      convert.rgb.hwb = function(rgb) {
+        const r = rgb[0];
+        const g = rgb[1];
+        let b = rgb[2];
+        const h = convert.rgb.hsl(rgb)[0];
+        const w = 1 / 255 * Math.min(r, Math.min(g, b));
+        b = 1 - 1 / 255 * Math.max(r, Math.max(g, b));
+        return [h, w * 100, b * 100];
+      };
+      convert.rgb.cmyk = function(rgb) {
+        const r = rgb[0] / 255;
+        const g = rgb[1] / 255;
+        const b = rgb[2] / 255;
+        const k = Math.min(1 - r, 1 - g, 1 - b);
+        const c = (1 - r - k) / (1 - k) || 0;
+        const m = (1 - g - k) / (1 - k) || 0;
+        const y = (1 - b - k) / (1 - k) || 0;
+        return [c * 100, m * 100, y * 100, k * 100];
+      };
+      function comparativeDistance(x, y) {
+        return (x[0] - y[0]) ** 2 + (x[1] - y[1]) ** 2 + (x[2] - y[2]) ** 2;
+      }
+      convert.rgb.keyword = function(rgb) {
+        const reversed = reverseKeywords[rgb];
+        if (reversed) {
+          return reversed;
+        }
+        let currentClosestDistance = Infinity;
+        let currentClosestKeyword;
+        for (const keyword of Object.keys(cssKeywords)) {
+          const value = cssKeywords[keyword];
+          const distance = comparativeDistance(rgb, value);
+          if (distance < currentClosestDistance) {
+            currentClosestDistance = distance;
+            currentClosestKeyword = keyword;
+          }
+        }
+        return currentClosestKeyword;
+      };
+      convert.keyword.rgb = function(keyword) {
+        return cssKeywords[keyword];
+      };
+      convert.rgb.xyz = function(rgb) {
+        let r = rgb[0] / 255;
+        let g = rgb[1] / 255;
+        let b = rgb[2] / 255;
+        r = r > 0.04045 ? ((r + 0.055) / 1.055) ** 2.4 : r / 12.92;
+        g = g > 0.04045 ? ((g + 0.055) / 1.055) ** 2.4 : g / 12.92;
+        b = b > 0.04045 ? ((b + 0.055) / 1.055) ** 2.4 : b / 12.92;
+        const x = r * 0.4124 + g * 0.3576 + b * 0.1805;
+        const y = r * 0.2126 + g * 0.7152 + b * 0.0722;
+        const z = r * 0.0193 + g * 0.1192 + b * 0.9505;
+        return [x * 100, y * 100, z * 100];
+      };
+      convert.rgb.lab = function(rgb) {
+        const xyz = convert.rgb.xyz(rgb);
+        let x = xyz[0];
+        let y = xyz[1];
+        let z = xyz[2];
+        x /= 95.047;
+        y /= 100;
+        z /= 108.883;
+        x = x > 8856e-6 ? x ** (1 / 3) : 7.787 * x + 16 / 116;
+        y = y > 8856e-6 ? y ** (1 / 3) : 7.787 * y + 16 / 116;
+        z = z > 8856e-6 ? z ** (1 / 3) : 7.787 * z + 16 / 116;
+        const l3 = 116 * y - 16;
+        const a = 500 * (x - y);
+        const b = 200 * (y - z);
+        return [l3, a, b];
+      };
+      convert.hsl.rgb = function(hsl) {
+        const h = hsl[0] / 360;
+        const s = hsl[1] / 100;
+        const l3 = hsl[2] / 100;
+        let t2;
+        let t3;
+        let val;
+        if (s === 0) {
+          val = l3 * 255;
+          return [val, val, val];
+        }
+        if (l3 < 0.5) {
+          t2 = l3 * (1 + s);
+        } else {
+          t2 = l3 + s - l3 * s;
+        }
+        const t1 = 2 * l3 - t2;
+        const rgb = [0, 0, 0];
+        for (let i3 = 0; i3 < 3; i3++) {
+          t3 = h + 1 / 3 * -(i3 - 1);
+          if (t3 < 0) {
+            t3++;
+          }
+          if (t3 > 1) {
+            t3--;
+          }
+          if (6 * t3 < 1) {
+            val = t1 + (t2 - t1) * 6 * t3;
+          } else if (2 * t3 < 1) {
+            val = t2;
+          } else if (3 * t3 < 2) {
+            val = t1 + (t2 - t1) * (2 / 3 - t3) * 6;
+          } else {
+            val = t1;
+          }
+          rgb[i3] = val * 255;
+        }
+        return rgb;
+      };
+      convert.hsl.hsv = function(hsl) {
+        const h = hsl[0];
+        let s = hsl[1] / 100;
+        let l3 = hsl[2] / 100;
+        let smin = s;
+        const lmin = Math.max(l3, 0.01);
+        l3 *= 2;
+        s *= l3 <= 1 ? l3 : 2 - l3;
+        smin *= lmin <= 1 ? lmin : 2 - lmin;
+        const v = (l3 + s) / 2;
+        const sv = l3 === 0 ? 2 * smin / (lmin + smin) : 2 * s / (l3 + s);
+        return [h, sv * 100, v * 100];
+      };
+      convert.hsv.rgb = function(hsv) {
+        const h = hsv[0] / 60;
+        const s = hsv[1] / 100;
+        let v = hsv[2] / 100;
+        const hi = Math.floor(h) % 6;
+        const f = h - Math.floor(h);
+        const p = 255 * v * (1 - s);
+        const q = 255 * v * (1 - s * f);
+        const t2 = 255 * v * (1 - s * (1 - f));
+        v *= 255;
+        switch (hi) {
+          case 0:
+            return [v, t2, p];
+          case 1:
+            return [q, v, p];
+          case 2:
+            return [p, v, t2];
+          case 3:
+            return [p, q, v];
+          case 4:
+            return [t2, p, v];
+          case 5:
+            return [v, p, q];
+        }
+      };
+      convert.hsv.hsl = function(hsv) {
+        const h = hsv[0];
+        const s = hsv[1] / 100;
+        const v = hsv[2] / 100;
+        const vmin = Math.max(v, 0.01);
+        let sl;
+        let l3;
+        l3 = (2 - s) * v;
+        const lmin = (2 - s) * vmin;
+        sl = s * vmin;
+        sl /= lmin <= 1 ? lmin : 2 - lmin;
+        sl = sl || 0;
+        l3 /= 2;
+        return [h, sl * 100, l3 * 100];
+      };
+      convert.hwb.rgb = function(hwb) {
+        const h = hwb[0] / 360;
+        let wh = hwb[1] / 100;
+        let bl = hwb[2] / 100;
+        const ratio = wh + bl;
+        let f;
+        if (ratio > 1) {
+          wh /= ratio;
+          bl /= ratio;
+        }
+        const i3 = Math.floor(6 * h);
+        const v = 1 - bl;
+        f = 6 * h - i3;
+        if ((i3 & 1) !== 0) {
+          f = 1 - f;
+        }
+        const n2 = wh + f * (v - wh);
+        let r;
+        let g;
+        let b;
+        switch (i3) {
+          default:
+          case 6:
+          case 0:
+            r = v;
+            g = n2;
+            b = wh;
+            break;
+          case 1:
+            r = n2;
+            g = v;
+            b = wh;
+            break;
+          case 2:
+            r = wh;
+            g = v;
+            b = n2;
+            break;
+          case 3:
+            r = wh;
+            g = n2;
+            b = v;
+            break;
+          case 4:
+            r = n2;
+            g = wh;
+            b = v;
+            break;
+          case 5:
+            r = v;
+            g = wh;
+            b = n2;
+            break;
+        }
+        return [r * 255, g * 255, b * 255];
+      };
+      convert.cmyk.rgb = function(cmyk) {
+        const c = cmyk[0] / 100;
+        const m = cmyk[1] / 100;
+        const y = cmyk[2] / 100;
+        const k = cmyk[3] / 100;
+        const r = 1 - Math.min(1, c * (1 - k) + k);
+        const g = 1 - Math.min(1, m * (1 - k) + k);
+        const b = 1 - Math.min(1, y * (1 - k) + k);
+        return [r * 255, g * 255, b * 255];
+      };
+      convert.xyz.rgb = function(xyz) {
+        const x = xyz[0] / 100;
+        const y = xyz[1] / 100;
+        const z = xyz[2] / 100;
+        let r;
+        let g;
+        let b;
+        r = x * 3.2406 + y * -1.5372 + z * -0.4986;
+        g = x * -0.9689 + y * 1.8758 + z * 0.0415;
+        b = x * 0.0557 + y * -0.204 + z * 1.057;
+        r = r > 31308e-7 ? 1.055 * r ** (1 / 2.4) - 0.055 : r * 12.92;
+        g = g > 31308e-7 ? 1.055 * g ** (1 / 2.4) - 0.055 : g * 12.92;
+        b = b > 31308e-7 ? 1.055 * b ** (1 / 2.4) - 0.055 : b * 12.92;
+        r = Math.min(Math.max(0, r), 1);
+        g = Math.min(Math.max(0, g), 1);
+        b = Math.min(Math.max(0, b), 1);
+        return [r * 255, g * 255, b * 255];
+      };
+      convert.xyz.lab = function(xyz) {
+        let x = xyz[0];
+        let y = xyz[1];
+        let z = xyz[2];
+        x /= 95.047;
+        y /= 100;
+        z /= 108.883;
+        x = x > 8856e-6 ? x ** (1 / 3) : 7.787 * x + 16 / 116;
+        y = y > 8856e-6 ? y ** (1 / 3) : 7.787 * y + 16 / 116;
+        z = z > 8856e-6 ? z ** (1 / 3) : 7.787 * z + 16 / 116;
+        const l3 = 116 * y - 16;
+        const a = 500 * (x - y);
+        const b = 200 * (y - z);
+        return [l3, a, b];
+      };
+      convert.lab.xyz = function(lab) {
+        const l3 = lab[0];
+        const a = lab[1];
+        const b = lab[2];
+        let x;
+        let y;
+        let z;
+        y = (l3 + 16) / 116;
+        x = a / 500 + y;
+        z = y - b / 200;
+        const y2 = y ** 3;
+        const x2 = x ** 3;
+        const z2 = z ** 3;
+        y = y2 > 8856e-6 ? y2 : (y - 16 / 116) / 7.787;
+        x = x2 > 8856e-6 ? x2 : (x - 16 / 116) / 7.787;
+        z = z2 > 8856e-6 ? z2 : (z - 16 / 116) / 7.787;
+        x *= 95.047;
+        y *= 100;
+        z *= 108.883;
+        return [x, y, z];
+      };
+      convert.lab.lch = function(lab) {
+        const l3 = lab[0];
+        const a = lab[1];
+        const b = lab[2];
+        let h;
+        const hr = Math.atan2(b, a);
+        h = hr * 360 / 2 / Math.PI;
+        if (h < 0) {
+          h += 360;
+        }
+        const c = Math.sqrt(a * a + b * b);
+        return [l3, c, h];
+      };
+      convert.lch.lab = function(lch) {
+        const l3 = lch[0];
+        const c = lch[1];
+        const h = lch[2];
+        const hr = h / 360 * 2 * Math.PI;
+        const a = c * Math.cos(hr);
+        const b = c * Math.sin(hr);
+        return [l3, a, b];
+      };
+      convert.rgb.ansi16 = function(args, saturation = null) {
+        const [r, g, b] = args;
+        let value = saturation === null ? convert.rgb.hsv(args)[2] : saturation;
+        value = Math.round(value / 50);
+        if (value === 0) {
+          return 30;
+        }
+        let ansi = 30 + (Math.round(b / 255) << 2 | Math.round(g / 255) << 1 | Math.round(r / 255));
+        if (value === 2) {
+          ansi += 60;
+        }
+        return ansi;
+      };
+      convert.hsv.ansi16 = function(args) {
+        return convert.rgb.ansi16(convert.hsv.rgb(args), args[2]);
+      };
+      convert.rgb.ansi256 = function(args) {
+        const r = args[0];
+        const g = args[1];
+        const b = args[2];
+        if (r === g && g === b) {
+          if (r < 8) {
+            return 16;
+          }
+          if (r > 248) {
+            return 231;
+          }
+          return Math.round((r - 8) / 247 * 24) + 232;
+        }
+        const ansi = 16 + 36 * Math.round(r / 255 * 5) + 6 * Math.round(g / 255 * 5) + Math.round(b / 255 * 5);
+        return ansi;
+      };
+      convert.ansi16.rgb = function(args) {
+        let color = args % 10;
+        if (color === 0 || color === 7) {
+          if (args > 50) {
+            color += 3.5;
+          }
+          color = color / 10.5 * 255;
+          return [color, color, color];
+        }
+        const mult = (~~(args > 50) + 1) * 0.5;
+        const r = (color & 1) * mult * 255;
+        const g = (color >> 1 & 1) * mult * 255;
+        const b = (color >> 2 & 1) * mult * 255;
+        return [r, g, b];
+      };
+      convert.ansi256.rgb = function(args) {
+        if (args >= 232) {
+          const c = (args - 232) * 10 + 8;
+          return [c, c, c];
+        }
+        args -= 16;
+        let rem;
+        const r = Math.floor(args / 36) / 5 * 255;
+        const g = Math.floor((rem = args % 36) / 6) / 5 * 255;
+        const b = rem % 6 / 5 * 255;
+        return [r, g, b];
+      };
+      convert.rgb.hex = function(args) {
+        const integer = ((Math.round(args[0]) & 255) << 16) + ((Math.round(args[1]) & 255) << 8) + (Math.round(args[2]) & 255);
+        const string = integer.toString(16).toUpperCase();
+        return "000000".substring(string.length) + string;
+      };
+      convert.hex.rgb = function(args) {
+        const match = args.toString(16).match(/[a-f0-9]{6}|[a-f0-9]{3}/i);
+        if (!match) {
+          return [0, 0, 0];
+        }
+        let colorString = match[0];
+        if (match[0].length === 3) {
+          colorString = colorString.split("").map((char) => {
+            return char + char;
+          }).join("");
+        }
+        const integer = parseInt(colorString, 16);
+        const r = integer >> 16 & 255;
+        const g = integer >> 8 & 255;
+        const b = integer & 255;
+        return [r, g, b];
+      };
+      convert.rgb.hcg = function(rgb) {
+        const r = rgb[0] / 255;
+        const g = rgb[1] / 255;
+        const b = rgb[2] / 255;
+        const max = Math.max(Math.max(r, g), b);
+        const min = Math.min(Math.min(r, g), b);
+        const chroma = max - min;
+        let grayscale;
+        let hue;
+        if (chroma < 1) {
+          grayscale = min / (1 - chroma);
+        } else {
+          grayscale = 0;
+        }
+        if (chroma <= 0) {
+          hue = 0;
+        } else if (max === r) {
+          hue = (g - b) / chroma % 6;
+        } else if (max === g) {
+          hue = 2 + (b - r) / chroma;
+        } else {
+          hue = 4 + (r - g) / chroma;
+        }
+        hue /= 6;
+        hue %= 1;
+        return [hue * 360, chroma * 100, grayscale * 100];
+      };
+      convert.hsl.hcg = function(hsl) {
+        const s = hsl[1] / 100;
+        const l3 = hsl[2] / 100;
+        const c = l3 < 0.5 ? 2 * s * l3 : 2 * s * (1 - l3);
+        let f = 0;
+        if (c < 1) {
+          f = (l3 - 0.5 * c) / (1 - c);
+        }
+        return [hsl[0], c * 100, f * 100];
+      };
+      convert.hsv.hcg = function(hsv) {
+        const s = hsv[1] / 100;
+        const v = hsv[2] / 100;
+        const c = s * v;
+        let f = 0;
+        if (c < 1) {
+          f = (v - c) / (1 - c);
+        }
+        return [hsv[0], c * 100, f * 100];
+      };
+      convert.hcg.rgb = function(hcg) {
+        const h = hcg[0] / 360;
+        const c = hcg[1] / 100;
+        const g = hcg[2] / 100;
+        if (c === 0) {
+          return [g * 255, g * 255, g * 255];
+        }
+        const pure = [0, 0, 0];
+        const hi = h % 1 * 6;
+        const v = hi % 1;
+        const w = 1 - v;
+        let mg = 0;
+        switch (Math.floor(hi)) {
+          case 0:
+            pure[0] = 1;
+            pure[1] = v;
+            pure[2] = 0;
+            break;
+          case 1:
+            pure[0] = w;
+            pure[1] = 1;
+            pure[2] = 0;
+            break;
+          case 2:
+            pure[0] = 0;
+            pure[1] = 1;
+            pure[2] = v;
+            break;
+          case 3:
+            pure[0] = 0;
+            pure[1] = w;
+            pure[2] = 1;
+            break;
+          case 4:
+            pure[0] = v;
+            pure[1] = 0;
+            pure[2] = 1;
+            break;
+          default:
+            pure[0] = 1;
+            pure[1] = 0;
+            pure[2] = w;
+        }
+        mg = (1 - c) * g;
+        return [
+          (c * pure[0] + mg) * 255,
+          (c * pure[1] + mg) * 255,
+          (c * pure[2] + mg) * 255
+        ];
+      };
+      convert.hcg.hsv = function(hcg) {
+        const c = hcg[1] / 100;
+        const g = hcg[2] / 100;
+        const v = c + g * (1 - c);
+        let f = 0;
+        if (v > 0) {
+          f = c / v;
+        }
+        return [hcg[0], f * 100, v * 100];
+      };
+      convert.hcg.hsl = function(hcg) {
+        const c = hcg[1] / 100;
+        const g = hcg[2] / 100;
+        const l3 = g * (1 - c) + 0.5 * c;
+        let s = 0;
+        if (l3 > 0 && l3 < 0.5) {
+          s = c / (2 * l3);
+        } else if (l3 >= 0.5 && l3 < 1) {
+          s = c / (2 * (1 - l3));
+        }
+        return [hcg[0], s * 100, l3 * 100];
+      };
+      convert.hcg.hwb = function(hcg) {
+        const c = hcg[1] / 100;
+        const g = hcg[2] / 100;
+        const v = c + g * (1 - c);
+        return [hcg[0], (v - c) * 100, (1 - v) * 100];
+      };
+      convert.hwb.hcg = function(hwb) {
+        const w = hwb[1] / 100;
+        const b = hwb[2] / 100;
+        const v = 1 - b;
+        const c = v - w;
+        let g = 0;
+        if (c < 1) {
+          g = (v - c) / (1 - c);
+        }
+        return [hwb[0], c * 100, g * 100];
+      };
+      convert.apple.rgb = function(apple) {
+        return [apple[0] / 65535 * 255, apple[1] / 65535 * 255, apple[2] / 65535 * 255];
+      };
+      convert.rgb.apple = function(rgb) {
+        return [rgb[0] / 255 * 65535, rgb[1] / 255 * 65535, rgb[2] / 255 * 65535];
+      };
+      convert.gray.rgb = function(args) {
+        return [args[0] / 100 * 255, args[0] / 100 * 255, args[0] / 100 * 255];
+      };
+      convert.gray.hsl = function(args) {
+        return [0, 0, args[0]];
+      };
+      convert.gray.hsv = convert.gray.hsl;
+      convert.gray.hwb = function(gray) {
+        return [0, 100, gray[0]];
+      };
+      convert.gray.cmyk = function(gray) {
+        return [0, 0, 0, gray[0]];
+      };
+      convert.gray.lab = function(gray) {
+        return [gray[0], 0, 0];
+      };
+      convert.gray.hex = function(gray) {
+        const val = Math.round(gray[0] / 100 * 255) & 255;
+        const integer = (val << 16) + (val << 8) + val;
+        const string = integer.toString(16).toUpperCase();
+        return "000000".substring(string.length) + string;
+      };
+      convert.rgb.gray = function(rgb) {
+        const val = (rgb[0] + rgb[1] + rgb[2]) / 3;
+        return [val / 255 * 100];
+      };
+    }
+  });
+
+  // node_modules/color-convert/route.js
+  var require_route = __commonJS({
+    "node_modules/color-convert/route.js"(exports, module) {
+      var conversions = require_conversions();
+      function buildGraph() {
+        const graph = {};
+        const models = Object.keys(conversions);
+        for (let len = models.length, i3 = 0; i3 < len; i3++) {
+          graph[models[i3]] = {
+            distance: -1,
+            parent: null
+          };
+        }
+        return graph;
+      }
+      function deriveBFS(fromModel) {
+        const graph = buildGraph();
+        const queue = [fromModel];
+        graph[fromModel].distance = 0;
+        while (queue.length) {
+          const current = queue.pop();
+          const adjacents = Object.keys(conversions[current]);
+          for (let len = adjacents.length, i3 = 0; i3 < len; i3++) {
+            const adjacent = adjacents[i3];
+            const node = graph[adjacent];
+            if (node.distance === -1) {
+              node.distance = graph[current].distance + 1;
+              node.parent = current;
+              queue.unshift(adjacent);
+            }
+          }
+        }
+        return graph;
+      }
+      function link(from, to) {
+        return function(args) {
+          return to(from(args));
+        };
+      }
+      function wrapConversion(toModel, graph) {
+        const path = [graph[toModel].parent, toModel];
+        let fn = conversions[graph[toModel].parent][toModel];
+        let cur = graph[toModel].parent;
+        while (graph[cur].parent) {
+          path.unshift(graph[cur].parent);
+          fn = link(conversions[graph[cur].parent][cur], fn);
+          cur = graph[cur].parent;
+        }
+        fn.conversion = path;
+        return fn;
+      }
+      module.exports = function(fromModel) {
+        const graph = deriveBFS(fromModel);
+        const conversion = {};
+        const models = Object.keys(graph);
+        for (let len = models.length, i3 = 0; i3 < len; i3++) {
+          const toModel = models[i3];
+          const node = graph[toModel];
+          if (node.parent === null) {
+            continue;
+          }
+          conversion[toModel] = wrapConversion(toModel, graph);
+        }
+        return conversion;
+      };
+    }
+  });
+
+  // node_modules/color-convert/index.js
+  var require_color_convert = __commonJS({
+    "node_modules/color-convert/index.js"(exports, module) {
+      var conversions = require_conversions();
+      var route = require_route();
+      var convert = {};
+      var models = Object.keys(conversions);
+      function wrapRaw(fn) {
+        const wrappedFn = function(...args) {
+          const arg0 = args[0];
+          if (arg0 === void 0 || arg0 === null) {
+            return arg0;
+          }
+          if (arg0.length > 1) {
+            args = arg0;
+          }
+          return fn(args);
+        };
+        if ("conversion" in fn) {
+          wrappedFn.conversion = fn.conversion;
+        }
+        return wrappedFn;
+      }
+      function wrapRounded(fn) {
+        const wrappedFn = function(...args) {
+          const arg0 = args[0];
+          if (arg0 === void 0 || arg0 === null) {
+            return arg0;
+          }
+          if (arg0.length > 1) {
+            args = arg0;
+          }
+          const result = fn(args);
+          if (typeof result === "object") {
+            for (let len = result.length, i3 = 0; i3 < len; i3++) {
+              result[i3] = Math.round(result[i3]);
+            }
+          }
+          return result;
+        };
+        if ("conversion" in fn) {
+          wrappedFn.conversion = fn.conversion;
+        }
+        return wrappedFn;
+      }
+      models.forEach((fromModel) => {
+        convert[fromModel] = {};
+        Object.defineProperty(convert[fromModel], "channels", { value: conversions[fromModel].channels });
+        Object.defineProperty(convert[fromModel], "labels", { value: conversions[fromModel].labels });
+        const routes = route(fromModel);
+        const routeModels = Object.keys(routes);
+        routeModels.forEach((toModel) => {
+          const fn = routes[toModel];
+          convert[fromModel][toModel] = wrapRounded(fn);
+          convert[fromModel][toModel].raw = wrapRaw(fn);
+        });
+      });
+      module.exports = convert;
+    }
+  });
+
+  // node_modules/color/index.js
+  var require_color = __commonJS({
+    "node_modules/color/index.js"(exports, module) {
+      var colorString = require_color_string();
+      var convert = require_color_convert();
+      var _slice = [].slice;
+      var skippedModels = [
+        "keyword",
+        "gray",
+        "hex"
+      ];
+      var hashedModelKeys = {};
+      for (const model of Object.keys(convert)) {
+        hashedModelKeys[_slice.call(convert[model].labels).sort().join("")] = model;
+      }
+      var limiters = {};
+      function Color2(object, model) {
+        if (!(this instanceof Color2)) {
+          return new Color2(object, model);
+        }
+        if (model && model in skippedModels) {
+          model = null;
+        }
+        if (model && !(model in convert)) {
+          throw new Error("Unknown model: " + model);
+        }
+        let i3;
+        let channels;
+        if (object == null) {
+          this.model = "rgb";
+          this.color = [0, 0, 0];
+          this.valpha = 1;
+        } else if (object instanceof Color2) {
+          this.model = object.model;
+          this.color = object.color.slice();
+          this.valpha = object.valpha;
+        } else if (typeof object === "string") {
+          const result = colorString.get(object);
+          if (result === null) {
+            throw new Error("Unable to parse color from string: " + object);
+          }
+          this.model = result.model;
+          channels = convert[this.model].channels;
+          this.color = result.value.slice(0, channels);
+          this.valpha = typeof result.value[channels] === "number" ? result.value[channels] : 1;
+        } else if (object.length > 0) {
+          this.model = model || "rgb";
+          channels = convert[this.model].channels;
+          const newArray = _slice.call(object, 0, channels);
+          this.color = zeroArray(newArray, channels);
+          this.valpha = typeof object[channels] === "number" ? object[channels] : 1;
+        } else if (typeof object === "number") {
+          this.model = "rgb";
+          this.color = [
+            object >> 16 & 255,
+            object >> 8 & 255,
+            object & 255
+          ];
+          this.valpha = 1;
+        } else {
+          this.valpha = 1;
+          const keys = Object.keys(object);
+          if ("alpha" in object) {
+            keys.splice(keys.indexOf("alpha"), 1);
+            this.valpha = typeof object.alpha === "number" ? object.alpha : 0;
+          }
+          const hashedKeys = keys.sort().join("");
+          if (!(hashedKeys in hashedModelKeys)) {
+            throw new Error("Unable to parse color from object: " + JSON.stringify(object));
+          }
+          this.model = hashedModelKeys[hashedKeys];
+          const labels = convert[this.model].labels;
+          const color = [];
+          for (i3 = 0; i3 < labels.length; i3++) {
+            color.push(object[labels[i3]]);
+          }
+          this.color = zeroArray(color);
+        }
+        if (limiters[this.model]) {
+          channels = convert[this.model].channels;
+          for (i3 = 0; i3 < channels; i3++) {
+            const limit = limiters[this.model][i3];
+            if (limit) {
+              this.color[i3] = limit(this.color[i3]);
+            }
+          }
+        }
+        this.valpha = Math.max(0, Math.min(1, this.valpha));
+        if (Object.freeze) {
+          Object.freeze(this);
+        }
+      }
+      Color2.prototype = {
+        toString() {
+          return this.string();
+        },
+        toJSON() {
+          return this[this.model]();
+        },
+        string(places) {
+          let self = this.model in colorString.to ? this : this.rgb();
+          self = self.round(typeof places === "number" ? places : 1);
+          const args = self.valpha === 1 ? self.color : self.color.concat(this.valpha);
+          return colorString.to[self.model](args);
+        },
+        percentString(places) {
+          const self = this.rgb().round(typeof places === "number" ? places : 1);
+          const args = self.valpha === 1 ? self.color : self.color.concat(this.valpha);
+          return colorString.to.rgb.percent(args);
+        },
+        array() {
+          return this.valpha === 1 ? this.color.slice() : this.color.concat(this.valpha);
+        },
+        object() {
+          const result = {};
+          const channels = convert[this.model].channels;
+          const labels = convert[this.model].labels;
+          for (let i3 = 0; i3 < channels; i3++) {
+            result[labels[i3]] = this.color[i3];
+          }
+          if (this.valpha !== 1) {
+            result.alpha = this.valpha;
+          }
+          return result;
+        },
+        unitArray() {
+          const rgb = this.rgb().color;
+          rgb[0] /= 255;
+          rgb[1] /= 255;
+          rgb[2] /= 255;
+          if (this.valpha !== 1) {
+            rgb.push(this.valpha);
+          }
+          return rgb;
+        },
+        unitObject() {
+          const rgb = this.rgb().object();
+          rgb.r /= 255;
+          rgb.g /= 255;
+          rgb.b /= 255;
+          if (this.valpha !== 1) {
+            rgb.alpha = this.valpha;
+          }
+          return rgb;
+        },
+        round(places) {
+          places = Math.max(places || 0, 0);
+          return new Color2(this.color.map(roundToPlace(places)).concat(this.valpha), this.model);
+        },
+        alpha(value) {
+          if (arguments.length > 0) {
+            return new Color2(this.color.concat(Math.max(0, Math.min(1, value))), this.model);
+          }
+          return this.valpha;
+        },
+        red: getset("rgb", 0, maxfn(255)),
+        green: getset("rgb", 1, maxfn(255)),
+        blue: getset("rgb", 2, maxfn(255)),
+        hue: getset(["hsl", "hsv", "hsl", "hwb", "hcg"], 0, (value) => (value % 360 + 360) % 360),
+        saturationl: getset("hsl", 1, maxfn(100)),
+        lightness: getset("hsl", 2, maxfn(100)),
+        saturationv: getset("hsv", 1, maxfn(100)),
+        value: getset("hsv", 2, maxfn(100)),
+        chroma: getset("hcg", 1, maxfn(100)),
+        gray: getset("hcg", 2, maxfn(100)),
+        white: getset("hwb", 1, maxfn(100)),
+        wblack: getset("hwb", 2, maxfn(100)),
+        cyan: getset("cmyk", 0, maxfn(100)),
+        magenta: getset("cmyk", 1, maxfn(100)),
+        yellow: getset("cmyk", 2, maxfn(100)),
+        black: getset("cmyk", 3, maxfn(100)),
+        x: getset("xyz", 0, maxfn(100)),
+        y: getset("xyz", 1, maxfn(100)),
+        z: getset("xyz", 2, maxfn(100)),
+        l: getset("lab", 0, maxfn(100)),
+        a: getset("lab", 1),
+        b: getset("lab", 2),
+        keyword(value) {
+          if (arguments.length > 0) {
+            return new Color2(value);
+          }
+          return convert[this.model].keyword(this.color);
+        },
+        hex(value) {
+          if (arguments.length > 0) {
+            return new Color2(value);
+          }
+          return colorString.to.hex(this.rgb().round().color);
+        },
+        hexa(value) {
+          if (arguments.length > 0) {
+            return new Color2(value);
+          }
+          const rgbArray = this.rgb().round().color;
+          let alphaHex = Math.round(this.valpha * 255).toString(16).toUpperCase();
+          if (alphaHex.length === 1) {
+            alphaHex = "0" + alphaHex;
+          }
+          return colorString.to.hex(rgbArray) + alphaHex;
+        },
+        rgbNumber() {
+          const rgb = this.rgb().color;
+          return (rgb[0] & 255) << 16 | (rgb[1] & 255) << 8 | rgb[2] & 255;
+        },
+        luminosity() {
+          const rgb = this.rgb().color;
+          const lum = [];
+          for (const [i3, element] of rgb.entries()) {
+            const chan = element / 255;
+            lum[i3] = chan <= 0.03928 ? chan / 12.92 : ((chan + 0.055) / 1.055) ** 2.4;
+          }
+          return 0.2126 * lum[0] + 0.7152 * lum[1] + 0.0722 * lum[2];
+        },
+        contrast(color2) {
+          const lum1 = this.luminosity();
+          const lum2 = color2.luminosity();
+          if (lum1 > lum2) {
+            return (lum1 + 0.05) / (lum2 + 0.05);
+          }
+          return (lum2 + 0.05) / (lum1 + 0.05);
+        },
+        level(color2) {
+          const contrastRatio = this.contrast(color2);
+          if (contrastRatio >= 7.1) {
+            return "AAA";
+          }
+          return contrastRatio >= 4.5 ? "AA" : "";
+        },
+        isDark() {
+          const rgb = this.rgb().color;
+          const yiq = (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1e3;
+          return yiq < 128;
+        },
+        isLight() {
+          return !this.isDark();
+        },
+        negate() {
+          const rgb = this.rgb();
+          for (let i3 = 0; i3 < 3; i3++) {
+            rgb.color[i3] = 255 - rgb.color[i3];
+          }
+          return rgb;
+        },
+        lighten(ratio) {
+          const hsl = this.hsl();
+          hsl.color[2] += hsl.color[2] * ratio;
+          return hsl;
+        },
+        darken(ratio) {
+          const hsl = this.hsl();
+          hsl.color[2] -= hsl.color[2] * ratio;
+          return hsl;
+        },
+        saturate(ratio) {
+          const hsl = this.hsl();
+          hsl.color[1] += hsl.color[1] * ratio;
+          return hsl;
+        },
+        desaturate(ratio) {
+          const hsl = this.hsl();
+          hsl.color[1] -= hsl.color[1] * ratio;
+          return hsl;
+        },
+        whiten(ratio) {
+          const hwb = this.hwb();
+          hwb.color[1] += hwb.color[1] * ratio;
+          return hwb;
+        },
+        blacken(ratio) {
+          const hwb = this.hwb();
+          hwb.color[2] += hwb.color[2] * ratio;
+          return hwb;
+        },
+        grayscale() {
+          const rgb = this.rgb().color;
+          const value = rgb[0] * 0.3 + rgb[1] * 0.59 + rgb[2] * 0.11;
+          return Color2.rgb(value, value, value);
+        },
+        fade(ratio) {
+          return this.alpha(this.valpha - this.valpha * ratio);
+        },
+        opaquer(ratio) {
+          return this.alpha(this.valpha + this.valpha * ratio);
+        },
+        rotate(degrees) {
+          const hsl = this.hsl();
+          let hue = hsl.color[0];
+          hue = (hue + degrees) % 360;
+          hue = hue < 0 ? 360 + hue : hue;
+          hsl.color[0] = hue;
+          return hsl;
+        },
+        mix(mixinColor, weight) {
+          if (!mixinColor || !mixinColor.rgb) {
+            throw new Error('Argument to "mix" was not a Color instance, but rather an instance of ' + typeof mixinColor);
+          }
+          const color1 = mixinColor.rgb();
+          const color2 = this.rgb();
+          const p = weight === void 0 ? 0.5 : weight;
+          const w = 2 * p - 1;
+          const a = color1.alpha() - color2.alpha();
+          const w1 = ((w * a === -1 ? w : (w + a) / (1 + w * a)) + 1) / 2;
+          const w2 = 1 - w1;
+          return Color2.rgb(
+            w1 * color1.red() + w2 * color2.red(),
+            w1 * color1.green() + w2 * color2.green(),
+            w1 * color1.blue() + w2 * color2.blue(),
+            color1.alpha() * p + color2.alpha() * (1 - p)
+          );
+        }
+      };
+      for (const model of Object.keys(convert)) {
+        if (skippedModels.includes(model)) {
+          continue;
+        }
+        const channels = convert[model].channels;
+        Color2.prototype[model] = function() {
+          if (this.model === model) {
+            return new Color2(this);
+          }
+          if (arguments.length > 0) {
+            return new Color2(arguments, model);
+          }
+          const newAlpha = typeof arguments[channels] === "number" ? channels : this.valpha;
+          return new Color2(assertArray(convert[this.model][model].raw(this.color)).concat(newAlpha), model);
+        };
+        Color2[model] = function(color) {
+          if (typeof color === "number") {
+            color = zeroArray(_slice.call(arguments), channels);
+          }
+          return new Color2(color, model);
+        };
+      }
+      function roundTo(number, places) {
+        return Number(number.toFixed(places));
+      }
+      function roundToPlace(places) {
+        return function(number) {
+          return roundTo(number, places);
+        };
+      }
+      function getset(model, channel, modifier) {
+        model = Array.isArray(model) ? model : [model];
+        for (const m of model) {
+          (limiters[m] || (limiters[m] = []))[channel] = modifier;
+        }
+        model = model[0];
+        return function(value) {
+          let result;
+          if (arguments.length > 0) {
+            if (modifier) {
+              value = modifier(value);
+            }
+            result = this[model]();
+            result.color[channel] = value;
+            return result;
+          }
+          result = this[model]().color[channel];
+          if (modifier) {
+            result = modifier(result);
+          }
+          return result;
+        };
+      }
+      function maxfn(max) {
+        return function(v) {
+          return Math.max(0, Math.min(max, v));
+        };
+      }
+      function assertArray(value) {
+        return Array.isArray(value) ? value : [value];
+      }
+      function zeroArray(array, length) {
+        for (let i3 = 0; i3 < length; i3++) {
+          if (typeof array[i3] !== "number") {
+            array[i3] = 0;
+          }
+        }
+        return array;
+      }
+      module.exports = Color2;
+    }
+  });
+
+  // src/components/color-picker/color-picker.ts
+  var import_color = __toESM(require_color(), 1);
+  var hasEyeDropper = "EyeDropper" in window;
+  var SlColorPicker = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.formSubmitController = new FormSubmitController(this);
+      this.isSafeValue = false;
+      this.localize = new LocalizeController2(this);
+      this.isDraggingGridHandle = false;
+      this.isEmpty = false;
+      this.inputValue = "";
+      this.hue = 0;
+      this.saturation = 100;
+      this.lightness = 100;
+      this.brightness = 100;
+      this.alpha = 100;
+      this.value = "";
+      this.defaultValue = "";
+      this.label = "";
+      this.format = "hex";
+      this.inline = false;
+      this.size = "medium";
+      this.noFormatToggle = false;
+      this.name = "";
+      this.disabled = false;
+      this.invalid = false;
+      this.hoist = false;
+      this.opacity = false;
+      this.uppercase = false;
+      this.swatches = [
+        "#d0021b",
+        "#f5a623",
+        "#f8e71c",
+        "#8b572a",
+        "#7ed321",
+        "#417505",
+        "#bd10e0",
+        "#9013fe",
+        "#4a90e2",
+        "#50e3c2",
+        "#b8e986",
+        "#000",
+        "#444",
+        "#888",
+        "#ccc",
+        "#fff"
+      ];
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      if (this.value) {
+        this.setColor(this.value);
+        this.inputValue = this.value;
+        this.lastValueEmitted = this.value;
+        this.syncValues();
+      } else {
+        this.isEmpty = true;
+        this.inputValue = "";
+        this.lastValueEmitted = "";
+      }
+    }
+    getFormattedValue(format = "hex") {
+      const currentColor = this.parseColor(
+        `hsla(${this.hue}, ${this.saturation}%, ${this.lightness}%, ${this.alpha / 100})`
+      );
+      if (currentColor === null) {
+        return "";
+      }
+      switch (format) {
+        case "hex":
+          return currentColor.hex;
+        case "hexa":
+          return currentColor.hexa;
+        case "rgb":
+          return currentColor.rgb.string;
+        case "rgba":
+          return currentColor.rgba.string;
+        case "hsl":
+          return currentColor.hsl.string;
+        case "hsla":
+          return currentColor.hsla.string;
+        default:
+          return "";
+      }
+    }
+    getBrightness(lightness) {
+      return clamp(-1 * (200 * lightness / (this.saturation - 200)), 0, 100);
+    }
+    getLightness(brightness) {
+      return clamp((200 - this.saturation) * brightness / 100 * 5 / 10, 0, 100);
+    }
+    reportValidity() {
+      if (!this.inline && this.input.invalid) {
+        return new Promise((resolve) => {
+          this.dropdown.addEventListener(
+            "sl-after-show",
+            () => {
+              this.input.reportValidity();
+              resolve();
+            },
+            { once: true }
+          );
+          this.dropdown.show();
         });
       }
+      return this.input.reportValidity();
+    }
+    setCustomValidity(message) {
+      this.input.setCustomValidity(message);
+      this.invalid = this.input.invalid;
+    }
+    handleCopy() {
+      this.input.select();
+      document.execCommand("copy");
+      this.previewButton.focus();
+      this.previewButton.classList.add("color-picker__preview-color--copied");
+      this.previewButton.addEventListener("animationend", () => {
+        this.previewButton.classList.remove("color-picker__preview-color--copied");
+      });
+    }
+    handleFormatToggle() {
+      const formats = ["hex", "rgb", "hsl"];
+      const nextIndex = (formats.indexOf(this.format) + 1) % formats.length;
+      this.format = formats[nextIndex];
+    }
+    handleAlphaDrag(event) {
+      const container = this.shadowRoot.querySelector(".color-picker__slider.color-picker__alpha");
+      const handle = container.querySelector(".color-picker__slider-handle");
+      const { width } = container.getBoundingClientRect();
+      handle.focus();
+      event.preventDefault();
+      drag(container, {
+        onMove: (x) => {
+          this.alpha = clamp(x / width * 100, 0, 100);
+          this.syncValues();
+        },
+        initialEvent: event
+      });
+    }
+    handleHueDrag(event) {
+      const container = this.shadowRoot.querySelector(".color-picker__slider.color-picker__hue");
+      const handle = container.querySelector(".color-picker__slider-handle");
+      const { width } = container.getBoundingClientRect();
+      handle.focus();
+      event.preventDefault();
+      drag(container, {
+        onMove: (x) => {
+          this.hue = clamp(x / width * 360, 0, 360);
+          this.syncValues();
+        },
+        initialEvent: event
+      });
+    }
+    handleGridDrag(event) {
+      const grid = this.shadowRoot.querySelector(".color-picker__grid");
+      const handle = grid.querySelector(".color-picker__grid-handle");
+      const { width, height } = grid.getBoundingClientRect();
+      handle.focus();
+      event.preventDefault();
+      this.isDraggingGridHandle = true;
+      drag(grid, {
+        onMove: (x, y) => {
+          this.saturation = clamp(x / width * 100, 0, 100);
+          this.brightness = clamp(100 - y / height * 100, 0, 100);
+          this.lightness = this.getLightness(this.brightness);
+          this.syncValues();
+        },
+        onStop: () => this.isDraggingGridHandle = false,
+        initialEvent: event
+      });
+    }
+    handleAlphaKeyDown(event) {
+      const increment = event.shiftKey ? 10 : 1;
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        this.alpha = clamp(this.alpha - increment, 0, 100);
+        this.syncValues();
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        this.alpha = clamp(this.alpha + increment, 0, 100);
+        this.syncValues();
+      }
+      if (event.key === "Home") {
+        event.preventDefault();
+        this.alpha = 0;
+        this.syncValues();
+      }
+      if (event.key === "End") {
+        event.preventDefault();
+        this.alpha = 100;
+        this.syncValues();
+      }
+    }
+    handleHueKeyDown(event) {
+      const increment = event.shiftKey ? 10 : 1;
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        this.hue = clamp(this.hue - increment, 0, 360);
+        this.syncValues();
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        this.hue = clamp(this.hue + increment, 0, 360);
+        this.syncValues();
+      }
+      if (event.key === "Home") {
+        event.preventDefault();
+        this.hue = 0;
+        this.syncValues();
+      }
+      if (event.key === "End") {
+        event.preventDefault();
+        this.hue = 360;
+        this.syncValues();
+      }
+    }
+    handleGridKeyDown(event) {
+      const increment = event.shiftKey ? 10 : 1;
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        this.saturation = clamp(this.saturation - increment, 0, 100);
+        this.lightness = this.getLightness(this.brightness);
+        this.syncValues();
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        this.saturation = clamp(this.saturation + increment, 0, 100);
+        this.lightness = this.getLightness(this.brightness);
+        this.syncValues();
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        this.brightness = clamp(this.brightness + increment, 0, 100);
+        this.lightness = this.getLightness(this.brightness);
+        this.syncValues();
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        this.brightness = clamp(this.brightness - increment, 0, 100);
+        this.lightness = this.getLightness(this.brightness);
+        this.syncValues();
+      }
+    }
+    handleInputChange(event) {
+      const target = event.target;
+      if (this.input.value) {
+        this.setColor(target.value);
+        target.value = this.value;
+      } else {
+        this.value = "";
+      }
+      event.stopPropagation();
+    }
+    handleInputKeyDown(event) {
+      if (event.key === "Enter") {
+        if (this.input.value) {
+          this.setColor(this.input.value);
+          this.input.value = this.value;
+          setTimeout(() => this.input.select());
+        } else {
+          this.hue = 0;
+        }
+      }
+    }
+    normalizeColorString(colorString) {
+      if (/rgba?/i.test(colorString)) {
+        const rgba = colorString.replace(/[^\d.%]/g, " ").split(" ").map((val) => val.trim()).filter((val) => val.length);
+        if (rgba.length < 4) {
+          rgba[3] = "1";
+        }
+        if (rgba[3].indexOf("%") > -1) {
+          rgba[3] = (parseFloat(rgba[3].replace(/%/g, "")) / 100).toString();
+        }
+        return `rgba(${rgba[0]}, ${rgba[1]}, ${rgba[2]}, ${rgba[3]})`;
+      }
+      if (/hsla?/i.test(colorString)) {
+        const hsla = colorString.replace(/[^\d.%]/g, " ").split(" ").map((val) => val.trim()).filter((val) => val.length);
+        if (hsla.length < 4) {
+          hsla[3] = "1";
+        }
+        if (hsla[3].indexOf("%") > -1) {
+          hsla[3] = (parseFloat(hsla[3].replace(/%/g, "")) / 100).toString();
+        }
+        return `hsla(${hsla[0]}, ${hsla[1]}, ${hsla[2]}, ${hsla[3]})`;
+      }
+      if (/^[0-9a-f]+$/i.test(colorString)) {
+        return `#${colorString}`;
+      }
+      return colorString;
+    }
+    parseColor(colorString) {
+      let parsed;
+      colorString = this.normalizeColorString(colorString);
+      try {
+        parsed = (0, import_color.default)(colorString);
+      } catch (e2) {
+        return null;
+      }
+      const hslColor = parsed.hsl();
+      const hsl = {
+        h: hslColor.hue(),
+        s: hslColor.saturationl(),
+        l: hslColor.lightness(),
+        a: hslColor.alpha()
+      };
+      const rgbColor = parsed.rgb();
+      const rgb = {
+        r: rgbColor.red(),
+        g: rgbColor.green(),
+        b: rgbColor.blue(),
+        a: rgbColor.alpha()
+      };
+      const hex = {
+        r: toHex(rgb.r),
+        g: toHex(rgb.g),
+        b: toHex(rgb.b),
+        a: toHex(rgb.a * 255)
+      };
+      return {
+        hsl: {
+          h: hsl.h,
+          s: hsl.s,
+          l: hsl.l,
+          string: this.setLetterCase(`hsl(${Math.round(hsl.h)}, ${Math.round(hsl.s)}%, ${Math.round(hsl.l)}%)`)
+        },
+        hsla: {
+          h: hsl.h,
+          s: hsl.s,
+          l: hsl.l,
+          a: hsl.a,
+          string: this.setLetterCase(
+            `hsla(${Math.round(hsl.h)}, ${Math.round(hsl.s)}%, ${Math.round(hsl.l)}%, ${hsl.a.toFixed(2).toString()})`
+          )
+        },
+        rgb: {
+          r: rgb.r,
+          g: rgb.g,
+          b: rgb.b,
+          string: this.setLetterCase(`rgb(${Math.round(rgb.r)}, ${Math.round(rgb.g)}, ${Math.round(rgb.b)})`)
+        },
+        rgba: {
+          r: rgb.r,
+          g: rgb.g,
+          b: rgb.b,
+          a: rgb.a,
+          string: this.setLetterCase(
+            `rgba(${Math.round(rgb.r)}, ${Math.round(rgb.g)}, ${Math.round(rgb.b)}, ${rgb.a.toFixed(2).toString()})`
+          )
+        },
+        hex: this.setLetterCase(`#${hex.r}${hex.g}${hex.b}`),
+        hexa: this.setLetterCase(`#${hex.r}${hex.g}${hex.b}${hex.a}`)
+      };
+    }
+    setColor(colorString) {
+      const newColor = this.parseColor(colorString);
+      if (newColor === null) {
+        return false;
+      }
+      this.hue = newColor.hsla.h;
+      this.saturation = newColor.hsla.s;
+      this.lightness = newColor.hsla.l;
+      this.brightness = this.getBrightness(newColor.hsla.l);
+      this.alpha = this.opacity ? newColor.hsla.a * 100 : 100;
+      this.syncValues();
+      return true;
+    }
+    setLetterCase(string) {
+      if (typeof string !== "string") {
+        return "";
+      }
+      return this.uppercase ? string.toUpperCase() : string.toLowerCase();
+    }
+    async syncValues() {
+      const currentColor = this.parseColor(
+        `hsla(${this.hue}, ${this.saturation}%, ${this.lightness}%, ${this.alpha / 100})`
+      );
+      if (currentColor === null) {
+        return;
+      }
+      if (this.format === "hsl") {
+        this.inputValue = this.opacity ? currentColor.hsla.string : currentColor.hsl.string;
+      } else if (this.format === "rgb") {
+        this.inputValue = this.opacity ? currentColor.rgba.string : currentColor.rgb.string;
+      } else {
+        this.inputValue = this.opacity ? currentColor.hexa : currentColor.hex;
+      }
+      this.isSafeValue = true;
+      this.value = this.inputValue;
+      await this.updateComplete;
+      this.isSafeValue = false;
+    }
+    handleAfterHide() {
+      this.previewButton.classList.remove("color-picker__preview-color--copied");
+    }
+    handleEyeDropper() {
+      if (!hasEyeDropper) {
+        return;
+      }
+      const eyeDropper = new EyeDropper();
+      eyeDropper.open().then((colorSelectionResult) => this.setColor(colorSelectionResult.sRGBHex)).catch(() => {
+      });
+    }
+    handleFormatChange() {
+      this.syncValues();
+    }
+    handleOpacityChange() {
+      this.alpha = 100;
+    }
+    handleValueChange(oldValue, newValue) {
+      this.isEmpty = !newValue;
+      if (!newValue) {
+        this.hue = 0;
+        this.saturation = 100;
+        this.brightness = 100;
+        this.lightness = this.getLightness(this.brightness);
+        this.alpha = 100;
+      }
+      if (!this.isSafeValue && oldValue !== void 0) {
+        const newColor = this.parseColor(newValue);
+        if (newColor !== null) {
+          this.inputValue = this.value;
+          this.hue = newColor.hsla.h;
+          this.saturation = newColor.hsla.s;
+          this.lightness = newColor.hsla.l;
+          this.brightness = this.getBrightness(newColor.hsla.l);
+          this.alpha = newColor.hsla.a * 100;
+        } else {
+          this.inputValue = oldValue;
+        }
+      }
+      if (this.value !== this.lastValueEmitted) {
+        this.emit("sl-change");
+        this.lastValueEmitted = this.value;
+      }
+    }
+    render() {
+      const gridHandleX = this.saturation;
+      const gridHandleY = 100 - this.brightness;
+      const colorPicker = $`
+      <div
+        part="base"
+        class=${o$3({
+      "color-picker": true,
+      "color-picker--inline": this.inline,
+      "color-picker--disabled": this.disabled
+    })}
+        aria-disabled=${this.disabled ? "true" : "false"}
+        aria-labelledby="label"
+        tabindex=${this.inline ? "0" : "-1"}
+      >
+        ${this.inline ? $`
+              <sl-visually-hidden id="label">
+                <slot name="label">${this.label}</slot>
+              </sl-visually-hidden>
+            ` : null}
 
+        <div
+          part="grid"
+          class="color-picker__grid"
+          style=${i2$1({ backgroundColor: `hsl(${this.hue}deg, 100%, 50%)` })}
+          @mousedown=${this.handleGridDrag}
+          @touchstart=${this.handleGridDrag}
+        >
+          <span
+            part="grid-handle"
+            class=${o$3({
+      "color-picker__grid-handle": true,
+      "color-picker__grid-handle--dragging": this.isDraggingGridHandle
+    })}
+            style=${i2$1({
+      top: `${gridHandleY}%`,
+      left: `${gridHandleX}%`,
+      backgroundColor: `hsla(${this.hue}deg, ${this.saturation}%, ${this.lightness}%)`
+    })}
+            role="application"
+            aria-label="HSL"
+            tabindex=${l$2(this.disabled ? void 0 : "0")}
+            @keydown=${this.handleGridKeyDown}
+          ></span>
+        </div>
+
+        <div class="color-picker__controls">
+          <div class="color-picker__sliders">
+            <div
+              part="slider hue-slider"
+              class="color-picker__hue color-picker__slider"
+              @mousedown=${this.handleHueDrag}
+              @touchstart=${this.handleHueDrag}
+            >
+              <span
+                part="slider-handle"
+                class="color-picker__slider-handle"
+                style=${i2$1({
+      left: `${this.hue === 0 ? 0 : 100 / (360 / this.hue)}%`
+    })}
+                role="slider"
+                aria-label="hue"
+                aria-orientation="horizontal"
+                aria-valuemin="0"
+                aria-valuemax="360"
+                aria-valuenow=${`${Math.round(this.hue)}`}
+                tabindex=${l$2(this.disabled ? void 0 : "0")}
+                @keydown=${this.handleHueKeyDown}
+              ></span>
+            </div>
+
+            ${this.opacity ? $`
+                  <div
+                    part="slider opacity-slider"
+                    class="color-picker__alpha color-picker__slider color-picker__transparent-bg"
+                    @mousedown="${this.handleAlphaDrag}"
+                    @touchstart="${this.handleAlphaDrag}"
+                  >
+                    <div
+                      class="color-picker__alpha-gradient"
+                      style=${i2$1({
+      backgroundImage: `linear-gradient(
+                          to right,
+                          hsl(${this.hue}deg, ${this.saturation}%, ${this.lightness}%, 0%) 0%,
+                          hsl(${this.hue}deg, ${this.saturation}%, ${this.lightness}%) 100%
+                        )`
+    })}
+                    ></div>
+                    <span
+                      part="slider-handle"
+                      class="color-picker__slider-handle"
+                      style=${i2$1({
+      left: `${this.alpha}%`
+    })}
+                      role="slider"
+                      aria-label="alpha"
+                      aria-orientation="horizontal"
+                      aria-valuemin="0"
+                      aria-valuemax="100"
+                      aria-valuenow=${Math.round(this.alpha)}
+                      tabindex=${l$2(this.disabled ? void 0 : "0")}
+                      @keydown=${this.handleAlphaKeyDown}
+                    ></span>
+                  </div>
+                ` : ""}
+          </div>
+
+          <button
+            type="button"
+            part="preview"
+            class="color-picker__preview color-picker__transparent-bg"
+            aria-label=${this.localize.term("copy")}
+            style=${i2$1({
+      "--preview-color": `hsla(${this.hue}deg, ${this.saturation}%, ${this.lightness}%, ${this.alpha / 100})`
+    })}
+            @click=${this.handleCopy}
+          ></button>
+        </div>
+
+        <div class="color-picker__user-input" aria-live="polite">
+          <sl-input
+            part="input"
+            type="text"
+            name=${this.name}
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            .value=${l$3(this.isEmpty ? "" : this.inputValue)}
+            ?disabled=${this.disabled}
+            aria-label=${this.localize.term("currentValue")}
+            @keydown=${this.handleInputKeyDown}
+            @sl-change=${this.handleInputChange}
+          ></sl-input>
+
+          <sl-button-group>
+            ${!this.noFormatToggle ? $`
+                  <sl-button
+                    part="format-button"
+                    aria-label=${this.localize.term("toggleColorFormat")}
+                    exportparts="
+                      base:format-button__base,
+                      prefix:format-button__prefix,
+                      label:format-button__label,
+                      suffix:format-button__suffix,
+                      caret:format-button__caret
+                    "
+                    @click=${this.handleFormatToggle}
+                  >
+                    ${this.setLetterCase(this.format)}
+                  </sl-button>
+                ` : ""}
+            ${hasEyeDropper ? $`
+                  <sl-button
+                    part="eye-dropper-button"
+                    exportparts="
+                      base:eye-dropper-button__base,
+                      prefix:eye-dropper-button__prefix,
+                      label:eye-dropper-button__label,
+                      suffix:eye-dropper-button__suffix,
+                      caret:eye-dropper-button__caret
+                    "
+                    @click=${this.handleEyeDropper}
+                  >
+                    <sl-icon
+                      library="system"
+                      name="eyedropper"
+                      label=${this.localize.term("selectAColorFromTheScreen")}
+                    ></sl-icon>
+                  </sl-button>
+                ` : ""}
+          </sl-button-group>
+        </div>
+
+        ${this.swatches.length > 0 ? $`
+              <div part="swatches" class="color-picker__swatches">
+                ${this.swatches.map((swatch) => {
+      return $`
+                    <div
+                      part="swatch"
+                      class="color-picker__swatch color-picker__transparent-bg"
+                      tabindex=${l$2(this.disabled ? void 0 : "0")}
+                      role="button"
+                      aria-label=${swatch}
+                      @click=${() => !this.disabled && this.setColor(swatch)}
+                      @keydown=${(event) => !this.disabled && event.key === "Enter" && this.setColor(swatch)}
+                    >
+                      <div class="color-picker__swatch-color" style=${i2$1({ backgroundColor: swatch })}></div>
+                    </div>
+                  `;
+    })}
+              </div>
+            ` : ""}
+      </div>
+    `;
+      if (this.inline) {
+        return colorPicker;
+      }
+      return $`
+      <sl-dropdown
+        class="color-dropdown"
+        aria-disabled=${this.disabled ? "true" : "false"}
+        .containing-element=${this}
+        ?disabled=${this.disabled}
+        ?hoist=${this.hoist}
+        @sl-after-hide=${this.handleAfterHide}
+      >
+        <button
+          part="trigger"
+          slot="trigger"
+          class=${o$3({
+      "color-dropdown__trigger": true,
+      "color-dropdown__trigger--disabled": this.disabled,
+      "color-dropdown__trigger--small": this.size === "small",
+      "color-dropdown__trigger--medium": this.size === "medium",
+      "color-dropdown__trigger--large": this.size === "large",
+      "color-dropdown__trigger--empty": this.isEmpty,
+      "color-picker__transparent-bg": true
+    })}
+          style=${i2$1({
+      color: `hsla(${this.hue}deg, ${this.saturation}%, ${this.lightness}%, ${this.alpha / 100})`
+    })}
+          type="button"
+        >
+          <sl-visually-hidden>
+            <slot name="label">${this.label}</slot>
+          </sl-visually-hidden>
+        </button>
+        ${colorPicker}
+      </sl-dropdown>
+    `;
+    }
+  };
+  SlColorPicker.styles = color_picker_styles_default;
+  __decorateClass([
+    i2$2('[part="input"]')
+  ], SlColorPicker.prototype, "input", 2);
+  __decorateClass([
+    i2$2('[part="preview"]')
+  ], SlColorPicker.prototype, "previewButton", 2);
+  __decorateClass([
+    i2$2(".color-dropdown")
+  ], SlColorPicker.prototype, "dropdown", 2);
+  __decorateClass([
+    t$1()
+  ], SlColorPicker.prototype, "isDraggingGridHandle", 2);
+  __decorateClass([
+    t$1()
+  ], SlColorPicker.prototype, "isEmpty", 2);
+  __decorateClass([
+    t$1()
+  ], SlColorPicker.prototype, "inputValue", 2);
+  __decorateClass([
+    t$1()
+  ], SlColorPicker.prototype, "hue", 2);
+  __decorateClass([
+    t$1()
+  ], SlColorPicker.prototype, "saturation", 2);
+  __decorateClass([
+    t$1()
+  ], SlColorPicker.prototype, "lightness", 2);
+  __decorateClass([
+    t$1()
+  ], SlColorPicker.prototype, "brightness", 2);
+  __decorateClass([
+    t$1()
+  ], SlColorPicker.prototype, "alpha", 2);
+  __decorateClass([
+    e$1()
+  ], SlColorPicker.prototype, "value", 2);
+  __decorateClass([
+    defaultValue()
+  ], SlColorPicker.prototype, "defaultValue", 2);
+  __decorateClass([
+    e$1()
+  ], SlColorPicker.prototype, "label", 2);
+  __decorateClass([
+    e$1()
+  ], SlColorPicker.prototype, "format", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlColorPicker.prototype, "inline", 2);
+  __decorateClass([
+    e$1()
+  ], SlColorPicker.prototype, "size", 2);
+  __decorateClass([
+    e$1({ attribute: "no-format-toggle", type: Boolean })
+  ], SlColorPicker.prototype, "noFormatToggle", 2);
+  __decorateClass([
+    e$1()
+  ], SlColorPicker.prototype, "name", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlColorPicker.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlColorPicker.prototype, "invalid", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlColorPicker.prototype, "hoist", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlColorPicker.prototype, "opacity", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlColorPicker.prototype, "uppercase", 2);
+  __decorateClass([
+    e$1({ attribute: false })
+  ], SlColorPicker.prototype, "swatches", 2);
+  __decorateClass([
+    watch("format", { waitUntilFirstUpdate: true })
+  ], SlColorPicker.prototype, "handleFormatChange", 1);
+  __decorateClass([
+    watch("opacity", { waitUntilFirstUpdate: true })
+  ], SlColorPicker.prototype, "handleOpacityChange", 1);
+  __decorateClass([
+    watch("value")
+  ], SlColorPicker.prototype, "handleValueChange", 1);
+  SlColorPicker = __decorateClass([
+    n$1("sl-color-picker")
+  ], SlColorPicker);
+  function toHex(value) {
+    const hex = Math.round(value).toString(16);
+    return hex.length === 1 ? `0${hex}` : hex;
+  }
+
+  // src/components/visually-hidden/visually-hidden.styles.ts
+  var visually_hidden_styles_default = r$2`
+  ${component_styles_default}
+
+  :host(:not(:focus-within)) {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    clip: rect(0 0 0 0) !important;
+    clip-path: inset(50%) !important;
+    border: none !important;
+    overflow: hidden !important;
+    white-space: nowrap !important;
+    padding: 0 !important;
+  }
+`;
+
+  // src/components/visually-hidden/visually-hidden.ts
+  var SlVisuallyHidden = class extends ShoelaceElement {
+    render() {
+      return $` <slot></slot> `;
+    }
+  };
+  SlVisuallyHidden.styles = visually_hidden_styles_default;
+  SlVisuallyHidden = __decorateClass([
+    n$1("sl-visually-hidden")
+  ], SlVisuallyHidden);
+
+  // src/components/input/input.styles.ts
+  var input_styles_default = r$2`
+  ${component_styles_default}
+  ${form_control_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .input {
+    flex: 1 1 auto;
+    display: inline-flex;
+    align-items: stretch;
+    justify-content: start;
+    position: relative;
+    width: 100%;
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-input-font-weight);
+    letter-spacing: var(--sl-input-letter-spacing);
+    vertical-align: middle;
+    overflow: hidden;
+    cursor: text;
+    transition: var(--sl-transition-fast) color, var(--sl-transition-fast) border, var(--sl-transition-fast) box-shadow,
+      var(--sl-transition-fast) background-color;
+  }
+
+  /* Standard inputs */
+  .input--standard {
+    background-color: var(--sl-input-background-color);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+  }
+
+  .input--standard:hover:not(.input--disabled) {
+    background-color: var(--sl-input-background-color-hover);
+    border-color: var(--sl-input-border-color-hover);
+  }
+
+  .input--standard.input--focused:not(.input--disabled) {
+    background-color: var(--sl-input-background-color-focus);
+    border-color: var(--sl-input-border-color-focus);
+    box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-input-focus-ring-color);
+  }
+
+  .input--standard.input--focused:not(.input--disabled) .input__control {
+    color: var(--sl-input-color-focus);
+  }
+
+  .input--standard.input--disabled {
+    background-color: var(--sl-input-background-color-disabled);
+    border-color: var(--sl-input-border-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .input--standard.input--disabled .input__control {
+    color: var(--sl-input-color-disabled);
+  }
+
+  .input--standard.input--disabled .input__control::placeholder {
+    color: var(--sl-input-placeholder-color-disabled);
+  }
+
+  /* Filled inputs */
+  .input--filled {
+    border: none;
+    background-color: var(--sl-input-filled-background-color);
+    color: var(--sl-input-color);
+  }
+
+  .input--filled:hover:not(.input--disabled) {
+    background-color: var(--sl-input-filled-background-color-hover);
+  }
+
+  .input--filled.input--focused:not(.input--disabled) {
+    background-color: var(--sl-input-filled-background-color-focus);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .input--filled.input--disabled {
+    background-color: var(--sl-input-filled-background-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .input__control {
+    flex: 1 1 auto;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    min-width: 0;
+    height: 100%;
+    color: var(--sl-input-color);
+    border: none;
+    background: none;
+    box-shadow: none;
+    padding: 0;
+    margin: 0;
+    cursor: inherit;
+    -webkit-appearance: none;
+  }
+
+  .input__control::-webkit-search-decoration,
+  .input__control::-webkit-search-cancel-button,
+  .input__control::-webkit-search-results-button,
+  .input__control::-webkit-search-results-decoration {
+    -webkit-appearance: none;
+  }
+
+  .input__control:-webkit-autofill,
+  .input__control:-webkit-autofill:hover,
+  .input__control:-webkit-autofill:focus,
+  .input__control:-webkit-autofill:active {
+    box-shadow: 0 0 0 var(--sl-input-height-large) var(--sl-input-background-color-hover) inset !important;
+    -webkit-text-fill-color: var(--sl-color-primary-500);
+    caret-color: var(--sl-input-color);
+  }
+
+  .input--filled .input__control:-webkit-autofill,
+  .input--filled .input__control:-webkit-autofill:hover,
+  .input--filled .input__control:-webkit-autofill:focus,
+  .input--filled .input__control:-webkit-autofill:active {
+    box-shadow: 0 0 0 var(--sl-input-height-large) var(--sl-input-filled-background-color) inset !important;
+  }
+
+  .input__control::placeholder {
+    color: var(--sl-input-placeholder-color);
+    user-select: none;
+  }
+
+  .input:hover:not(.input--disabled) .input__control {
+    color: var(--sl-input-color-hover);
+  }
+
+  .input__control:focus {
+    outline: none;
+  }
+
+  .input__prefix,
+  .input__suffix {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    cursor: default;
+  }
+
+  .input__prefix ::slotted(sl-icon),
+  .input__suffix ::slotted(sl-icon) {
+    color: var(--sl-input-icon-color);
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .input--small {
+    border-radius: var(--sl-input-border-radius-small);
+    font-size: var(--sl-input-font-size-small);
+    height: var(--sl-input-height-small);
+  }
+
+  .input--small .input__control {
+    height: calc(var(--sl-input-height-small) - var(--sl-input-border-width) * 2);
+    padding: 0 var(--sl-input-spacing-small);
+  }
+
+  .input--small .input__clear,
+  .input--small .input__password-toggle {
+    width: calc(1em + var(--sl-input-spacing-small) * 2);
+  }
+
+  .input--small .input__prefix ::slotted(*) {
+    padding-inline-start: var(--sl-input-spacing-small);
+  }
+
+  .input--small .input__suffix ::slotted(*) {
+    padding-inline-end: var(--sl-input-spacing-small);
+  }
+
+  .input--medium {
+    border-radius: var(--sl-input-border-radius-medium);
+    font-size: var(--sl-input-font-size-medium);
+    height: var(--sl-input-height-medium);
+  }
+
+  .input--medium .input__control {
+    height: calc(var(--sl-input-height-medium) - var(--sl-input-border-width) * 2);
+    padding: 0 var(--sl-input-spacing-medium);
+  }
+
+  .input--medium .input__clear,
+  .input--medium .input__password-toggle {
+    width: calc(1em + var(--sl-input-spacing-medium) * 2);
+  }
+
+  .input--medium .input__prefix ::slotted(*) {
+    padding-inline-start: var(--sl-input-spacing-medium);
+  }
+
+  .input--medium .input__suffix ::slotted(*) {
+    padding-inline-end: var(--sl-input-spacing-medium);
+  }
+
+  .input--large {
+    border-radius: var(--sl-input-border-radius-large);
+    font-size: var(--sl-input-font-size-large);
+    height: var(--sl-input-height-large);
+  }
+
+  .input--large .input__control {
+    height: calc(var(--sl-input-height-large) - var(--sl-input-border-width) * 2);
+    padding: 0 var(--sl-input-spacing-large);
+  }
+
+  .input--large .input__clear,
+  .input--large .input__password-toggle {
+    width: calc(1em + var(--sl-input-spacing-large) * 2);
+  }
+
+  .input--large .input__prefix ::slotted(*) {
+    padding-inline-start: var(--sl-input-spacing-large);
+  }
+
+  .input--large .input__suffix ::slotted(*) {
+    padding-inline-end: var(--sl-input-spacing-large);
+  }
+
+  /*
+   * Pill modifier
+   */
+
+  .input--pill.input--small {
+    border-radius: var(--sl-input-height-small);
+  }
+
+  .input--pill.input--medium {
+    border-radius: var(--sl-input-height-medium);
+  }
+
+  .input--pill.input--large {
+    border-radius: var(--sl-input-height-large);
+  }
+
+  /*
+   * Clearable + Password Toggle
+   */
+
+  .input__clear,
+  .input__password-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: inherit;
+    color: var(--sl-input-icon-color);
+    border: none;
+    background: none;
+    padding: 0;
+    transition: var(--sl-transition-fast) color;
+    cursor: pointer;
+  }
+
+  .input__clear:hover,
+  .input__password-toggle:hover {
+    color: var(--sl-input-icon-color-hover);
+  }
+
+  .input__clear:focus,
+  .input__password-toggle:focus {
+    outline: none;
+  }
+
+  .input--empty .input__clear {
+    visibility: hidden;
+  }
+
+  /* Don't show the browser's password toggle in Edge */
+  ::-ms-reveal {
+    display: none;
+  }
+
+  /* Hide Firefox's clear button on date and time inputs */
+  .input--is-firefox input[type='date'],
+  .input--is-firefox input[type='time'] {
+    clip-path: inset(0 2em 0 0);
+  }
+
+  /* Hide the built-in number spinner */
+  .input--no-spin-buttons input[type='number']::-webkit-outer-spin-button,
+  .input--no-spin-buttons input[type='number']::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    display: none;
+  }
+
+  .input--no-spin-buttons input[type='number'] {
+    -moz-appearance: textfield;
+  }
+`;
+
+  // src/components/input/input.ts
+  var _a;
+  var isChromium = (_a = navigator.userAgentData) == null ? void 0 : _a.brands.some((b) => b.brand.includes("Chromium"));
+  var isFirefox = isChromium ? false : navigator.userAgent.includes("Firefox");
+  var SlInput = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.formSubmitController = new FormSubmitController(this);
+      this.hasSlotController = new HasSlotController(this, "help-text", "label");
+      this.localize = new LocalizeController2(this);
+      this.hasFocus = false;
+      this.type = "text";
+      this.size = "medium";
+      this.value = "";
+      this.defaultValue = "";
+      this.filled = false;
+      this.pill = false;
+      this.label = "";
+      this.helpText = "";
+      this.clearable = false;
+      this.passwordToggle = false;
+      this.passwordVisible = false;
+      this.noSpinButtons = false;
+      this.disabled = false;
+      this.readonly = false;
+      this.required = false;
+      this.invalid = false;
+    }
+    get valueAsDate() {
+      var _a2, _b;
+      return (_b = (_a2 = this.input) == null ? void 0 : _a2.valueAsDate) != null ? _b : null;
+    }
+    set valueAsDate(newValue) {
+      const input = document.createElement("input");
+      input.type = "date";
+      input.valueAsDate = newValue;
+      this.value = input.value;
+    }
+    get valueAsNumber() {
+      var _a2, _b;
+      return (_b = (_a2 = this.input) == null ? void 0 : _a2.valueAsNumber) != null ? _b : parseFloat(this.value);
+    }
+    set valueAsNumber(newValue) {
+      const input = document.createElement("input");
+      input.type = "number";
+      input.valueAsNumber = newValue;
+      this.value = input.value;
+    }
+    firstUpdated() {
+      this.invalid = !this.input.checkValidity();
+    }
+    focus(options) {
+      this.input.focus(options);
+    }
+    blur() {
+      this.input.blur();
+    }
+    select() {
+      this.input.select();
+    }
+    setSelectionRange(selectionStart, selectionEnd, selectionDirection = "none") {
+      this.input.setSelectionRange(selectionStart, selectionEnd, selectionDirection);
+    }
+    setRangeText(replacement, start, end, selectMode = "preserve") {
+      this.input.setRangeText(replacement, start, end, selectMode);
+      if (this.value !== this.input.value) {
+        this.value = this.input.value;
+        this.emit("sl-input");
+        this.emit("sl-change");
+      }
+    }
+    reportValidity() {
+      return this.input.reportValidity();
+    }
+    setCustomValidity(message) {
+      this.input.setCustomValidity(message);
+      this.invalid = !this.input.checkValidity();
+    }
+    handleBlur() {
+      this.hasFocus = false;
+      this.emit("sl-blur");
+    }
+    handleChange() {
+      this.value = this.input.value;
+      this.emit("sl-change");
+    }
+    handleClearClick(event) {
+      this.value = "";
+      this.emit("sl-clear");
+      this.emit("sl-input");
+      this.emit("sl-change");
+      this.input.focus();
+      event.stopPropagation();
+    }
+    handleDisabledChange() {
+      this.input.disabled = this.disabled;
+      this.invalid = !this.input.checkValidity();
+    }
+    handleStepChange() {
+      this.input.step = String(this.step);
+      this.invalid = !this.input.checkValidity();
+    }
+    handleFocus() {
+      this.hasFocus = true;
+      this.emit("sl-focus");
+    }
+    handleInput() {
+      this.value = this.input.value;
+      this.emit("sl-input");
+    }
+    handleInvalid() {
+      this.invalid = true;
+    }
+    handleKeyDown(event) {
+      const hasModifier = event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+      if (event.key === "Enter" && !hasModifier) {
+        setTimeout(() => {
+          if (!event.defaultPrevented) {
+            this.formSubmitController.submit();
+          }
+        });
+      }
+    }
+    handlePasswordToggle() {
+      this.passwordVisible = !this.passwordVisible;
+    }
+    handleValueChange() {
+      this.invalid = !this.input.checkValidity();
+    }
+    render() {
+      const hasLabelSlot = this.hasSlotController.test("label");
+      const hasHelpTextSlot = this.hasSlotController.test("help-text");
+      const hasLabel = this.label ? true : !!hasLabelSlot;
+      const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
+      const hasClearIcon = this.clearable && !this.disabled && !this.readonly && (typeof this.value === "number" || this.value.length > 0);
+      return $`
+      <div
+        part="form-control"
+        class=${o$3({
+      "form-control": true,
+      "form-control--small": this.size === "small",
+      "form-control--medium": this.size === "medium",
+      "form-control--large": this.size === "large",
+      "form-control--has-label": hasLabel,
+      "form-control--has-help-text": hasHelpText
+    })}
+      >
+        <label
+          part="form-control-label"
+          class="form-control__label"
+          for="input"
+          aria-hidden=${hasLabel ? "false" : "true"}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <div
+            part="base"
+            class=${o$3({
+      input: true,
+      "input--small": this.size === "small",
+      "input--medium": this.size === "medium",
+      "input--large": this.size === "large",
+      "input--pill": this.pill,
+      "input--standard": !this.filled,
+      "input--filled": this.filled,
+      "input--disabled": this.disabled,
+      "input--focused": this.hasFocus,
+      "input--empty": !this.value,
+      "input--invalid": this.invalid,
+      "input--no-spin-buttons": this.noSpinButtons,
+      "input--is-firefox": isFirefox
+    })}
+          >
+            <span part="prefix" class="input__prefix">
+              <slot name="prefix"></slot>
+            </span>
+
+            <input
+              part="input"
+              id="input"
+              class="input__control"
+              type=${this.type === "password" && this.passwordVisible ? "text" : this.type}
+              name=${l$2(this.name)}
+              ?disabled=${this.disabled}
+              ?readonly=${this.readonly}
+              ?required=${this.required}
+              placeholder=${l$2(this.placeholder)}
+              minlength=${l$2(this.minlength)}
+              maxlength=${l$2(this.maxlength)}
+              min=${l$2(this.min)}
+              max=${l$2(this.max)}
+              step=${l$2(this.step)}
+              .value=${l$3(this.value)}
+              autocapitalize=${l$2(this.type === "password" ? "off" : this.autocapitalize)}
+              autocomplete=${l$2(this.type === "password" ? "off" : this.autocomplete)}
+              autocorrect=${l$2(this.type === "password" ? "off" : this.autocorrect)}
+              ?autofocus=${this.autofocus}
+              spellcheck=${l$2(this.spellcheck)}
+              pattern=${l$2(this.pattern)}
+              enterkeyhint=${l$2(this.enterkeyhint)}
+              inputmode=${l$2(this.inputmode)}
+              aria-describedby="help-text"
+              aria-invalid=${this.invalid ? "true" : "false"}
+              @change=${this.handleChange}
+              @input=${this.handleInput}
+              @invalid=${this.handleInvalid}
+              @keydown=${this.handleKeyDown}
+              @focus=${this.handleFocus}
+              @blur=${this.handleBlur}
+            />
+
+            ${hasClearIcon ? $`
+                  <button
+                    part="clear-button"
+                    class="input__clear"
+                    type="button"
+                    aria-label=${this.localize.term("clearEntry")}
+                    @click=${this.handleClearClick}
+                    tabindex="-1"
+                  >
+                    <slot name="clear-icon">
+                      <sl-icon name="x-circle-fill" library="system"></sl-icon>
+                    </slot>
+                  </button>
+                ` : ""}
+            ${this.passwordToggle && !this.disabled ? $`
+                  <button
+                    part="password-toggle-button"
+                    class="input__password-toggle"
+                    type="button"
+                    aria-label=${this.localize.term(this.passwordVisible ? "hidePassword" : "showPassword")}
+                    @click=${this.handlePasswordToggle}
+                    tabindex="-1"
+                  >
+                    ${this.passwordVisible ? $`
+                          <slot name="show-password-icon">
+                            <sl-icon name="eye-slash" library="system"></sl-icon>
+                          </slot>
+                        ` : $`
+                          <slot name="hide-password-icon">
+                            <sl-icon name="eye" library="system"></sl-icon>
+                          </slot>
+                        `}
+                  </button>
+                ` : ""}
+
+            <span part="suffix" class="input__suffix">
+              <slot name="suffix"></slot>
+            </span>
+          </div>
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${hasHelpText ? "false" : "true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlInput.styles = input_styles_default;
+  __decorateClass([
+    i2$2(".input__control")
+  ], SlInput.prototype, "input", 2);
+  __decorateClass([
+    t$1()
+  ], SlInput.prototype, "hasFocus", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlInput.prototype, "type", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlInput.prototype, "size", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "name", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "value", 2);
+  __decorateClass([
+    defaultValue()
+  ], SlInput.prototype, "defaultValue", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlInput.prototype, "filled", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlInput.prototype, "pill", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "label", 2);
+  __decorateClass([
+    e$1({ attribute: "help-text" })
+  ], SlInput.prototype, "helpText", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlInput.prototype, "clearable", 2);
+  __decorateClass([
+    e$1({ attribute: "password-toggle", type: Boolean })
+  ], SlInput.prototype, "passwordToggle", 2);
+  __decorateClass([
+    e$1({ attribute: "password-visible", type: Boolean })
+  ], SlInput.prototype, "passwordVisible", 2);
+  __decorateClass([
+    e$1({ attribute: "no-spin-buttons", type: Boolean })
+  ], SlInput.prototype, "noSpinButtons", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "placeholder", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlInput.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlInput.prototype, "readonly", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlInput.prototype, "minlength", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlInput.prototype, "maxlength", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "min", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "max", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "step", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "pattern", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlInput.prototype, "required", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlInput.prototype, "invalid", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "autocapitalize", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "autocorrect", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "autocomplete", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlInput.prototype, "autofocus", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "enterkeyhint", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlInput.prototype, "spellcheck", 2);
+  __decorateClass([
+    e$1()
+  ], SlInput.prototype, "inputmode", 2);
+  __decorateClass([
+    watch("disabled", { waitUntilFirstUpdate: true })
+  ], SlInput.prototype, "handleDisabledChange", 1);
+  __decorateClass([
+    watch("step", { waitUntilFirstUpdate: true })
+  ], SlInput.prototype, "handleStepChange", 1);
+  __decorateClass([
+    watch("value", { waitUntilFirstUpdate: true })
+  ], SlInput.prototype, "handleValueChange", 1);
+  SlInput = __decorateClass([
+    n$1("sl-input")
+  ], SlInput);
+
+  // src/components/dropdown/dropdown.styles.ts
+  var dropdown_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .dropdown::part(popup) {
+    z-index: var(--sl-z-index-dropdown);
+  }
+
+  .dropdown[data-current-placement^='top']::part(popup) {
+    transform-origin: bottom;
+  }
+
+  .dropdown[data-current-placement^='bottom']::part(popup) {
+    transform-origin: top;
+  }
+
+  .dropdown[data-current-placement^='left']::part(popup) {
+    transform-origin: right;
+  }
+
+  .dropdown[data-current-placement^='right']::part(popup) {
+    transform-origin: left;
+  }
+
+  .dropdown__trigger {
+    display: block;
+  }
+
+  .dropdown__panel {
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+    font-weight: var(--sl-font-weight-normal);
+    color: var(--color);
+    box-shadow: var(--sl-shadow-large);
+    pointer-events: none;
+  }
+
+  .dropdown--open .dropdown__panel {
+    pointer-events: all;
+  }
+
+  /* When users slot a menu, make sure it conforms to the popup's auto-size */
+  ::slotted(sl-menu) {
+    max-width: var(--auto-size-available-width) !important;
+    max-height: var(--auto-size-available-height) !important;
+  }
+`;
+
+  // src/components/dropdown/dropdown.ts
+  var SlDropdown = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.open = false;
+      this.placement = "bottom-start";
+      this.disabled = false;
+      this.stayOpenOnSelect = false;
+      this.distance = 0;
+      this.skidding = 0;
+      this.hoist = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.handleMenuItemActivate = this.handleMenuItemActivate.bind(this);
+      this.handlePanelSelect = this.handlePanelSelect.bind(this);
+      this.handleDocumentKeyDown = this.handleDocumentKeyDown.bind(this);
+      this.handleDocumentMouseDown = this.handleDocumentMouseDown.bind(this);
+      if (!this.containingElement) {
+        this.containingElement = this;
+      }
+    }
+    firstUpdated() {
+      this.panel.hidden = !this.open;
+      if (this.open) {
+        this.addOpenListeners();
+        this.popup.active = true;
+      }
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.removeOpenListeners();
+      this.hide();
+    }
+    focusOnTrigger() {
+      const slot = this.trigger.querySelector("slot");
+      const trigger = slot.assignedElements({ flatten: true })[0];
+      if (typeof (trigger == null ? void 0 : trigger.focus) === "function") {
+        trigger.focus();
+      }
+    }
+    getMenu() {
+      const slot = this.panel.querySelector("slot");
+      return slot.assignedElements({ flatten: true }).find((el) => el.tagName.toLowerCase() === "sl-menu");
+    }
+    handleDocumentKeyDown(event) {
+      var _a;
+      if (event.key === "Escape") {
+        this.hide();
+        this.focusOnTrigger();
+        return;
+      }
+      if (event.key === "Tab") {
+        if (this.open && ((_a = document.activeElement) == null ? void 0 : _a.tagName.toLowerCase()) === "sl-menu-item") {
+          event.preventDefault();
+          this.hide();
+          this.focusOnTrigger();
+          return;
+        }
+        setTimeout(() => {
+          var _a2, _b, _c;
+          const activeElement = ((_a2 = this.containingElement) == null ? void 0 : _a2.getRootNode()) instanceof ShadowRoot ? (_c = (_b = document.activeElement) == null ? void 0 : _b.shadowRoot) == null ? void 0 : _c.activeElement : document.activeElement;
+          if (!this.containingElement || (activeElement == null ? void 0 : activeElement.closest(this.containingElement.tagName.toLowerCase())) !== this.containingElement) {
+            this.hide();
+          }
+        });
+      }
+    }
+    handleDocumentMouseDown(event) {
+      const path = event.composedPath();
+      if (this.containingElement && !path.includes(this.containingElement)) {
+        this.hide();
+      }
+    }
+    handleMenuItemActivate(event) {
+      const item = event.target;
+      scrollIntoView(item, this.panel);
+    }
+    handlePanelSelect(event) {
+      const target = event.target;
+      if (!this.stayOpenOnSelect && target.tagName.toLowerCase() === "sl-menu") {
+        this.hide();
+        this.focusOnTrigger();
+      }
+    }
+    handleTriggerClick() {
+      if (this.open) {
+        this.hide();
+      } else {
+        this.show();
+      }
+    }
+    handleTriggerKeyDown(event) {
+      if (event.key === "Escape") {
+        this.focusOnTrigger();
+        this.hide();
+        return;
+      }
+      if ([" ", "Enter"].includes(event.key)) {
+        event.preventDefault();
+        this.handleTriggerClick();
+        return;
+      }
+      const menu = this.getMenu();
+      if (menu) {
+        const menuItems = menu.defaultSlot.assignedElements({ flatten: true });
+        const firstMenuItem = menuItems[0];
+        const lastMenuItem = menuItems[menuItems.length - 1];
+        if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+          event.preventDefault();
+          if (!this.open) {
+            this.show();
+          }
+          if (menuItems.length > 0) {
+            requestAnimationFrame(() => {
+              if (event.key === "ArrowDown" || event.key === "Home") {
+                menu.setCurrentItem(firstMenuItem);
+                firstMenuItem.focus();
+              }
+              if (event.key === "ArrowUp" || event.key === "End") {
+                menu.setCurrentItem(lastMenuItem);
+                lastMenuItem.focus();
+              }
+            });
+          }
+        }
+        const ignoredKeys = ["Tab", "Shift", "Meta", "Ctrl", "Alt"];
+        if (this.open && !ignoredKeys.includes(event.key)) {
+          menu.typeToSelect(event);
+        }
+      }
+    }
+    handleTriggerKeyUp(event) {
+      if (event.key === " ") {
+        event.preventDefault();
+      }
+    }
+    handleTriggerSlotChange() {
+      this.updateAccessibleTrigger();
+    }
+    updateAccessibleTrigger() {
+      const slot = this.trigger.querySelector("slot");
+      const assignedElements = slot.assignedElements({ flatten: true });
+      const accessibleTrigger = assignedElements.find((el) => getTabbableBoundary(el).start);
+      let target;
+      if (accessibleTrigger) {
+        switch (accessibleTrigger.tagName.toLowerCase()) {
+          case "sl-button":
+          case "sl-icon-button":
+            target = accessibleTrigger.button;
+            break;
+          default:
+            target = accessibleTrigger;
+        }
+        target.setAttribute("aria-haspopup", "true");
+        target.setAttribute("aria-expanded", this.open ? "true" : "false");
+      }
+    }
+    async show() {
+      if (this.open) {
+        return void 0;
+      }
+      this.open = true;
+      return waitForEvent(this, "sl-after-show");
+    }
+    async hide() {
+      if (!this.open) {
+        return void 0;
+      }
+      this.open = false;
+      return waitForEvent(this, "sl-after-hide");
+    }
+    reposition() {
+      this.popup.reposition();
+    }
+    addOpenListeners() {
+      this.panel.addEventListener("sl-activate", this.handleMenuItemActivate);
+      this.panel.addEventListener("sl-select", this.handlePanelSelect);
+      document.addEventListener("keydown", this.handleDocumentKeyDown);
+      document.addEventListener("mousedown", this.handleDocumentMouseDown);
+    }
+    removeOpenListeners() {
+      this.panel.removeEventListener("sl-activate", this.handleMenuItemActivate);
+      this.panel.removeEventListener("sl-select", this.handlePanelSelect);
+      document.removeEventListener("keydown", this.handleDocumentKeyDown);
+      document.removeEventListener("mousedown", this.handleDocumentMouseDown);
+    }
+    async handleOpenChange() {
+      if (this.disabled) {
+        this.open = false;
+        return;
+      }
+      this.updateAccessibleTrigger();
+      if (this.open) {
+        this.emit("sl-show");
+        this.addOpenListeners();
+        await stopAnimations(this);
+        this.panel.hidden = false;
+        this.popup.active = true;
+        const { keyframes, options } = getAnimation(this, "dropdown.show", { dir: this.localize.dir() });
+        await animateTo(this.popup.popup, keyframes, options);
+        this.emit("sl-after-show");
+      } else {
+        this.emit("sl-hide");
+        this.removeOpenListeners();
+        await stopAnimations(this);
+        const { keyframes, options } = getAnimation(this, "dropdown.hide", { dir: this.localize.dir() });
+        await animateTo(this.popup.popup, keyframes, options);
+        this.panel.hidden = true;
+        this.popup.active = false;
+        this.emit("sl-after-hide");
+      }
+    }
+    render() {
+      return $`
+      <sl-popup
+        part="base"
+        id="dropdown"
+        placement=${this.placement}
+        distance=${this.distance}
+        skidding=${this.skidding}
+        strategy=${this.hoist ? "fixed" : "absolute"}
+        flip
+        shift
+        auto-size="vertical"
+        auto-size-padding="10"
+        class=${o$3({
+      dropdown: true,
+      "dropdown--open": this.open
+    })}
+      >
+        <span
+          slot="anchor"
+          part="trigger"
+          class="dropdown__trigger"
+          @click=${this.handleTriggerClick}
+          @keydown=${this.handleTriggerKeyDown}
+          @keyup=${this.handleTriggerKeyUp}
+        >
+          <slot name="trigger" @slotchange=${this.handleTriggerSlotChange}></slot>
+        </span>
+
+        <div
+          part="panel"
+          class="dropdown__panel"
+          aria-hidden=${this.open ? "false" : "true"}
+          aria-labelledby="dropdown"
+        >
+          <slot></slot>
+        </div>
+      </sl-popup>
+    `;
+    }
+  };
+  SlDropdown.styles = dropdown_styles_default;
+  __decorateClass([
+    i2$2(".dropdown")
+  ], SlDropdown.prototype, "popup", 2);
+  __decorateClass([
+    i2$2(".dropdown__trigger")
+  ], SlDropdown.prototype, "trigger", 2);
+  __decorateClass([
+    i2$2(".dropdown__panel")
+  ], SlDropdown.prototype, "panel", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlDropdown.prototype, "open", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlDropdown.prototype, "placement", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlDropdown.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ attribute: "stay-open-on-select", type: Boolean, reflect: true })
+  ], SlDropdown.prototype, "stayOpenOnSelect", 2);
+  __decorateClass([
+    e$1({ attribute: false })
+  ], SlDropdown.prototype, "containingElement", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlDropdown.prototype, "distance", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlDropdown.prototype, "skidding", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlDropdown.prototype, "hoist", 2);
+  __decorateClass([
+    watch("open", { waitUntilFirstUpdate: true })
+  ], SlDropdown.prototype, "handleOpenChange", 1);
+  SlDropdown = __decorateClass([
+    n$1("sl-dropdown")
+  ], SlDropdown);
+  setDefaultAnimation("dropdown.show", {
+    keyframes: [
+      { opacity: 0, transform: "scale(0.9)" },
+      { opacity: 1, transform: "scale(1)" }
+    ],
+    options: { duration: 100, easing: "ease" }
+  });
+  setDefaultAnimation("dropdown.hide", {
+    keyframes: [
+      { opacity: 1, transform: "scale(1)" },
+      { opacity: 0, transform: "scale(0.9)" }
+    ],
+    options: { duration: 100, easing: "ease" }
+  });
+
+  // src/components/popup/popup.styles.ts
+  var popup_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --arrow-color: var(--sl-color-neutral-1000);
+    --arrow-size: 6px;
+
+    /*
+     * These properties are computed to account for the arrow's dimensions after being rotated 45º. The constant
+     * 0.7071 is derived from sin(45), which is the diagonal size of the arrow's container after rotating.
+     */
+    --arrow-size-diagonal: calc(var(--arrow-size) * 0.7071);
+    --arrow-padding-offset: calc(var(--arrow-size-diagonal) - var(--arrow-size));
+
+    display: contents;
+  }
+
+  .popup {
+    position: absolute;
+    isolation: isolate;
+    max-width: var(--auto-size-available-width, none);
+    max-height: var(--auto-size-available-height, none);
+  }
+
+  .popup--fixed {
+    position: fixed;
+  }
+
+  .popup:not(.popup--active) {
+    display: none;
+  }
+
+  .popup__arrow {
+    position: absolute;
+    width: calc(var(--arrow-size-diagonal) * 2);
+    height: calc(var(--arrow-size-diagonal) * 2);
+    transform: rotate(45deg);
+    background: var(--arrow-color);
+    z-index: -1;
+  }
+`;
+
+  // node_modules/@floating-ui/core/dist/floating-ui.core.browser.min.mjs
+  function t(t2) {
+    return t2.split("-")[0];
+  }
+  function e2(t2) {
+    return t2.split("-")[1];
+  }
+  function n2(e3) {
+    return ["top", "bottom"].includes(t(e3)) ? "x" : "y";
+  }
+  function r(t2) {
+    return "y" === t2 ? "height" : "width";
+  }
+  function i2(i4, o4, a3) {
+    let { reference: l3, floating: s3 } = i4;
+    const c3 = l3.x + l3.width / 2 - s3.width / 2, f3 = l3.y + l3.height / 2 - s3.height / 2, u3 = n2(o4), m3 = r(u3), g3 = l3[m3] / 2 - s3[m3] / 2, d3 = "x" === u3;
+    let p3;
+    switch (t(o4)) {
+      case "top":
+        p3 = { x: c3, y: l3.y - s3.height };
+        break;
+      case "bottom":
+        p3 = { x: c3, y: l3.y + l3.height };
+        break;
+      case "right":
+        p3 = { x: l3.x + l3.width, y: f3 };
+        break;
+      case "left":
+        p3 = { x: l3.x - s3.width, y: f3 };
+        break;
+      default:
+        p3 = { x: l3.x, y: l3.y };
+    }
+    switch (e2(o4)) {
+      case "start":
+        p3[u3] -= g3 * (a3 && d3 ? -1 : 1);
+        break;
+      case "end":
+        p3[u3] += g3 * (a3 && d3 ? -1 : 1);
+    }
+    return p3;
+  }
+  var o2 = async (t2, e3, n4) => {
+    const { placement: r3 = "bottom", strategy: o4 = "absolute", middleware: a3 = [], platform: l3 } = n4, s3 = await (null == l3.isRTL ? void 0 : l3.isRTL(e3));
+    let c3 = await l3.getElementRects({ reference: t2, floating: e3, strategy: o4 }), { x: f3, y: u3 } = i2(c3, r3, s3), m3 = r3, g3 = {}, d3 = 0;
+    for (let n5 = 0; n5 < a3.length; n5++) {
+      const { name: p3, fn: h3 } = a3[n5], { x: y3, y: x3, data: w3, reset: v3 } = await h3({ x: f3, y: u3, initialPlacement: r3, placement: m3, strategy: o4, middlewareData: g3, rects: c3, platform: l3, elements: { reference: t2, floating: e3 } });
+      f3 = null != y3 ? y3 : f3, u3 = null != x3 ? x3 : u3, g3 = __spreadProps(__spreadValues({}, g3), { [p3]: __spreadValues(__spreadValues({}, g3[p3]), w3) }), v3 && d3 <= 50 && (d3++, "object" == typeof v3 && (v3.placement && (m3 = v3.placement), v3.rects && (c3 = true === v3.rects ? await l3.getElementRects({ reference: t2, floating: e3, strategy: o4 }) : v3.rects), { x: f3, y: u3 } = i2(c3, m3, s3)), n5 = -1);
+    }
+    return { x: f3, y: u3, placement: m3, strategy: o4, middlewareData: g3 };
+  };
+  function a(t2) {
+    return "number" != typeof t2 ? function(t3) {
+      return __spreadValues({ top: 0, right: 0, bottom: 0, left: 0 }, t3);
+    }(t2) : { top: t2, right: t2, bottom: t2, left: t2 };
+  }
+  function l(t2) {
+    return __spreadProps(__spreadValues({}, t2), { top: t2.y, left: t2.x, right: t2.x + t2.width, bottom: t2.y + t2.height });
+  }
+  async function s(t2, e3) {
+    var n4;
+    void 0 === e3 && (e3 = {});
+    const { x: r3, y: i4, platform: o4, rects: s3, elements: c3, strategy: f3 } = t2, { boundary: u3 = "clippingAncestors", rootBoundary: m3 = "viewport", elementContext: g3 = "floating", altBoundary: d3 = false, padding: p3 = 0 } = e3, h3 = a(p3), y3 = c3[d3 ? "floating" === g3 ? "reference" : "floating" : g3], x3 = l(await o4.getClippingRect({ element: null == (n4 = await (null == o4.isElement ? void 0 : o4.isElement(y3))) || n4 ? y3 : y3.contextElement || await (null == o4.getDocumentElement ? void 0 : o4.getDocumentElement(c3.floating)), boundary: u3, rootBoundary: m3, strategy: f3 })), w3 = l(o4.convertOffsetParentRelativeRectToViewportRelativeRect ? await o4.convertOffsetParentRelativeRectToViewportRelativeRect({ rect: "floating" === g3 ? __spreadProps(__spreadValues({}, s3.floating), { x: r3, y: i4 }) : s3.reference, offsetParent: await (null == o4.getOffsetParent ? void 0 : o4.getOffsetParent(c3.floating)), strategy: f3 }) : s3[g3]);
+    return { top: x3.top - w3.top + h3.top, bottom: w3.bottom - x3.bottom + h3.bottom, left: x3.left - w3.left + h3.left, right: w3.right - x3.right + h3.right };
+  }
+  var c = Math.min;
+  var f = Math.max;
+  function u(t2, e3, n4) {
+    return f(t2, c(e3, n4));
+  }
+  var m = (t2) => ({ name: "arrow", options: t2, async fn(i4) {
+    const { element: o4, padding: l3 = 0 } = null != t2 ? t2 : {}, { x: s3, y: c3, placement: f3, rects: m3, platform: g3 } = i4;
+    if (null == o4)
+      return {};
+    const d3 = a(l3), p3 = { x: s3, y: c3 }, h3 = n2(f3), y3 = e2(f3), x3 = r(h3), w3 = await g3.getDimensions(o4), v3 = "y" === h3 ? "top" : "left", b3 = "y" === h3 ? "bottom" : "right", R2 = m3.reference[x3] + m3.reference[h3] - p3[h3] - m3.floating[x3], A = p3[h3] - m3.reference[h3], P2 = await (null == g3.getOffsetParent ? void 0 : g3.getOffsetParent(o4));
+    let T3 = P2 ? "y" === h3 ? P2.clientHeight || 0 : P2.clientWidth || 0 : 0;
+    0 === T3 && (T3 = m3.floating[x3]);
+    const O2 = R2 / 2 - A / 2, L3 = d3[v3], D3 = T3 - w3[x3] - d3[b3], k2 = T3 / 2 - w3[x3] / 2 + O2, E3 = u(L3, k2, D3), C2 = ("start" === y3 ? d3[v3] : d3[b3]) > 0 && k2 !== E3 && m3.reference[x3] <= m3.floating[x3];
+    return { [h3]: p3[h3] - (C2 ? k2 < L3 ? L3 - k2 : D3 - k2 : 0), data: { [h3]: E3, centerOffset: k2 - E3 } };
+  } });
+  var g = { left: "right", right: "left", bottom: "top", top: "bottom" };
+  function d(t2) {
+    return t2.replace(/left|right|bottom|top/g, (t3) => g[t3]);
+  }
+  function p(t2, i4, o4) {
+    void 0 === o4 && (o4 = false);
+    const a3 = e2(t2), l3 = n2(t2), s3 = r(l3);
+    let c3 = "x" === l3 ? a3 === (o4 ? "end" : "start") ? "right" : "left" : "start" === a3 ? "bottom" : "top";
+    return i4.reference[s3] > i4.floating[s3] && (c3 = d(c3)), { main: c3, cross: d(c3) };
+  }
+  var h = { start: "end", end: "start" };
+  function y(t2) {
+    return t2.replace(/start|end/g, (t3) => h[t3]);
+  }
+  var x = ["top", "right", "bottom", "left"];
+  x.reduce((t2, e3) => t2.concat(e3, e3 + "-start", e3 + "-end"), []);
+  var b = function(e3) {
+    return void 0 === e3 && (e3 = {}), { name: "flip", options: e3, async fn(n4) {
+      var r3;
+      const { placement: i4, middlewareData: o4, rects: a3, initialPlacement: l3, platform: c3, elements: f3 } = n4, _a = e3, { mainAxis: u3 = true, crossAxis: m3 = true, fallbackPlacements: g3, fallbackStrategy: h3 = "bestFit", flipAlignment: x3 = true } = _a, w3 = __objRest(_a, ["mainAxis", "crossAxis", "fallbackPlacements", "fallbackStrategy", "flipAlignment"]), v3 = t(i4), b3 = g3 || (v3 === l3 || !x3 ? [d(l3)] : function(t2) {
+        const e4 = d(t2);
+        return [y(t2), e4, y(e4)];
+      }(l3)), R2 = [l3, ...b3], A = await s(n4, w3), P2 = [];
+      let T3 = (null == (r3 = o4.flip) ? void 0 : r3.overflows) || [];
+      if (u3 && P2.push(A[v3]), m3) {
+        const { main: t2, cross: e4 } = p(i4, a3, await (null == c3.isRTL ? void 0 : c3.isRTL(f3.floating)));
+        P2.push(A[t2], A[e4]);
+      }
+      if (T3 = [...T3, { placement: i4, overflows: P2 }], !P2.every((t2) => t2 <= 0)) {
+        var O2, L3;
+        const t2 = (null != (O2 = null == (L3 = o4.flip) ? void 0 : L3.index) ? O2 : 0) + 1, e4 = R2[t2];
+        if (e4)
+          return { data: { index: t2, overflows: T3 }, reset: { placement: e4 } };
+        let n5 = "bottom";
+        switch (h3) {
+          case "bestFit": {
+            var D3;
+            const t3 = null == (D3 = T3.map((t4) => [t4, t4.overflows.filter((t5) => t5 > 0).reduce((t5, e5) => t5 + e5, 0)]).sort((t4, e5) => t4[1] - e5[1])[0]) ? void 0 : D3[0].placement;
+            t3 && (n5 = t3);
+            break;
+          }
+          case "initialPlacement":
+            n5 = l3;
+        }
+        if (i4 !== n5)
+          return { reset: { placement: n5 } };
+      }
+      return {};
+    } };
+  };
+  var T = function(r3) {
+    return void 0 === r3 && (r3 = 0), { name: "offset", options: r3, async fn(i4) {
+      const { x: o4, y: a3 } = i4, l3 = await async function(r4, i5) {
+        const { placement: o5, platform: a4, elements: l4 } = r4, s3 = await (null == a4.isRTL ? void 0 : a4.isRTL(l4.floating)), c3 = t(o5), f3 = e2(o5), u3 = "x" === n2(o5), m3 = ["left", "top"].includes(c3) ? -1 : 1, g3 = s3 && u3 ? -1 : 1, d3 = "function" == typeof i5 ? i5(r4) : i5;
+        let { mainAxis: p3, crossAxis: h3, alignmentAxis: y3 } = "number" == typeof d3 ? { mainAxis: d3, crossAxis: 0, alignmentAxis: null } : __spreadValues({ mainAxis: 0, crossAxis: 0, alignmentAxis: null }, d3);
+        return f3 && "number" == typeof y3 && (h3 = "end" === f3 ? -1 * y3 : y3), u3 ? { x: h3 * g3, y: p3 * m3 } : { x: p3 * m3, y: h3 * g3 };
+      }(i4, r3);
+      return { x: o4 + l3.x, y: a3 + l3.y, data: l3 };
+    } };
+  };
+  function O(t2) {
+    return "x" === t2 ? "y" : "x";
+  }
+  var L = function(e3) {
+    return void 0 === e3 && (e3 = {}), { name: "shift", options: e3, async fn(r3) {
+      const { x: i4, y: o4, placement: a3 } = r3, _a = e3, { mainAxis: l3 = true, crossAxis: c3 = false, limiter: f3 = { fn: (t2) => {
+        let { x: e4, y: n4 } = t2;
+        return { x: e4, y: n4 };
+      } } } = _a, m3 = __objRest(_a, ["mainAxis", "crossAxis", "limiter"]), g3 = { x: i4, y: o4 }, d3 = await s(r3, m3), p3 = n2(t(a3)), h3 = O(p3);
+      let y3 = g3[p3], x3 = g3[h3];
+      if (l3) {
+        const t2 = "y" === p3 ? "bottom" : "right";
+        y3 = u(y3 + d3["y" === p3 ? "top" : "left"], y3, y3 - d3[t2]);
+      }
+      if (c3) {
+        const t2 = "y" === h3 ? "bottom" : "right";
+        x3 = u(x3 + d3["y" === h3 ? "top" : "left"], x3, x3 - d3[t2]);
+      }
+      const w3 = f3.fn(__spreadProps(__spreadValues({}, r3), { [p3]: y3, [h3]: x3 }));
+      return __spreadProps(__spreadValues({}, w3), { data: { x: w3.x - i4, y: w3.y - o4 } });
+    } };
+  };
+  var k = function(n4) {
+    return void 0 === n4 && (n4 = {}), { name: "size", options: n4, async fn(r3) {
+      const { placement: i4, rects: o4, platform: a3, elements: l3 } = r3, _a = n4, { apply: c3 = () => {
+      } } = _a, u3 = __objRest(_a, ["apply"]), m3 = await s(r3, u3), g3 = t(i4), d3 = e2(i4);
+      let p3, h3;
+      "top" === g3 || "bottom" === g3 ? (p3 = g3, h3 = d3 === (await (null == a3.isRTL ? void 0 : a3.isRTL(l3.floating)) ? "start" : "end") ? "left" : "right") : (h3 = g3, p3 = "end" === d3 ? "top" : "bottom");
+      const y3 = f(m3.left, 0), x3 = f(m3.right, 0), w3 = f(m3.top, 0), v3 = f(m3.bottom, 0), b3 = { availableHeight: o4.floating.height - (["left", "right"].includes(i4) ? 2 * (0 !== w3 || 0 !== v3 ? w3 + v3 : f(m3.top, m3.bottom)) : m3[p3]), availableWidth: o4.floating.width - (["top", "bottom"].includes(i4) ? 2 * (0 !== y3 || 0 !== x3 ? y3 + x3 : f(m3.left, m3.right)) : m3[h3]) };
+      await c3(__spreadValues(__spreadValues({}, r3), b3));
+      const R2 = await a3.getDimensions(l3.floating);
+      return o4.floating.width !== R2.width || o4.floating.height !== R2.height ? { reset: { rects: true } } : {};
+    } };
+  };
+
+  // node_modules/@floating-ui/dom/dist/floating-ui.dom.browser.min.mjs
+  function n3(t2) {
+    return t2 && t2.document && t2.location && t2.alert && t2.setInterval;
+  }
+  function o3(t2) {
+    if (null == t2)
+      return window;
+    if (!n3(t2)) {
+      const e3 = t2.ownerDocument;
+      return e3 && e3.defaultView || window;
+    }
+    return t2;
+  }
+  function i3(t2) {
+    return o3(t2).getComputedStyle(t2);
+  }
+  function r2(t2) {
+    return n3(t2) ? "" : t2 ? (t2.nodeName || "").toLowerCase() : "";
+  }
+  function l2() {
+    const t2 = navigator.userAgentData;
+    return null != t2 && t2.brands ? t2.brands.map((t3) => t3.brand + "/" + t3.version).join(" ") : navigator.userAgent;
+  }
+  function c2(t2) {
+    return t2 instanceof o3(t2).HTMLElement;
+  }
+  function f2(t2) {
+    return t2 instanceof o3(t2).Element;
+  }
+  function s2(t2) {
+    if ("undefined" == typeof ShadowRoot)
+      return false;
+    return t2 instanceof o3(t2).ShadowRoot || t2 instanceof ShadowRoot;
+  }
+  function u2(t2) {
+    const { overflow: e3, overflowX: n4, overflowY: o4 } = i3(t2);
+    return /auto|scroll|overlay|hidden/.test(e3 + o4 + n4);
+  }
+  function d2(t2) {
+    return ["table", "td", "th"].includes(r2(t2));
+  }
+  function h2(t2) {
+    const e3 = /firefox/i.test(l2()), n4 = i3(t2);
+    return "none" !== n4.transform || "none" !== n4.perspective || "paint" === n4.contain || ["transform", "perspective"].includes(n4.willChange) || e3 && "filter" === n4.willChange || e3 && !!n4.filter && "none" !== n4.filter;
+  }
+  function a2() {
+    return !/^((?!chrome|android).)*safari/i.test(l2());
+  }
+  var g2 = Math.min;
+  var p2 = Math.max;
+  var m2 = Math.round;
+  function w2(t2, e3, n4) {
+    var i4, r3, l3, s3;
+    void 0 === e3 && (e3 = false), void 0 === n4 && (n4 = false);
+    const u3 = t2.getBoundingClientRect();
+    let d3 = 1, h3 = 1;
+    e3 && c2(t2) && (d3 = t2.offsetWidth > 0 && m2(u3.width) / t2.offsetWidth || 1, h3 = t2.offsetHeight > 0 && m2(u3.height) / t2.offsetHeight || 1);
+    const g3 = f2(t2) ? o3(t2) : window, p3 = !a2() && n4, w3 = (u3.left + (p3 && null != (i4 = null == (r3 = g3.visualViewport) ? void 0 : r3.offsetLeft) ? i4 : 0)) / d3, v3 = (u3.top + (p3 && null != (l3 = null == (s3 = g3.visualViewport) ? void 0 : s3.offsetTop) ? l3 : 0)) / h3, y3 = u3.width / d3, x3 = u3.height / h3;
+    return { width: y3, height: x3, top: v3, right: w3 + y3, bottom: v3 + x3, left: w3, x: w3, y: v3 };
+  }
+  function v2(t2) {
+    return (e3 = t2, (e3 instanceof o3(e3).Node ? t2.ownerDocument : t2.document) || window.document).documentElement;
+    var e3;
+  }
+  function y2(t2) {
+    return f2(t2) ? { scrollLeft: t2.scrollLeft, scrollTop: t2.scrollTop } : { scrollLeft: t2.pageXOffset, scrollTop: t2.pageYOffset };
+  }
+  function x2(t2) {
+    return w2(v2(t2)).left + y2(t2).scrollLeft;
+  }
+  function b2(t2, e3, n4) {
+    const o4 = c2(e3), i4 = v2(e3), l3 = w2(t2, o4 && function(t3) {
+      const e4 = w2(t3);
+      return m2(e4.width) !== t3.offsetWidth || m2(e4.height) !== t3.offsetHeight;
+    }(e3), "fixed" === n4);
+    let f3 = { scrollLeft: 0, scrollTop: 0 };
+    const s3 = { x: 0, y: 0 };
+    if (o4 || !o4 && "fixed" !== n4)
+      if (("body" !== r2(e3) || u2(i4)) && (f3 = y2(e3)), c2(e3)) {
+        const t3 = w2(e3, true);
+        s3.x = t3.x + e3.clientLeft, s3.y = t3.y + e3.clientTop;
+      } else
+        i4 && (s3.x = x2(i4));
+    return { x: l3.left + f3.scrollLeft - s3.x, y: l3.top + f3.scrollTop - s3.y, width: l3.width, height: l3.height };
+  }
+  function L2(t2) {
+    return "html" === r2(t2) ? t2 : t2.assignedSlot || t2.parentNode || (s2(t2) ? t2.host : null) || v2(t2);
+  }
+  function R(t2) {
+    return c2(t2) && "fixed" !== getComputedStyle(t2).position ? t2.offsetParent : null;
+  }
+  function T2(t2) {
+    const e3 = o3(t2);
+    let n4 = R(t2);
+    for (; n4 && d2(n4) && "static" === getComputedStyle(n4).position; )
+      n4 = R(n4);
+    return n4 && ("html" === r2(n4) || "body" === r2(n4) && "static" === getComputedStyle(n4).position && !h2(n4)) ? e3 : n4 || function(t3) {
+      let e4 = L2(t3);
+      for (s2(e4) && (e4 = e4.host); c2(e4) && !["html", "body"].includes(r2(e4)); ) {
+        if (h2(e4))
+          return e4;
+        e4 = e4.parentNode;
+      }
+      return null;
+    }(t2) || e3;
+  }
+  function W(t2) {
+    if (c2(t2))
+      return { width: t2.offsetWidth, height: t2.offsetHeight };
+    const e3 = w2(t2);
+    return { width: e3.width, height: e3.height };
+  }
+  function E2(t2) {
+    const e3 = L2(t2);
+    return ["html", "body", "#document"].includes(r2(e3)) ? t2.ownerDocument.body : c2(e3) && u2(e3) ? e3 : E2(e3);
+  }
+  function H(t2, e3) {
+    var n4;
+    void 0 === e3 && (e3 = []);
+    const i4 = E2(t2), r3 = i4 === (null == (n4 = t2.ownerDocument) ? void 0 : n4.body), l3 = o3(i4), c3 = r3 ? [l3].concat(l3.visualViewport || [], u2(i4) ? i4 : []) : i4, f3 = e3.concat(c3);
+    return r3 ? f3 : f3.concat(H(c3));
+  }
+  function C(e3, n4, r3) {
+    return "viewport" === n4 ? l(function(t2, e4) {
+      const n5 = o3(t2), i4 = v2(t2), r4 = n5.visualViewport;
+      let l3 = i4.clientWidth, c3 = i4.clientHeight, f3 = 0, s3 = 0;
+      if (r4) {
+        l3 = r4.width, c3 = r4.height;
+        const t3 = a2();
+        (t3 || !t3 && "fixed" === e4) && (f3 = r4.offsetLeft, s3 = r4.offsetTop);
+      }
+      return { width: l3, height: c3, x: f3, y: s3 };
+    }(e3, r3)) : f2(n4) ? function(t2, e4) {
+      const n5 = w2(t2, false, "fixed" === e4), o4 = n5.top + t2.clientTop, i4 = n5.left + t2.clientLeft;
+      return { top: o4, left: i4, x: i4, y: o4, right: i4 + t2.clientWidth, bottom: o4 + t2.clientHeight, width: t2.clientWidth, height: t2.clientHeight };
+    }(n4, r3) : l(function(t2) {
+      var e4;
+      const n5 = v2(t2), o4 = y2(t2), r4 = null == (e4 = t2.ownerDocument) ? void 0 : e4.body, l3 = p2(n5.scrollWidth, n5.clientWidth, r4 ? r4.scrollWidth : 0, r4 ? r4.clientWidth : 0), c3 = p2(n5.scrollHeight, n5.clientHeight, r4 ? r4.scrollHeight : 0, r4 ? r4.clientHeight : 0);
+      let f3 = -o4.scrollLeft + x2(t2);
+      const s3 = -o4.scrollTop;
+      return "rtl" === i3(r4 || n5).direction && (f3 += p2(n5.clientWidth, r4 ? r4.clientWidth : 0) - l3), { width: l3, height: c3, x: f3, y: s3 };
+    }(v2(e3)));
+  }
+  function S(t2) {
+    const e3 = H(t2), n4 = ["absolute", "fixed"].includes(i3(t2).position) && c2(t2) ? T2(t2) : t2;
+    return f2(n4) ? e3.filter((t3) => f2(t3) && function(t4, e4) {
+      const n5 = null == e4.getRootNode ? void 0 : e4.getRootNode();
+      if (t4.contains(e4))
+        return true;
+      if (n5 && s2(n5)) {
+        let n6 = e4;
+        do {
+          if (n6 && t4 === n6)
+            return true;
+          n6 = n6.parentNode || n6.host;
+        } while (n6);
+      }
+      return false;
+    }(t3, n4) && "body" !== r2(t3)) : [];
+  }
+  var D2 = { getClippingRect: function(t2) {
+    let { element: e3, boundary: n4, rootBoundary: o4, strategy: i4 } = t2;
+    const r3 = [..."clippingAncestors" === n4 ? S(e3) : [].concat(n4), o4], l3 = r3[0], c3 = r3.reduce((t3, n5) => {
+      const o5 = C(e3, n5, i4);
+      return t3.top = p2(o5.top, t3.top), t3.right = g2(o5.right, t3.right), t3.bottom = g2(o5.bottom, t3.bottom), t3.left = p2(o5.left, t3.left), t3;
+    }, C(e3, l3, i4));
+    return { width: c3.right - c3.left, height: c3.bottom - c3.top, x: c3.left, y: c3.top };
+  }, convertOffsetParentRelativeRectToViewportRelativeRect: function(t2) {
+    let { rect: e3, offsetParent: n4, strategy: o4 } = t2;
+    const i4 = c2(n4), l3 = v2(n4);
+    if (n4 === l3)
+      return e3;
+    let f3 = { scrollLeft: 0, scrollTop: 0 };
+    const s3 = { x: 0, y: 0 };
+    if ((i4 || !i4 && "fixed" !== o4) && (("body" !== r2(n4) || u2(l3)) && (f3 = y2(n4)), c2(n4))) {
+      const t3 = w2(n4, true);
+      s3.x = t3.x + n4.clientLeft, s3.y = t3.y + n4.clientTop;
+    }
+    return __spreadProps(__spreadValues({}, e3), { x: e3.x - f3.scrollLeft + s3.x, y: e3.y - f3.scrollTop + s3.y });
+  }, isElement: f2, getDimensions: W, getOffsetParent: T2, getDocumentElement: v2, getElementRects: (t2) => {
+    let { reference: e3, floating: n4, strategy: o4 } = t2;
+    return { reference: b2(e3, T2(n4), o4), floating: __spreadProps(__spreadValues({}, W(n4)), { x: 0, y: 0 }) };
+  }, getClientRects: (t2) => Array.from(t2.getClientRects()), isRTL: (t2) => "rtl" === i3(t2).direction };
+  function N(t2, e3, n4, o4) {
+    void 0 === o4 && (o4 = {});
+    const { ancestorScroll: i4 = true, ancestorResize: r3 = true, elementResize: l3 = true, animationFrame: c3 = false } = o4, s3 = i4 && !c3, u3 = r3 && !c3, d3 = s3 || u3 ? [...f2(t2) ? H(t2) : [], ...H(e3)] : [];
+    d3.forEach((t3) => {
+      s3 && t3.addEventListener("scroll", n4, { passive: true }), u3 && t3.addEventListener("resize", n4);
+    });
+    let h3, a3 = null;
+    if (l3) {
+      let o5 = true;
+      a3 = new ResizeObserver(() => {
+        o5 || n4(), o5 = false;
+      }), f2(t2) && !c3 && a3.observe(t2), a3.observe(e3);
+    }
+    let g3 = c3 ? w2(t2) : null;
+    return c3 && function e4() {
+      const o5 = w2(t2);
+      !g3 || o5.x === g3.x && o5.y === g3.y && o5.width === g3.width && o5.height === g3.height || n4();
+      g3 = o5, h3 = requestAnimationFrame(e4);
+    }(), n4(), () => {
+      var t3;
+      d3.forEach((t4) => {
+        s3 && t4.removeEventListener("scroll", n4), u3 && t4.removeEventListener("resize", n4);
+      }), null == (t3 = a3) || t3.disconnect(), a3 = null, c3 && cancelAnimationFrame(h3);
+    };
+  }
+  var z = (t2, n4, o4) => o2(t2, n4, __spreadValues({ platform: D2 }, o4));
+
+  // src/components/popup/popup.ts
+  var SlPopup = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.active = false;
+      this.placement = "top";
+      this.strategy = "absolute";
+      this.distance = 0;
+      this.skidding = 0;
+      this.arrow = false;
+      this.arrowPlacement = "anchor";
+      this.arrowPadding = 10;
+      this.flip = false;
+      this.flipFallbackPlacements = "";
+      this.flipFallbackStrategy = "initial";
+      this.flipPadding = 0;
+      this.shift = false;
+      this.shiftPadding = 0;
+      this.autoSizePadding = 0;
+    }
+    async connectedCallback() {
+      super.connectedCallback();
+      await this.updateComplete;
+      this.start();
+    }
+    disconnectedCallback() {
+      this.stop();
+    }
+    async handleAnchorChange() {
+      await this.stop();
+      if (this.anchor && typeof this.anchor === "string") {
+        const root = this.getRootNode();
+        this.anchorEl = root.getElementById(this.anchor);
+      } else if (this.anchor instanceof HTMLElement) {
+        this.anchorEl = this.anchor;
+      } else {
+        this.anchorEl = this.querySelector('[slot="anchor"]');
+      }
+      if (this.anchorEl instanceof HTMLSlotElement) {
+        this.anchorEl = this.anchorEl.assignedElements({ flatten: true })[0];
+      }
+      if (!this.anchorEl) {
+        throw new Error(
+          "Invalid anchor element: no anchor could be found using the anchor slot or the anchor attribute."
+        );
+      }
+      this.start();
+    }
+    start() {
+      if (!this.anchorEl) {
+        return;
+      }
+      this.cleanup = N(this.anchorEl, this.popup, () => {
+        this.reposition();
+      });
+    }
+    async stop() {
+      return new Promise((resolve) => {
+        if (this.cleanup) {
+          this.cleanup();
+          this.cleanup = void 0;
+          this.removeAttribute("data-current-placement");
+          this.style.removeProperty("--auto-size-available-width");
+          this.style.removeProperty("--auto-size-available-height");
+          requestAnimationFrame(() => resolve());
+        } else {
+          resolve();
+        }
+      });
+    }
+    async updated(changedProps) {
+      super.updated(changedProps);
+      if (changedProps.has("active")) {
+        if (this.active) {
+          this.start();
+        } else {
+          this.stop();
+        }
+      }
+      if (changedProps.has("anchor")) {
+        this.handleAnchorChange();
+      }
+      if (this.active) {
+        await this.updateComplete;
+        this.reposition();
+      }
+    }
+    reposition() {
+      if (!this.active || !this.anchorEl) {
+        return;
+      }
+      const middleware = [
+        T({ mainAxis: this.distance, crossAxis: this.skidding })
+      ];
+      if (this.sync) {
+        middleware.push(
+          k({
+            apply: ({ rects }) => {
+              const syncWidth = this.sync === "width" || this.sync === "both";
+              const syncHeight = this.sync === "height" || this.sync === "both";
+              this.popup.style.width = syncWidth ? `${rects.reference.width}px` : "";
+              this.popup.style.height = syncHeight ? `${rects.reference.height}px` : "";
+            }
+          })
+        );
+      } else {
+        this.popup.style.width = "";
+        this.popup.style.height = "";
+      }
+      if (this.flip) {
+        middleware.push(
+          b({
+            boundary: this.flipBoundary,
+            fallbackPlacements: this.flipFallbackPlacements,
+            fallbackStrategy: this.flipFallbackStrategy === "best-fit" ? "bestFit" : "initialPlacement",
+            padding: this.flipPadding
+          })
+        );
+      }
+      if (this.shift) {
+        middleware.push(
+          L({
+            boundary: this.shiftBoundary,
+            padding: this.shiftPadding
+          })
+        );
+      }
+      if (this.autoSize) {
+        middleware.push(
+          k({
+            boundary: this.autoSizeBoundary,
+            padding: this.autoSizePadding,
+            apply: ({ availableWidth, availableHeight }) => {
+              if (this.autoSize === "vertical" || this.autoSize === "both") {
+                this.style.setProperty("--auto-size-available-height", `${availableHeight}px`);
+              } else {
+                this.style.removeProperty("--auto-size-available-height");
+              }
+              if (this.autoSize === "horizontal" || this.autoSize === "both") {
+                this.style.setProperty("--auto-size-available-width", `${availableWidth}px`);
+              } else {
+                this.style.removeProperty("--auto-size-available-width");
+              }
+            }
+          })
+        );
+      } else {
+        this.style.removeProperty("--auto-size-available-width");
+        this.style.removeProperty("--auto-size-available-height");
+      }
+      if (this.arrow) {
+        middleware.push(
+          m({
+            element: this.arrowEl,
+            padding: this.arrowPadding
+          })
+        );
+      }
+      z(this.anchorEl, this.popup, {
+        placement: this.placement,
+        middleware,
+        strategy: this.strategy
+      }).then(({ x: x3, y: y3, middlewareData, placement }) => {
+        const isRtl = getComputedStyle(this).direction === "rtl";
+        const staticSide = { top: "bottom", right: "left", bottom: "top", left: "right" }[placement.split("-")[0]];
+        this.setAttribute("data-current-placement", placement);
+        Object.assign(this.popup.style, {
+          left: `${x3}px`,
+          top: `${y3}px`
+        });
+        if (this.arrow) {
+          const arrowX = middlewareData.arrow.x;
+          const arrowY = middlewareData.arrow.y;
+          let top = "";
+          let right = "";
+          let bottom = "";
+          let left = "";
+          if (this.arrowPlacement === "start") {
+            const value = typeof arrowX === "number" ? `calc(${this.arrowPadding}px - var(--arrow-padding-offset))` : "";
+            top = typeof arrowY === "number" ? `calc(${this.arrowPadding}px - var(--arrow-padding-offset))` : "";
+            right = isRtl ? value : "";
+            left = isRtl ? "" : value;
+          } else if (this.arrowPlacement === "end") {
+            const value = typeof arrowX === "number" ? `calc(${this.arrowPadding}px - var(--arrow-padding-offset))` : "";
+            right = isRtl ? "" : value;
+            left = isRtl ? value : "";
+            bottom = typeof arrowY === "number" ? `calc(${this.arrowPadding}px - var(--arrow-padding-offset))` : "";
+          } else if (this.arrowPlacement === "center") {
+            left = typeof arrowX === "number" ? `calc(50% - var(--arrow-size-diagonal))` : "";
+            top = typeof arrowY === "number" ? `calc(50% - var(--arrow-size-diagonal))` : "";
+          } else {
+            left = typeof arrowX === "number" ? `${arrowX}px` : "";
+            top = typeof arrowY === "number" ? `${arrowY}px` : "";
+          }
+          Object.assign(this.arrowEl.style, {
+            top,
+            right,
+            bottom,
+            left,
+            [staticSide]: "calc(var(--arrow-size-diagonal) * -1)"
+          });
+        }
+      });
+      this.emit("sl-reposition");
+    }
+    render() {
+      return $`
+      <slot name="anchor" @slotchange=${this.handleAnchorChange}></slot>
+
+      <div
+        part="popup"
+        class=${o$3({
+      popup: true,
+      "popup--active": this.active,
+      "popup--fixed": this.strategy === "fixed",
+      "popup--has-arrow": this.arrow
+    })}
+      >
+        <slot></slot>
+        ${this.arrow ? $`<div part="arrow" class="popup__arrow" role="presentation"></div>` : ""}
+      </div>
+    `;
+    }
+  };
+  SlPopup.styles = popup_styles_default;
+  __decorateClass([
+    i2$2(".popup")
+  ], SlPopup.prototype, "popup", 2);
+  __decorateClass([
+    i2$2(".popup__arrow")
+  ], SlPopup.prototype, "arrowEl", 2);
+  __decorateClass([
+    e$1()
+  ], SlPopup.prototype, "anchor", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlPopup.prototype, "active", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlPopup.prototype, "placement", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlPopup.prototype, "strategy", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlPopup.prototype, "distance", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlPopup.prototype, "skidding", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlPopup.prototype, "arrow", 2);
+  __decorateClass([
+    e$1({ attribute: "arrow-placement" })
+  ], SlPopup.prototype, "arrowPlacement", 2);
+  __decorateClass([
+    e$1({ attribute: "arrow-padding", type: Number })
+  ], SlPopup.prototype, "arrowPadding", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlPopup.prototype, "flip", 2);
+  __decorateClass([
+    e$1({
+      attribute: "flip-fallback-placements",
+      converter: {
+        fromAttribute: (value) => {
+          return value.split(" ").map((p3) => p3.trim()).filter((p3) => p3 !== "");
+        },
+        toAttribute: (value) => {
+          return value.join(" ");
+        }
+      }
+    })
+  ], SlPopup.prototype, "flipFallbackPlacements", 2);
+  __decorateClass([
+    e$1({ attribute: "flip-fallback-strategy" })
+  ], SlPopup.prototype, "flipFallbackStrategy", 2);
+  __decorateClass([
+    e$1({ type: Object })
+  ], SlPopup.prototype, "flipBoundary", 2);
+  __decorateClass([
+    e$1({ attribute: "flip-padding", type: Number })
+  ], SlPopup.prototype, "flipPadding", 2);
+  __decorateClass([
+    e$1({ type: Boolean })
+  ], SlPopup.prototype, "shift", 2);
+  __decorateClass([
+    e$1({ type: Object })
+  ], SlPopup.prototype, "shiftBoundary", 2);
+  __decorateClass([
+    e$1({ attribute: "shift-padding", type: Number })
+  ], SlPopup.prototype, "shiftPadding", 2);
+  __decorateClass([
+    e$1({ attribute: "auto-size" })
+  ], SlPopup.prototype, "autoSize", 2);
+  __decorateClass([
+    e$1()
+  ], SlPopup.prototype, "sync", 2);
+  __decorateClass([
+    e$1({ type: Object })
+  ], SlPopup.prototype, "autoSizeBoundary", 2);
+  __decorateClass([
+    e$1({ attribute: "auto-size-padding", type: Number })
+  ], SlPopup.prototype, "autoSizePadding", 2);
+  SlPopup = __decorateClass([
+    n$1("sl-popup")
+  ], SlPopup);
+
+  // src/components/details/details.styles.ts
+  var details_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: block;
+  }
+
+  .details {
+    border: solid 1px var(--sl-color-neutral-200);
+    border-radius: var(--sl-border-radius-medium);
+    background-color: var(--sl-color-neutral-0);
+    overflow-anchor: none;
+  }
+
+  .details--disabled {
+    opacity: 0.5;
+  }
+
+  .details__header {
+    display: flex;
+    align-items: center;
+    border-radius: inherit;
+    padding: var(--sl-spacing-medium);
+    user-select: none;
+    cursor: pointer;
+  }
+
+  .details__header:focus {
+    outline: none;
+  }
+
+  .details__header:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: calc(1px + var(--sl-focus-ring-offset));
+  }
+
+  .details--disabled .details__header {
+    cursor: not-allowed;
+  }
+
+  .details--disabled .details__header:focus-visible {
+    outline: none;
+    box-shadow: none;
+  }
+
+  .details__summary {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .details__summary-icon {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    transition: var(--sl-transition-medium) transform ease;
+  }
+
+  .details--open .details__summary-icon {
+    transform: rotate(90deg);
+  }
+
+  .details__body {
+    overflow: hidden;
+  }
+
+  .details__content {
+    padding: var(--sl-spacing-medium);
+  }
+`;
+
+  // src/components/details/details.ts
+  var SlDetails = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.open = false;
+      this.disabled = false;
+    }
+    firstUpdated() {
+      this.body.hidden = !this.open;
+      this.body.style.height = this.open ? "auto" : "0";
+    }
+    async show() {
+      if (this.open || this.disabled) {
+        return void 0;
+      }
+      this.open = true;
+      return waitForEvent(this, "sl-after-show");
+    }
+    async hide() {
+      if (!this.open || this.disabled) {
+        return void 0;
+      }
+      this.open = false;
+      return waitForEvent(this, "sl-after-hide");
+    }
+    handleSummaryClick() {
+      if (!this.disabled) {
+        if (this.open) {
+          this.hide();
+        } else {
+          this.show();
+        }
+        this.header.focus();
+      }
+    }
+    handleSummaryKeyDown(event) {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        if (this.open) {
+          this.hide();
+        } else {
+          this.show();
+        }
+      }
+      if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+        event.preventDefault();
+        this.hide();
+      }
+      if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+        event.preventDefault();
+        this.show();
+      }
+    }
+    async handleOpenChange() {
+      if (this.open) {
+        this.emit("sl-show");
+        await stopAnimations(this.body);
+        this.body.hidden = false;
+        const { keyframes, options } = getAnimation(this, "details.show", { dir: this.localize.dir() });
+        await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
+        this.body.style.height = "auto";
+        this.emit("sl-after-show");
+      } else {
+        this.emit("sl-hide");
+        await stopAnimations(this.body);
+        const { keyframes, options } = getAnimation(this, "details.hide", { dir: this.localize.dir() });
+        await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
+        this.body.hidden = true;
+        this.body.style.height = "auto";
+        this.emit("sl-after-hide");
+      }
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      details: true,
+      "details--open": this.open,
+      "details--disabled": this.disabled
+    })}
+      >
+        <header
+          part="header"
+          id="header"
+          class="details__header"
+          role="button"
+          aria-expanded=${this.open ? "true" : "false"}
+          aria-controls="content"
+          aria-disabled=${this.disabled ? "true" : "false"}
+          tabindex=${this.disabled ? "-1" : "0"}
+          @click=${this.handleSummaryClick}
+          @keydown=${this.handleSummaryKeyDown}
+        >
+          <div part="summary" class="details__summary">
+            <slot name="summary">${this.summary}</slot>
+          </div>
+
+          <span part="summary-icon" class="details__summary-icon">
+            <sl-icon name="chevron-right" library="system"></sl-icon>
+          </span>
+        </header>
+
+        <div class="details__body">
+          <div part="content" id="content" class="details__content" role="region" aria-labelledby="header">
+            <slot></slot>
+          </div>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlDetails.styles = details_styles_default;
+  __decorateClass([
+    i2$2(".details")
+  ], SlDetails.prototype, "details", 2);
+  __decorateClass([
+    i2$2(".details__header")
+  ], SlDetails.prototype, "header", 2);
+  __decorateClass([
+    i2$2(".details__body")
+  ], SlDetails.prototype, "body", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlDetails.prototype, "open", 2);
+  __decorateClass([
+    e$1()
+  ], SlDetails.prototype, "summary", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlDetails.prototype, "disabled", 2);
+  __decorateClass([
+    watch("open", { waitUntilFirstUpdate: true })
+  ], SlDetails.prototype, "handleOpenChange", 1);
+  SlDetails = __decorateClass([
+    n$1("sl-details")
+  ], SlDetails);
+  setDefaultAnimation("details.show", {
+    keyframes: [
+      { height: "0", opacity: "0" },
+      { height: "auto", opacity: "1" }
+    ],
+    options: { duration: 250, easing: "linear" }
+  });
+  setDefaultAnimation("details.hide", {
+    keyframes: [
+      { height: "auto", opacity: "1" },
+      { height: "0", opacity: "0" }
+    ],
+    options: { duration: 250, easing: "linear" }
+  });
+
+  // src/components/dialog/dialog.styles.ts
+  var dialog_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --width: 31rem;
+    --header-spacing: var(--sl-spacing-large);
+    --body-spacing: var(--sl-spacing-large);
+    --footer-spacing: var(--sl-spacing-large);
+
+    display: contents;
+  }
+
+  .dialog {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: var(--sl-z-index-dialog);
+  }
+
+  .dialog__panel {
+    display: flex;
+    flex-direction: column;
+    z-index: 2;
+    width: var(--width);
+    max-width: calc(100% - var(--sl-spacing-2x-large));
+    max-height: calc(100% - var(--sl-spacing-2x-large));
+    background-color: var(--sl-panel-background-color);
+    border-radius: var(--sl-border-radius-medium);
+    box-shadow: var(--sl-shadow-x-large);
+  }
+
+  .dialog__panel:focus {
+    outline: none;
+  }
+
+  /* Ensure there's enough vertical padding for phones that don't update vh when chrome appears (e.g. iPhone) */
+  @media screen and (max-width: 420px) {
+    .dialog__panel {
+      max-height: 80vh;
+    }
+  }
+
+  .dialog--open .dialog__panel {
+    display: flex;
+    opacity: 1;
+    transform: none;
+  }
+
+  .dialog__header {
+    flex: 0 0 auto;
+    display: flex;
+  }
+
+  .dialog__title {
+    flex: 1 1 auto;
+    font: inherit;
+    font-size: var(--sl-font-size-large);
+    line-height: var(--sl-line-height-dense);
+    padding: var(--header-spacing);
+    margin: 0;
+  }
+
+  .dialog__close {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    font-size: var(--sl-font-size-x-large);
+    padding: 0 var(--header-spacing);
+  }
+
+  .dialog__body {
+    flex: 1 1 auto;
+    padding: var(--body-spacing);
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .dialog__footer {
+    flex: 0 0 auto;
+    text-align: right;
+    padding: var(--footer-spacing);
+  }
+
+  .dialog__footer ::slotted(sl-button:not(:first-of-type)) {
+    margin-inline-start: var(--sl-spacing-x-small);
+  }
+
+  .dialog:not(.dialog--has-footer) .dialog__footer {
+    display: none;
+  }
+
+  .dialog__overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: var(--sl-overlay-background-color);
+  }
+`;
+
+  // src/components/dialog/dialog.ts
+  var SlDialog = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.hasSlotController = new HasSlotController(this, "footer");
+      this.localize = new LocalizeController2(this);
+      this.open = false;
+      this.label = "";
+      this.noHeader = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.modal = new Modal(this);
+    }
+    firstUpdated() {
+      this.dialog.hidden = !this.open;
+      if (this.open) {
+        this.modal.activate();
+        lockBodyScrolling(this);
+      }
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      unlockBodyScrolling(this);
+    }
+    async show() {
+      if (this.open) {
+        return void 0;
+      }
+      this.open = true;
+      return waitForEvent(this, "sl-after-show");
+    }
+    async hide() {
+      if (!this.open) {
+        return void 0;
+      }
+      this.open = false;
+      return waitForEvent(this, "sl-after-hide");
+    }
+    requestClose(source) {
+      const slRequestClose = this.emit("sl-request-close", {
+        cancelable: true,
+        detail: { source }
+      });
+      if (slRequestClose.defaultPrevented) {
+        const animation = getAnimation(this, "dialog.denyClose", { dir: this.localize.dir() });
+        animateTo(this.panel, animation.keyframes, animation.options);
+        return;
+      }
+      this.hide();
+    }
+    handleKeyDown(event) {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        this.requestClose("keyboard");
+      }
+    }
+    async handleOpenChange() {
+      if (this.open) {
+        this.emit("sl-show");
+        this.originalTrigger = document.activeElement;
+        this.modal.activate();
+        lockBodyScrolling(this);
+        const autoFocusTarget = this.querySelector("[autofocus]");
+        if (autoFocusTarget) {
+          autoFocusTarget.removeAttribute("autofocus");
+        }
+        await Promise.all([stopAnimations(this.dialog), stopAnimations(this.overlay)]);
+        this.dialog.hidden = false;
+        requestAnimationFrame(() => {
+          const slInitialFocus = this.emit("sl-initial-focus", { cancelable: true });
+          if (!slInitialFocus.defaultPrevented) {
+            if (autoFocusTarget) {
+              autoFocusTarget.focus({ preventScroll: true });
+            } else {
+              this.panel.focus({ preventScroll: true });
+            }
+          }
+          if (autoFocusTarget) {
+            autoFocusTarget.setAttribute("autofocus", "");
+          }
+        });
+        const panelAnimation = getAnimation(this, "dialog.show", { dir: this.localize.dir() });
+        const overlayAnimation = getAnimation(this, "dialog.overlay.show", { dir: this.localize.dir() });
+        await Promise.all([
+          animateTo(this.panel, panelAnimation.keyframes, panelAnimation.options),
+          animateTo(this.overlay, overlayAnimation.keyframes, overlayAnimation.options)
+        ]);
+        this.emit("sl-after-show");
+      } else {
+        this.emit("sl-hide");
+        this.modal.deactivate();
+        await Promise.all([stopAnimations(this.dialog), stopAnimations(this.overlay)]);
+        const panelAnimation = getAnimation(this, "dialog.hide", { dir: this.localize.dir() });
+        const overlayAnimation = getAnimation(this, "dialog.overlay.hide", { dir: this.localize.dir() });
+        await Promise.all([
+          animateTo(this.overlay, overlayAnimation.keyframes, overlayAnimation.options).then(() => {
+            this.overlay.hidden = true;
+          }),
+          animateTo(this.panel, panelAnimation.keyframes, panelAnimation.options).then(() => {
+            this.panel.hidden = true;
+          })
+        ]);
+        this.dialog.hidden = true;
+        this.overlay.hidden = false;
+        this.panel.hidden = false;
+        unlockBodyScrolling(this);
+        const trigger = this.originalTrigger;
+        if (typeof (trigger == null ? void 0 : trigger.focus) === "function") {
+          setTimeout(() => trigger.focus());
+        }
+        this.emit("sl-after-hide");
+      }
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      dialog: true,
+      "dialog--open": this.open,
+      "dialog--has-footer": this.hasSlotController.test("footer")
+    })}
+        @keydown=${this.handleKeyDown}
+      >
+        <div part="overlay" class="dialog__overlay" @click=${() => this.requestClose("overlay")} tabindex="-1"></div>
+
+        <div
+          part="panel"
+          class="dialog__panel"
+          role="dialog"
+          aria-modal="true"
+          aria-hidden=${this.open ? "false" : "true"}
+          aria-label=${l$2(this.noHeader ? this.label : void 0)}
+          aria-labelledby=${l$2(!this.noHeader ? "title" : void 0)}
+          tabindex="0"
+        >
+          ${!this.noHeader ? $`
+                <header part="header" class="dialog__header">
+                  <h2 part="title" class="dialog__title" id="title">
+                    <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(65279)} </slot>
+                  </h2>
+                  <sl-icon-button
+                    part="close-button"
+                    exportparts="base:close-button__base"
+                    class="dialog__close"
+                    name="x"
+                    label=${this.localize.term("close")}
+                    library="system"
+                    @click="${() => this.requestClose("close-button")}"
+                  ></sl-icon-button>
+                </header>
+              ` : ""}
+
+          <div part="body" class="dialog__body">
+            <slot></slot>
+          </div>
+
+          <footer part="footer" class="dialog__footer">
+            <slot name="footer"></slot>
+          </footer>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlDialog.styles = dialog_styles_default;
+  __decorateClass([
+    i2$2(".dialog")
+  ], SlDialog.prototype, "dialog", 2);
+  __decorateClass([
+    i2$2(".dialog__panel")
+  ], SlDialog.prototype, "panel", 2);
+  __decorateClass([
+    i2$2(".dialog__overlay")
+  ], SlDialog.prototype, "overlay", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlDialog.prototype, "open", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlDialog.prototype, "label", 2);
+  __decorateClass([
+    e$1({ attribute: "no-header", type: Boolean, reflect: true })
+  ], SlDialog.prototype, "noHeader", 2);
+  __decorateClass([
+    watch("open", { waitUntilFirstUpdate: true })
+  ], SlDialog.prototype, "handleOpenChange", 1);
+  SlDialog = __decorateClass([
+    n$1("sl-dialog")
+  ], SlDialog);
+  setDefaultAnimation("dialog.show", {
+    keyframes: [
+      { opacity: 0, transform: "scale(0.8)" },
+      { opacity: 1, transform: "scale(1)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("dialog.hide", {
+    keyframes: [
+      { opacity: 1, transform: "scale(1)" },
+      { opacity: 0, transform: "scale(0.8)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("dialog.denyClose", {
+    keyframes: [{ transform: "scale(1)" }, { transform: "scale(1.02)" }, { transform: "scale(1)" }],
+    options: { duration: 250 }
+  });
+  setDefaultAnimation("dialog.overlay.show", {
+    keyframes: [{ opacity: 0 }, { opacity: 1 }],
+    options: { duration: 250 }
+  });
+  setDefaultAnimation("dialog.overlay.hide", {
+    keyframes: [{ opacity: 1 }, { opacity: 0 }],
+    options: { duration: 250 }
+  });
+
+  // src/components/divider/divider.styles.ts
+  var divider_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --color: var(--sl-panel-border-color);
+    --width: var(--sl-panel-border-width);
+    --spacing: var(--sl-spacing-medium);
+  }
+
+  :host(:not([vertical])) {
+    display: block;
+    border-top: solid var(--width) var(--color);
+    margin: var(--spacing) 0;
+  }
+
+  :host([vertical]) {
+    display: inline-block;
+    height: 100%;
+    border-left: solid var(--width) var(--color);
+    margin: 0 var(--spacing);
+  }
+`;
+
+  // src/components/divider/divider.ts
+  var SlDivider = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.vertical = false;
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.setAttribute("role", "separator");
+    }
+    handleVerticalChange() {
+      this.setAttribute("aria-orientation", this.vertical ? "vertical" : "horizontal");
+    }
+  };
+  SlDivider.styles = divider_styles_default;
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlDivider.prototype, "vertical", 2);
+  __decorateClass([
+    watch("vertical")
+  ], SlDivider.prototype, "handleVerticalChange", 1);
+  SlDivider = __decorateClass([
+    n$1("sl-divider")
+  ], SlDivider);
+
+  // src/components/button/button.ts
+  var SlButton = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.formSubmitController = new FormSubmitController(this, {
+        form: (input) => {
+          if (input.hasAttribute("form")) {
+            const doc = input.getRootNode();
+            const formId = input.getAttribute("form");
+            return doc.getElementById(formId);
+          }
+          return input.closest("form");
+        }
+      });
+      this.hasSlotController = new HasSlotController(this, "[default]", "prefix", "suffix");
+      this.localize = new LocalizeController2(this);
+      this.hasFocus = false;
+      this.variant = "default";
+      this.size = "medium";
+      this.caret = false;
+      this.disabled = false;
+      this.loading = false;
+      this.outline = false;
+      this.pill = false;
+      this.circle = false;
+      this.type = "button";
+    }
+    click() {
+      this.button.click();
+    }
+    focus(options) {
+      this.button.focus(options);
+    }
+    blur() {
+      this.button.blur();
+    }
+    handleBlur() {
+      this.hasFocus = false;
+      this.emit("sl-blur");
+    }
+    handleFocus() {
+      this.hasFocus = true;
+      this.emit("sl-focus");
+    }
+    handleClick(event) {
+      if (this.disabled || this.loading) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      if (this.type === "submit") {
+        this.formSubmitController.submit(this);
+      }
+      if (this.type === "reset") {
+        this.formSubmitController.reset(this);
+      }
+    }
+    render() {
+      const isLink = this.href ? true : false;
+      const tag = isLink ? l$1`a` : l$1`button`;
+      return n`
+      <${tag}
+        part="base"
+        class=${o$3({
+      button: true,
+      "button--default": this.variant === "default",
+      "button--primary": this.variant === "primary",
+      "button--success": this.variant === "success",
+      "button--neutral": this.variant === "neutral",
+      "button--warning": this.variant === "warning",
+      "button--danger": this.variant === "danger",
+      "button--text": this.variant === "text",
+      "button--small": this.size === "small",
+      "button--medium": this.size === "medium",
+      "button--large": this.size === "large",
+      "button--caret": this.caret,
+      "button--circle": this.circle,
+      "button--disabled": this.disabled,
+      "button--focused": this.hasFocus,
+      "button--loading": this.loading,
+      "button--standard": !this.outline,
+      "button--outline": this.outline,
+      "button--pill": this.pill,
+      "button--rtl": this.localize.dir() === "rtl",
+      "button--has-label": this.hasSlotController.test("[default]"),
+      "button--has-prefix": this.hasSlotController.test("prefix"),
+      "button--has-suffix": this.hasSlotController.test("suffix")
+    })}
+        ?disabled=${l$2(isLink ? void 0 : this.disabled)}
+        type=${l$2(isLink ? void 0 : this.type)}
+        name=${l$2(isLink ? void 0 : this.name)}
+        value=${l$2(isLink ? void 0 : this.value)}
+        href=${l$2(isLink ? this.href : void 0)}
+        target=${l$2(isLink ? this.target : void 0)}
+        download=${l$2(isLink ? this.download : void 0)}
+        rel=${l$2(isLink && this.target ? "noreferrer noopener" : void 0)}
+        role=${l$2(isLink ? void 0 : "button")}
+        aria-disabled=${this.disabled ? "true" : "false"}
+        tabindex=${this.disabled ? "-1" : "0"}
+        @blur=${this.handleBlur}
+        @focus=${this.handleFocus}
+        @click=${this.handleClick}
+      >
+        <span part="prefix" class="button__prefix">
+          <slot name="prefix"></slot>
+        </span>
+        <span part="label" class="button__label">
+          <slot></slot>
+        </span>
+        <span part="suffix" class="button__suffix">
+          <slot name="suffix"></slot>
+        </span>
+        ${this.caret ? n`
+                <span part="caret" class="button__caret">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <polyline points="6 9 12 15 18 9"></polyline>
+                  </svg>
+                </span>
+              ` : ""}
+        ${this.loading ? n`<sl-spinner></sl-spinner>` : ""}
+      </${tag}>
+    `;
+    }
+  };
+  SlButton.styles = button_styles_default;
+  __decorateClass([
+    i2$2(".button")
+  ], SlButton.prototype, "button", 2);
+  __decorateClass([
+    t$1()
+  ], SlButton.prototype, "hasFocus", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlButton.prototype, "variant", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlButton.prototype, "size", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlButton.prototype, "caret", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlButton.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlButton.prototype, "loading", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlButton.prototype, "outline", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlButton.prototype, "pill", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlButton.prototype, "circle", 2);
+  __decorateClass([
+    e$1()
+  ], SlButton.prototype, "type", 2);
+  __decorateClass([
+    e$1()
+  ], SlButton.prototype, "name", 2);
+  __decorateClass([
+    e$1()
+  ], SlButton.prototype, "value", 2);
+  __decorateClass([
+    e$1()
+  ], SlButton.prototype, "href", 2);
+  __decorateClass([
+    e$1()
+  ], SlButton.prototype, "target", 2);
+  __decorateClass([
+    e$1()
+  ], SlButton.prototype, "download", 2);
+  __decorateClass([
+    e$1()
+  ], SlButton.prototype, "form", 2);
+  __decorateClass([
+    e$1({ attribute: "formaction" })
+  ], SlButton.prototype, "formAction", 2);
+  __decorateClass([
+    e$1({ attribute: "formmethod" })
+  ], SlButton.prototype, "formMethod", 2);
+  __decorateClass([
+    e$1({ attribute: "formnovalidate", type: Boolean })
+  ], SlButton.prototype, "formNoValidate", 2);
+  __decorateClass([
+    e$1({ attribute: "formtarget" })
+  ], SlButton.prototype, "formTarget", 2);
+  SlButton = __decorateClass([
+    n$1("sl-button")
+  ], SlButton);
+
+  // src/components/spinner/spinner.styles.ts
+  var spinner_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --track-width: 2px;
+    --track-color: rgb(128 128 128 / 25%);
+    --indicator-color: var(--sl-color-primary-600);
+    --speed: 2s;
+
+    display: inline-flex;
+    width: 1em;
+    height: 1em;
+  }
+
+  .spinner {
+    flex: 1 1 auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .spinner__track,
+  .spinner__indicator {
+    fill: none;
+    stroke-width: var(--track-width);
+    r: calc(0.5em - var(--track-width) / 2);
+    cx: 0.5em;
+    cy: 0.5em;
+    transform-origin: 50% 50%;
+  }
+
+  .spinner__track {
+    stroke: var(--track-color);
+    transform-origin: 0% 0%;
+    mix-blend-mode: multiply;
+  }
+
+  .spinner__indicator {
+    stroke: var(--indicator-color);
+    stroke-linecap: round;
+    stroke-dasharray: 150% 75%;
+    animation: spin var(--speed) linear infinite;
+  }
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+      stroke-dasharray: 0.01em, 2.75em;
     }
 
-    _defineProperty(_class, "targets", ["switchable", "clickable"]);
+    50% {
+      transform: rotate(450deg);
+      stroke-dasharray: 1.375em, 1.375em;
+    }
 
-    const Honeybadger = require("@honeybadger-io/js");
+    100% {
+      transform: rotate(1080deg);
+      stroke-dasharray: 0.01em, 2.75em;
+    }
+  }
+`;
 
-    const getAppContext = () => {
-      // TODO: Kali - remove this var once upstream Heroku/Doppler issues resolved
-      if (process.env.EXPLICIT_APP_CONTEXT) return process.env.EXPLICIT_APP_CONTEXT;
+  // src/components/spinner/spinner.ts
+  var SlSpinner = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+    }
+    render() {
+      return $`
+      <svg part="base" class="spinner" role="progressbar" aria-valuetext=${this.localize.term("loading")}>
+        <circle class="spinner__track"></circle>
+        <circle class="spinner__indicator"></circle>
+      </svg>
+    `;
+    }
+  };
+  SlSpinner.styles = spinner_styles_default;
+  SlSpinner = __decorateClass([
+    n$1("sl-spinner")
+  ], SlSpinner);
 
-      if (!process.env.HEROKU_APP_NAME) {
-        console.log("WARN: production-ish environment is missing both HEROKU_APP_NAME and EXPLICIT_APP_CONTEXT");
+  // src/components/animation/animation.styles.ts
+  var animation_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: contents;
+  }
+`;
+
+  // node_modules/@shoelace-style/animations/dist/index.js
+  var dist_exports = {};
+  __export(dist_exports, {
+    backInDown: () => backInDown,
+    backInLeft: () => backInLeft,
+    backInRight: () => backInRight,
+    backInUp: () => backInUp,
+    backOutDown: () => backOutDown,
+    backOutLeft: () => backOutLeft,
+    backOutRight: () => backOutRight,
+    backOutUp: () => backOutUp,
+    bounce: () => bounce,
+    bounceIn: () => bounceIn,
+    bounceInDown: () => bounceInDown,
+    bounceInLeft: () => bounceInLeft,
+    bounceInRight: () => bounceInRight,
+    bounceInUp: () => bounceInUp,
+    bounceOut: () => bounceOut,
+    bounceOutDown: () => bounceOutDown,
+    bounceOutLeft: () => bounceOutLeft,
+    bounceOutRight: () => bounceOutRight,
+    bounceOutUp: () => bounceOutUp,
+    easings: () => easings,
+    fadeIn: () => fadeIn,
+    fadeInBottomLeft: () => fadeInBottomLeft,
+    fadeInBottomRight: () => fadeInBottomRight,
+    fadeInDown: () => fadeInDown,
+    fadeInDownBig: () => fadeInDownBig,
+    fadeInLeft: () => fadeInLeft,
+    fadeInLeftBig: () => fadeInLeftBig,
+    fadeInRight: () => fadeInRight,
+    fadeInRightBig: () => fadeInRightBig,
+    fadeInTopLeft: () => fadeInTopLeft,
+    fadeInTopRight: () => fadeInTopRight,
+    fadeInUp: () => fadeInUp,
+    fadeInUpBig: () => fadeInUpBig,
+    fadeOut: () => fadeOut,
+    fadeOutBottomLeft: () => fadeOutBottomLeft,
+    fadeOutBottomRight: () => fadeOutBottomRight,
+    fadeOutDown: () => fadeOutDown,
+    fadeOutDownBig: () => fadeOutDownBig,
+    fadeOutLeft: () => fadeOutLeft,
+    fadeOutLeftBig: () => fadeOutLeftBig,
+    fadeOutRight: () => fadeOutRight,
+    fadeOutRightBig: () => fadeOutRightBig,
+    fadeOutTopLeft: () => fadeOutTopLeft,
+    fadeOutTopRight: () => fadeOutTopRight,
+    fadeOutUp: () => fadeOutUp,
+    fadeOutUpBig: () => fadeOutUpBig,
+    flash: () => flash,
+    flip: () => flip,
+    flipInX: () => flipInX,
+    flipInY: () => flipInY,
+    flipOutX: () => flipOutX,
+    flipOutY: () => flipOutY,
+    headShake: () => headShake,
+    heartBeat: () => heartBeat,
+    hinge: () => hinge,
+    jackInTheBox: () => jackInTheBox,
+    jello: () => jello,
+    lightSpeedInLeft: () => lightSpeedInLeft,
+    lightSpeedInRight: () => lightSpeedInRight,
+    lightSpeedOutLeft: () => lightSpeedOutLeft,
+    lightSpeedOutRight: () => lightSpeedOutRight,
+    pulse: () => pulse,
+    rollIn: () => rollIn,
+    rollOut: () => rollOut,
+    rotateIn: () => rotateIn,
+    rotateInDownLeft: () => rotateInDownLeft,
+    rotateInDownRight: () => rotateInDownRight,
+    rotateInUpLeft: () => rotateInUpLeft,
+    rotateInUpRight: () => rotateInUpRight,
+    rotateOut: () => rotateOut,
+    rotateOutDownLeft: () => rotateOutDownLeft,
+    rotateOutDownRight: () => rotateOutDownRight,
+    rotateOutUpLeft: () => rotateOutUpLeft,
+    rotateOutUpRight: () => rotateOutUpRight,
+    rubberBand: () => rubberBand,
+    shake: () => shake,
+    shakeX: () => shakeX,
+    shakeY: () => shakeY,
+    slideInDown: () => slideInDown,
+    slideInLeft: () => slideInLeft,
+    slideInRight: () => slideInRight,
+    slideInUp: () => slideInUp,
+    slideOutDown: () => slideOutDown,
+    slideOutLeft: () => slideOutLeft,
+    slideOutRight: () => slideOutRight,
+    slideOutUp: () => slideOutUp,
+    swing: () => swing,
+    tada: () => tada,
+    wobble: () => wobble,
+    zoomIn: () => zoomIn,
+    zoomInDown: () => zoomInDown,
+    zoomInLeft: () => zoomInLeft,
+    zoomInRight: () => zoomInRight,
+    zoomInUp: () => zoomInUp,
+    zoomOut: () => zoomOut,
+    zoomOutDown: () => zoomOutDown,
+    zoomOutLeft: () => zoomOutLeft,
+    zoomOutRight: () => zoomOutRight,
+    zoomOutUp: () => zoomOutUp
+  });
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/bounce.js
+  var bounce = [
+    { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)", transform: "translate3d(0, 0, 0)" },
+    { offset: 0.2, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)", transform: "translate3d(0, 0, 0)" },
+    { offset: 0.4, easing: "cubic-bezier(0.755, 0.05, 0.855, 0.06)", transform: "translate3d(0, -30px, 0) scaleY(1.1)" },
+    { offset: 0.43, easing: "cubic-bezier(0.755, 0.05, 0.855, 0.06)", transform: "translate3d(0, -30px, 0) scaleY(1.1)" },
+    { offset: 0.53, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)", transform: "translate3d(0, 0, 0)" },
+    { offset: 0.7, easing: "cubic-bezier(0.755, 0.05, 0.855, 0.06)", transform: "translate3d(0, -15px, 0) scaleY(1.05)" },
+    {
+      offset: 0.8,
+      "transition-timing-function": "cubic-bezier(0.215, 0.61, 0.355, 1)",
+      transform: "translate3d(0, 0, 0) scaleY(0.95)"
+    },
+    { offset: 0.9, transform: "translate3d(0, -4px, 0) scaleY(1.02)" },
+    { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/flash.js
+  var flash = [
+    { offset: 0, opacity: "1" },
+    { offset: 0.25, opacity: "0" },
+    { offset: 0.5, opacity: "1" },
+    { offset: 0.75, opacity: "0" },
+    { offset: 1, opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/headShake.js
+  var headShake = [
+    { offset: 0, transform: "translateX(0)" },
+    { offset: 0.065, transform: "translateX(-6px) rotateY(-9deg)" },
+    { offset: 0.185, transform: "translateX(5px) rotateY(7deg)" },
+    { offset: 0.315, transform: "translateX(-3px) rotateY(-5deg)" },
+    { offset: 0.435, transform: "translateX(2px) rotateY(3deg)" },
+    { offset: 0.5, transform: "translateX(0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/heartBeat.js
+  var heartBeat = [
+    { offset: 0, transform: "scale(1)" },
+    { offset: 0.14, transform: "scale(1.3)" },
+    { offset: 0.28, transform: "scale(1)" },
+    { offset: 0.42, transform: "scale(1.3)" },
+    { offset: 0.7, transform: "scale(1)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/jello.js
+  var jello = [
+    { offset: 0, transform: "translate3d(0, 0, 0)" },
+    { offset: 0.111, transform: "translate3d(0, 0, 0)" },
+    { offset: 0.222, transform: "skewX(-12.5deg) skewY(-12.5deg)" },
+    { offset: 0.33299999999999996, transform: "skewX(6.25deg) skewY(6.25deg)" },
+    { offset: 0.444, transform: "skewX(-3.125deg) skewY(-3.125deg)" },
+    { offset: 0.555, transform: "skewX(1.5625deg) skewY(1.5625deg)" },
+    { offset: 0.6659999999999999, transform: "skewX(-0.78125deg) skewY(-0.78125deg)" },
+    { offset: 0.777, transform: "skewX(0.390625deg) skewY(0.390625deg)" },
+    { offset: 0.888, transform: "skewX(-0.1953125deg) skewY(-0.1953125deg)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/pulse.js
+  var pulse = [
+    { offset: 0, transform: "scale3d(1, 1, 1)" },
+    { offset: 0.5, transform: "scale3d(1.05, 1.05, 1.05)" },
+    { offset: 1, transform: "scale3d(1, 1, 1)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/rubberBand.js
+  var rubberBand = [
+    { offset: 0, transform: "scale3d(1, 1, 1)" },
+    { offset: 0.3, transform: "scale3d(1.25, 0.75, 1)" },
+    { offset: 0.4, transform: "scale3d(0.75, 1.25, 1)" },
+    { offset: 0.5, transform: "scale3d(1.15, 0.85, 1)" },
+    { offset: 0.65, transform: "scale3d(0.95, 1.05, 1)" },
+    { offset: 0.75, transform: "scale3d(1.05, 0.95, 1)" },
+    { offset: 1, transform: "scale3d(1, 1, 1)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/shake.js
+  var shake = [
+    { offset: 0, transform: "translate3d(0, 0, 0)" },
+    { offset: 0.1, transform: "translate3d(-10px, 0, 0)" },
+    { offset: 0.2, transform: "translate3d(10px, 0, 0)" },
+    { offset: 0.3, transform: "translate3d(-10px, 0, 0)" },
+    { offset: 0.4, transform: "translate3d(10px, 0, 0)" },
+    { offset: 0.5, transform: "translate3d(-10px, 0, 0)" },
+    { offset: 0.6, transform: "translate3d(10px, 0, 0)" },
+    { offset: 0.7, transform: "translate3d(-10px, 0, 0)" },
+    { offset: 0.8, transform: "translate3d(10px, 0, 0)" },
+    { offset: 0.9, transform: "translate3d(-10px, 0, 0)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/shakeX.js
+  var shakeX = [
+    { offset: 0, transform: "translate3d(0, 0, 0)" },
+    { offset: 0.1, transform: "translate3d(-10px, 0, 0)" },
+    { offset: 0.2, transform: "translate3d(10px, 0, 0)" },
+    { offset: 0.3, transform: "translate3d(-10px, 0, 0)" },
+    { offset: 0.4, transform: "translate3d(10px, 0, 0)" },
+    { offset: 0.5, transform: "translate3d(-10px, 0, 0)" },
+    { offset: 0.6, transform: "translate3d(10px, 0, 0)" },
+    { offset: 0.7, transform: "translate3d(-10px, 0, 0)" },
+    { offset: 0.8, transform: "translate3d(10px, 0, 0)" },
+    { offset: 0.9, transform: "translate3d(-10px, 0, 0)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/shakeY.js
+  var shakeY = [
+    { offset: 0, transform: "translate3d(0, 0, 0)" },
+    { offset: 0.1, transform: "translate3d(0, -10px, 0)" },
+    { offset: 0.2, transform: "translate3d(0, 10px, 0)" },
+    { offset: 0.3, transform: "translate3d(0, -10px, 0)" },
+    { offset: 0.4, transform: "translate3d(0, 10px, 0)" },
+    { offset: 0.5, transform: "translate3d(0, -10px, 0)" },
+    { offset: 0.6, transform: "translate3d(0, 10px, 0)" },
+    { offset: 0.7, transform: "translate3d(0, -10px, 0)" },
+    { offset: 0.8, transform: "translate3d(0, 10px, 0)" },
+    { offset: 0.9, transform: "translate3d(0, -10px, 0)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/swing.js
+  var swing = [
+    { offset: 0.2, transform: "rotate3d(0, 0, 1, 15deg)" },
+    { offset: 0.4, transform: "rotate3d(0, 0, 1, -10deg)" },
+    { offset: 0.6, transform: "rotate3d(0, 0, 1, 5deg)" },
+    { offset: 0.8, transform: "rotate3d(0, 0, 1, -5deg)" },
+    { offset: 1, transform: "rotate3d(0, 0, 1, 0deg)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/tada.js
+  var tada = [
+    { offset: 0, transform: "scale3d(1, 1, 1)" },
+    { offset: 0.1, transform: "scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)" },
+    { offset: 0.2, transform: "scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)" },
+    { offset: 0.3, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)" },
+    { offset: 0.4, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)" },
+    { offset: 0.5, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)" },
+    { offset: 0.6, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)" },
+    { offset: 0.7, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)" },
+    { offset: 0.8, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)" },
+    { offset: 0.9, transform: "scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)" },
+    { offset: 1, transform: "scale3d(1, 1, 1)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/attention_seekers/wobble.js
+  var wobble = [
+    { offset: 0, transform: "translate3d(0, 0, 0)" },
+    { offset: 0.15, transform: "translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg)" },
+    { offset: 0.3, transform: "translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg)" },
+    { offset: 0.45, transform: "translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg)" },
+    { offset: 0.6, transform: "translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg)" },
+    { offset: 0.75, transform: "translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/back_entrances/backInDown.js
+  var backInDown = [
+    { offset: 0, transform: "translateY(-1200px) scale(0.7)", opacity: "0.7" },
+    { offset: 0.8, transform: "translateY(0px) scale(0.7)", opacity: "0.7" },
+    { offset: 1, transform: "scale(1)", opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/back_entrances/backInLeft.js
+  var backInLeft = [
+    { offset: 0, transform: "translateX(-2000px) scale(0.7)", opacity: "0.7" },
+    { offset: 0.8, transform: "translateX(0px) scale(0.7)", opacity: "0.7" },
+    { offset: 1, transform: "scale(1)", opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/back_entrances/backInRight.js
+  var backInRight = [
+    { offset: 0, transform: "translateX(2000px) scale(0.7)", opacity: "0.7" },
+    { offset: 0.8, transform: "translateX(0px) scale(0.7)", opacity: "0.7" },
+    { offset: 1, transform: "scale(1)", opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/back_entrances/backInUp.js
+  var backInUp = [
+    { offset: 0, transform: "translateY(1200px) scale(0.7)", opacity: "0.7" },
+    { offset: 0.8, transform: "translateY(0px) scale(0.7)", opacity: "0.7" },
+    { offset: 1, transform: "scale(1)", opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/back_exits/backOutDown.js
+  var backOutDown = [
+    { offset: 0, transform: "scale(1)", opacity: "1" },
+    { offset: 0.2, transform: "translateY(0px) scale(0.7)", opacity: "0.7" },
+    { offset: 1, transform: "translateY(700px) scale(0.7)", opacity: "0.7" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/back_exits/backOutLeft.js
+  var backOutLeft = [
+    { offset: 0, transform: "scale(1)", opacity: "1" },
+    { offset: 0.2, transform: "translateX(0px) scale(0.7)", opacity: "0.7" },
+    { offset: 1, transform: "translateX(-2000px) scale(0.7)", opacity: "0.7" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/back_exits/backOutRight.js
+  var backOutRight = [
+    { offset: 0, transform: "scale(1)", opacity: "1" },
+    { offset: 0.2, transform: "translateX(0px) scale(0.7)", opacity: "0.7" },
+    { offset: 1, transform: "translateX(2000px) scale(0.7)", opacity: "0.7" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/back_exits/backOutUp.js
+  var backOutUp = [
+    { offset: 0, transform: "scale(1)", opacity: "1" },
+    { offset: 0.2, transform: "translateY(0px) scale(0.7)", opacity: "0.7" },
+    { offset: 1, transform: "translateY(-700px) scale(0.7)", opacity: "0.7" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/bouncing_entrances/bounceIn.js
+  var bounceIn = [
+    { offset: 0, opacity: "0", transform: "scale3d(0.3, 0.3, 0.3)" },
+    { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.2, transform: "scale3d(1.1, 1.1, 1.1)" },
+    { offset: 0.2, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.4, transform: "scale3d(0.9, 0.9, 0.9)" },
+    { offset: 0.4, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.6, opacity: "1", transform: "scale3d(1.03, 1.03, 1.03)" },
+    { offset: 0.6, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.8, transform: "scale3d(0.97, 0.97, 0.97)" },
+    { offset: 0.8, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 1, opacity: "1", transform: "scale3d(1, 1, 1)" },
+    { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/bouncing_entrances/bounceInDown.js
+  var bounceInDown = [
+    { offset: 0, opacity: "0", transform: "translate3d(0, -3000px, 0) scaleY(3)" },
+    { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.6, opacity: "1", transform: "translate3d(0, 25px, 0) scaleY(0.9)" },
+    { offset: 0.6, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.75, transform: "translate3d(0, -10px, 0) scaleY(0.95)" },
+    { offset: 0.75, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.9, transform: "translate3d(0, 5px, 0) scaleY(0.985)" },
+    { offset: 0.9, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" },
+    { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/bouncing_entrances/bounceInLeft.js
+  var bounceInLeft = [
+    { offset: 0, opacity: "0", transform: "translate3d(-3000px, 0, 0) scaleX(3)" },
+    { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.6, opacity: "1", transform: "translate3d(25px, 0, 0) scaleX(1)" },
+    { offset: 0.6, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.75, transform: "translate3d(-10px, 0, 0) scaleX(0.98)" },
+    { offset: 0.75, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.9, transform: "translate3d(5px, 0, 0) scaleX(0.995)" },
+    { offset: 0.9, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" },
+    { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/bouncing_entrances/bounceInRight.js
+  var bounceInRight = [
+    { offset: 0, opacity: "0", transform: "translate3d(3000px, 0, 0) scaleX(3)" },
+    { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.6, opacity: "1", transform: "translate3d(-25px, 0, 0) scaleX(1)" },
+    { offset: 0.6, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.75, transform: "translate3d(10px, 0, 0) scaleX(0.98)" },
+    { offset: 0.75, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.9, transform: "translate3d(-5px, 0, 0) scaleX(0.995)" },
+    { offset: 0.9, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" },
+    { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/bouncing_entrances/bounceInUp.js
+  var bounceInUp = [
+    { offset: 0, opacity: "0", transform: "translate3d(0, 3000px, 0) scaleY(5)" },
+    { offset: 0, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.6, opacity: "1", transform: "translate3d(0, -20px, 0) scaleY(0.9)" },
+    { offset: 0.6, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.75, transform: "translate3d(0, 10px, 0) scaleY(0.95)" },
+    { offset: 0.75, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 0.9, transform: "translate3d(0, -5px, 0) scaleY(0.985)" },
+    { offset: 0.9, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" },
+    { offset: 1, easing: "cubic-bezier(0.215, 0.61, 0.355, 1)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/bouncing_exits/bounceOut.js
+  var bounceOut = [
+    { offset: 0.2, transform: "scale3d(0.9, 0.9, 0.9)" },
+    { offset: 0.5, opacity: "1", transform: "scale3d(1.1, 1.1, 1.1)" },
+    { offset: 0.55, opacity: "1", transform: "scale3d(1.1, 1.1, 1.1)" },
+    { offset: 1, opacity: "0", transform: "scale3d(0.3, 0.3, 0.3)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/bouncing_exits/bounceOutDown.js
+  var bounceOutDown = [
+    { offset: 0.2, transform: "translate3d(0, 10px, 0) scaleY(0.985)" },
+    { offset: 0.4, opacity: "1", transform: "translate3d(0, -20px, 0) scaleY(0.9)" },
+    { offset: 0.45, opacity: "1", transform: "translate3d(0, -20px, 0) scaleY(0.9)" },
+    { offset: 1, opacity: "0", transform: "translate3d(0, 2000px, 0) scaleY(3)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/bouncing_exits/bounceOutLeft.js
+  var bounceOutLeft = [
+    { offset: 0.2, opacity: "1", transform: "translate3d(20px, 0, 0) scaleX(0.9)" },
+    { offset: 1, opacity: "0", transform: "translate3d(-2000px, 0, 0) scaleX(2)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/bouncing_exits/bounceOutRight.js
+  var bounceOutRight = [
+    { offset: 0.2, opacity: "1", transform: "translate3d(-20px, 0, 0) scaleX(0.9)" },
+    { offset: 1, opacity: "0", transform: "translate3d(2000px, 0, 0) scaleX(2)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/bouncing_exits/bounceOutUp.js
+  var bounceOutUp = [
+    { offset: 0.2, transform: "translate3d(0, -10px, 0) scaleY(0.985)" },
+    { offset: 0.4, opacity: "1", transform: "translate3d(0, 20px, 0) scaleY(0.9)" },
+    { offset: 0.45, opacity: "1", transform: "translate3d(0, 20px, 0) scaleY(0.9)" },
+    { offset: 1, opacity: "0", transform: "translate3d(0, -2000px, 0) scaleY(3)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeIn.js
+  var fadeIn = [
+    { offset: 0, opacity: "0" },
+    { offset: 1, opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInBottomLeft.js
+  var fadeInBottomLeft = [
+    { offset: 0, opacity: "0", transform: "translate3d(-100%, 100%, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInBottomRight.js
+  var fadeInBottomRight = [
+    { offset: 0, opacity: "0", transform: "translate3d(100%, 100%, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInDown.js
+  var fadeInDown = [
+    { offset: 0, opacity: "0", transform: "translate3d(0, -100%, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInDownBig.js
+  var fadeInDownBig = [
+    { offset: 0, opacity: "0", transform: "translate3d(0, -2000px, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInLeft.js
+  var fadeInLeft = [
+    { offset: 0, opacity: "0", transform: "translate3d(-100%, 0, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInLeftBig.js
+  var fadeInLeftBig = [
+    { offset: 0, opacity: "0", transform: "translate3d(-2000px, 0, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInRight.js
+  var fadeInRight = [
+    { offset: 0, opacity: "0", transform: "translate3d(100%, 0, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInRightBig.js
+  var fadeInRightBig = [
+    { offset: 0, opacity: "0", transform: "translate3d(2000px, 0, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInTopLeft.js
+  var fadeInTopLeft = [
+    { offset: 0, opacity: "0", transform: "translate3d(-100%, -100%, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInTopRight.js
+  var fadeInTopRight = [
+    { offset: 0, opacity: "0", transform: "translate3d(100%, -100%, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInUp.js
+  var fadeInUp = [
+    { offset: 0, opacity: "0", transform: "translate3d(0, 100%, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_entrances/fadeInUpBig.js
+  var fadeInUpBig = [
+    { offset: 0, opacity: "0", transform: "translate3d(0, 2000px, 0)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOut.js
+  var fadeOut = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutBottomLeft.js
+  var fadeOutBottomLeft = [
+    { offset: 0, opacity: "1", transform: "translate3d(0, 0, 0)" },
+    { offset: 1, opacity: "0", transform: "translate3d(-100%, 100%, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutBottomRight.js
+  var fadeOutBottomRight = [
+    { offset: 0, opacity: "1", transform: "translate3d(0, 0, 0)" },
+    { offset: 1, opacity: "0", transform: "translate3d(100%, 100%, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutDown.js
+  var fadeOutDown = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, opacity: "0", transform: "translate3d(0, 100%, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutDownBig.js
+  var fadeOutDownBig = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, opacity: "0", transform: "translate3d(0, 2000px, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutLeft.js
+  var fadeOutLeft = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, opacity: "0", transform: "translate3d(-100%, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutLeftBig.js
+  var fadeOutLeftBig = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, opacity: "0", transform: "translate3d(-2000px, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutRight.js
+  var fadeOutRight = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, opacity: "0", transform: "translate3d(100%, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutRightBig.js
+  var fadeOutRightBig = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, opacity: "0", transform: "translate3d(2000px, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutTopLeft.js
+  var fadeOutTopLeft = [
+    { offset: 0, opacity: "1", transform: "translate3d(0, 0, 0)" },
+    { offset: 1, opacity: "0", transform: "translate3d(-100%, -100%, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutTopRight.js
+  var fadeOutTopRight = [
+    { offset: 0, opacity: "1", transform: "translate3d(0, 0, 0)" },
+    { offset: 1, opacity: "0", transform: "translate3d(100%, -100%, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutUp.js
+  var fadeOutUp = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, opacity: "0", transform: "translate3d(0, -100%, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/fading_exits/fadeOutUpBig.js
+  var fadeOutUpBig = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, opacity: "0", transform: "translate3d(0, -2000px, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/flippers/flip.js
+  var flip = [
+    {
+      offset: 0,
+      transform: "perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, -360deg)",
+      easing: "ease-out"
+    },
+    {
+      offset: 0.4,
+      transform: "perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px)\n      rotate3d(0, 1, 0, -190deg)",
+      easing: "ease-out"
+    },
+    {
+      offset: 0.5,
+      transform: "perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px)\n      rotate3d(0, 1, 0, -170deg)",
+      easing: "ease-in"
+    },
+    {
+      offset: 0.8,
+      transform: "perspective(400px) scale3d(0.95, 0.95, 0.95) translate3d(0, 0, 0)\n      rotate3d(0, 1, 0, 0deg)",
+      easing: "ease-in"
+    },
+    {
+      offset: 1,
+      transform: "perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)",
+      easing: "ease-in"
+    }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/flippers/flipInX.js
+  var flipInX = [
+    { offset: 0, transform: "perspective(400px) rotate3d(1, 0, 0, 90deg)", easing: "ease-in", opacity: "0" },
+    { offset: 0.4, transform: "perspective(400px) rotate3d(1, 0, 0, -20deg)", easing: "ease-in" },
+    { offset: 0.6, transform: "perspective(400px) rotate3d(1, 0, 0, 10deg)", opacity: "1" },
+    { offset: 0.8, transform: "perspective(400px) rotate3d(1, 0, 0, -5deg)" },
+    { offset: 1, transform: "perspective(400px)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/flippers/flipInY.js
+  var flipInY = [
+    { offset: 0, transform: "perspective(400px) rotate3d(0, 1, 0, 90deg)", easing: "ease-in", opacity: "0" },
+    { offset: 0.4, transform: "perspective(400px) rotate3d(0, 1, 0, -20deg)", easing: "ease-in" },
+    { offset: 0.6, transform: "perspective(400px) rotate3d(0, 1, 0, 10deg)", opacity: "1" },
+    { offset: 0.8, transform: "perspective(400px) rotate3d(0, 1, 0, -5deg)" },
+    { offset: 1, transform: "perspective(400px)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/flippers/flipOutX.js
+  var flipOutX = [
+    { offset: 0, transform: "perspective(400px)" },
+    { offset: 0.3, transform: "perspective(400px) rotate3d(1, 0, 0, -20deg)", opacity: "1" },
+    { offset: 1, transform: "perspective(400px) rotate3d(1, 0, 0, 90deg)", opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/flippers/flipOutY.js
+  var flipOutY = [
+    { offset: 0, transform: "perspective(400px)" },
+    { offset: 0.3, transform: "perspective(400px) rotate3d(0, 1, 0, -15deg)", opacity: "1" },
+    { offset: 1, transform: "perspective(400px) rotate3d(0, 1, 0, 90deg)", opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/lightspeed/lightSpeedInLeft.js
+  var lightSpeedInLeft = [
+    { offset: 0, transform: "translate3d(-100%, 0, 0) skewX(30deg)", opacity: "0" },
+    { offset: 0.6, transform: "skewX(-20deg)", opacity: "1" },
+    { offset: 0.8, transform: "skewX(5deg)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/lightspeed/lightSpeedInRight.js
+  var lightSpeedInRight = [
+    { offset: 0, transform: "translate3d(100%, 0, 0) skewX(-30deg)", opacity: "0" },
+    { offset: 0.6, transform: "skewX(20deg)", opacity: "1" },
+    { offset: 0.8, transform: "skewX(-5deg)" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/lightspeed/lightSpeedOutLeft.js
+  var lightSpeedOutLeft = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, transform: "translate3d(-100%, 0, 0) skewX(-30deg)", opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/lightspeed/lightSpeedOutRight.js
+  var lightSpeedOutRight = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, transform: "translate3d(100%, 0, 0) skewX(30deg)", opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/rotating_entrances/rotateIn.js
+  var rotateIn = [
+    { offset: 0, transform: "rotate3d(0, 0, 1, -200deg)", opacity: "0" },
+    { offset: 1, transform: "translate3d(0, 0, 0)", opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/rotating_entrances/rotateInDownLeft.js
+  var rotateInDownLeft = [
+    { offset: 0, transform: "rotate3d(0, 0, 1, -45deg)", opacity: "0" },
+    { offset: 1, transform: "translate3d(0, 0, 0)", opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/rotating_entrances/rotateInDownRight.js
+  var rotateInDownRight = [
+    { offset: 0, transform: "rotate3d(0, 0, 1, 45deg)", opacity: "0" },
+    { offset: 1, transform: "translate3d(0, 0, 0)", opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/rotating_entrances/rotateInUpLeft.js
+  var rotateInUpLeft = [
+    { offset: 0, transform: "rotate3d(0, 0, 1, 45deg)", opacity: "0" },
+    { offset: 1, transform: "translate3d(0, 0, 0)", opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/rotating_entrances/rotateInUpRight.js
+  var rotateInUpRight = [
+    { offset: 0, transform: "rotate3d(0, 0, 1, -90deg)", opacity: "0" },
+    { offset: 1, transform: "translate3d(0, 0, 0)", opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/rotating_exits/rotateOut.js
+  var rotateOut = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, transform: "rotate3d(0, 0, 1, 200deg)", opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/rotating_exits/rotateOutDownLeft.js
+  var rotateOutDownLeft = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, transform: "rotate3d(0, 0, 1, 45deg)", opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/rotating_exits/rotateOutDownRight.js
+  var rotateOutDownRight = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, transform: "rotate3d(0, 0, 1, -45deg)", opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/rotating_exits/rotateOutUpLeft.js
+  var rotateOutUpLeft = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, transform: "rotate3d(0, 0, 1, -45deg)", opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/rotating_exits/rotateOutUpRight.js
+  var rotateOutUpRight = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, transform: "rotate3d(0, 0, 1, 90deg)", opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/sliding_entrances/slideInDown.js
+  var slideInDown = [
+    { offset: 0, transform: "translate3d(0, -100%, 0)", visibility: "visible" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/sliding_entrances/slideInLeft.js
+  var slideInLeft = [
+    { offset: 0, transform: "translate3d(-100%, 0, 0)", visibility: "visible" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/sliding_entrances/slideInRight.js
+  var slideInRight = [
+    { offset: 0, transform: "translate3d(100%, 0, 0)", visibility: "visible" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/sliding_entrances/slideInUp.js
+  var slideInUp = [
+    { offset: 0, transform: "translate3d(0, 100%, 0)", visibility: "visible" },
+    { offset: 1, transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/sliding_exits/slideOutDown.js
+  var slideOutDown = [
+    { offset: 0, transform: "translate3d(0, 0, 0)" },
+    { offset: 1, visibility: "hidden", transform: "translate3d(0, 100%, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/sliding_exits/slideOutLeft.js
+  var slideOutLeft = [
+    { offset: 0, transform: "translate3d(0, 0, 0)" },
+    { offset: 1, visibility: "hidden", transform: "translate3d(-100%, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/sliding_exits/slideOutRight.js
+  var slideOutRight = [
+    { offset: 0, transform: "translate3d(0, 0, 0)" },
+    { offset: 1, visibility: "hidden", transform: "translate3d(100%, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/sliding_exits/slideOutUp.js
+  var slideOutUp = [
+    { offset: 0, transform: "translate3d(0, 0, 0)" },
+    { offset: 1, visibility: "hidden", transform: "translate3d(0, -100%, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/specials/hinge.js
+  var hinge = [
+    { offset: 0, easing: "ease-in-out" },
+    { offset: 0.2, transform: "rotate3d(0, 0, 1, 80deg)", easing: "ease-in-out" },
+    { offset: 0.4, transform: "rotate3d(0, 0, 1, 60deg)", easing: "ease-in-out", opacity: "1" },
+    { offset: 0.6, transform: "rotate3d(0, 0, 1, 80deg)", easing: "ease-in-out" },
+    { offset: 0.8, transform: "rotate3d(0, 0, 1, 60deg)", easing: "ease-in-out", opacity: "1" },
+    { offset: 1, transform: "translate3d(0, 700px, 0)", opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/specials/jackInTheBox.js
+  var jackInTheBox = [
+    { offset: 0, opacity: "0", transform: "scale(0.1) rotate(30deg)", "transform-origin": "center bottom" },
+    { offset: 0.5, transform: "rotate(-10deg)" },
+    { offset: 0.7, transform: "rotate(3deg)" },
+    { offset: 1, opacity: "1", transform: "scale(1)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/specials/rollIn.js
+  var rollIn = [
+    { offset: 0, opacity: "0", transform: "translate3d(-100%, 0, 0) rotate3d(0, 0, 1, -120deg)" },
+    { offset: 1, opacity: "1", transform: "translate3d(0, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/specials/rollOut.js
+  var rollOut = [
+    { offset: 0, opacity: "1" },
+    { offset: 1, opacity: "0", transform: "translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/zooming_entrances/zoomIn.js
+  var zoomIn = [
+    { offset: 0, opacity: "0", transform: "scale3d(0.3, 0.3, 0.3)" },
+    { offset: 0.5, opacity: "1" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/zooming_entrances/zoomInDown.js
+  var zoomInDown = [
+    {
+      offset: 0,
+      opacity: "0",
+      transform: "scale3d(0.1, 0.1, 0.1) translate3d(0, -1000px, 0)",
+      easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+    },
+    {
+      offset: 0.6,
+      opacity: "1",
+      transform: "scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)",
+      easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+    }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/zooming_entrances/zoomInLeft.js
+  var zoomInLeft = [
+    {
+      offset: 0,
+      opacity: "0",
+      transform: "scale3d(0.1, 0.1, 0.1) translate3d(-1000px, 0, 0)",
+      easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+    },
+    {
+      offset: 0.6,
+      opacity: "1",
+      transform: "scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0)",
+      easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+    }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/zooming_entrances/zoomInRight.js
+  var zoomInRight = [
+    {
+      offset: 0,
+      opacity: "0",
+      transform: "scale3d(0.1, 0.1, 0.1) translate3d(1000px, 0, 0)",
+      easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+    },
+    {
+      offset: 0.6,
+      opacity: "1",
+      transform: "scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0)",
+      easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+    }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/zooming_entrances/zoomInUp.js
+  var zoomInUp = [
+    {
+      offset: 0,
+      opacity: "0",
+      transform: "scale3d(0.1, 0.1, 0.1) translate3d(0, 1000px, 0)",
+      easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+    },
+    {
+      offset: 0.6,
+      opacity: "1",
+      transform: "scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)",
+      easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+    }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/zooming_exits/zoomOut.js
+  var zoomOut = [
+    { offset: 0, opacity: "1" },
+    { offset: 0.5, opacity: "0", transform: "scale3d(0.3, 0.3, 0.3)" },
+    { offset: 1, opacity: "0" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/zooming_exits/zoomOutDown.js
+  var zoomOutDown = [
+    {
+      offset: 0.4,
+      opacity: "1",
+      transform: "scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)",
+      easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+    },
+    {
+      offset: 1,
+      opacity: "0",
+      transform: "scale3d(0.1, 0.1, 0.1) translate3d(0, 2000px, 0)",
+      easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+    }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/zooming_exits/zoomOutLeft.js
+  var zoomOutLeft = [
+    { offset: 0.4, opacity: "1", transform: "scale3d(0.475, 0.475, 0.475) translate3d(42px, 0, 0)" },
+    { offset: 1, opacity: "0", transform: "scale(0.1) translate3d(-2000px, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/zooming_exits/zoomOutRight.js
+  var zoomOutRight = [
+    { offset: 0.4, opacity: "1", transform: "scale3d(0.475, 0.475, 0.475) translate3d(-42px, 0, 0)" },
+    { offset: 1, opacity: "0", transform: "scale(0.1) translate3d(2000px, 0, 0)" }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/zooming_exits/zoomOutUp.js
+  var zoomOutUp = [
+    {
+      offset: 0.4,
+      opacity: "1",
+      transform: "scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)",
+      easing: "cubic-bezier(0.55, 0.055, 0.675, 0.19)"
+    },
+    {
+      offset: 1,
+      opacity: "0",
+      transform: "scale3d(0.1, 0.1, 0.1) translate3d(0, -2000px, 0)",
+      easing: "cubic-bezier(0.175, 0.885, 0.32, 1)"
+    }
+  ];
+
+  // node_modules/@shoelace-style/animations/dist/easings/easings.js
+  var easings = {
+    linear: "linear",
+    ease: "ease",
+    easeIn: "ease-in",
+    easeOut: "ease-out",
+    easeInOut: "ease-in-out",
+    easeInSine: "cubic-bezier(0.47, 0, 0.745, 0.715)",
+    easeOutSine: "cubic-bezier(0.39, 0.575, 0.565, 1)",
+    easeInOutSine: "cubic-bezier(0.445, 0.05, 0.55, 0.95)",
+    easeInQuad: "cubic-bezier(0.55, 0.085, 0.68, 0.53)",
+    easeOutQuad: "cubic-bezier(0.25, 0.46, 0.45, 0.94)",
+    easeInOutQuad: "cubic-bezier(0.455, 0.03, 0.515, 0.955)",
+    easeInCubic: "cubic-bezier(0.55, 0.055, 0.675, 0.19)",
+    easeOutCubic: "cubic-bezier(0.215, 0.61, 0.355, 1)",
+    easeInOutCubic: "cubic-bezier(0.645, 0.045, 0.355, 1)",
+    easeInQuart: "cubic-bezier(0.895, 0.03, 0.685, 0.22)",
+    easeOutQuart: "cubic-bezier(0.165, 0.84, 0.44, 1)",
+    easeInOutQuart: "cubic-bezier(0.77, 0, 0.175, 1)",
+    easeInQuint: "cubic-bezier(0.755, 0.05, 0.855, 0.06)",
+    easeOutQuint: "cubic-bezier(0.23, 1, 0.32, 1)",
+    easeInOutQuint: "cubic-bezier(0.86, 0, 0.07, 1)",
+    easeInExpo: "cubic-bezier(0.95, 0.05, 0.795, 0.035)",
+    easeOutExpo: "cubic-bezier(0.19, 1, 0.22, 1)",
+    easeInOutExpo: "cubic-bezier(1, 0, 0, 1)",
+    easeInCirc: "cubic-bezier(0.6, 0.04, 0.98, 0.335)",
+    easeOutCirc: "cubic-bezier(0.075, 0.82, 0.165, 1)",
+    easeInOutCirc: "cubic-bezier(0.785, 0.135, 0.15, 0.86)",
+    easeInBack: "cubic-bezier(0.6, -0.28, 0.735, 0.045)",
+    easeOutBack: "cubic-bezier(0.175, 0.885, 0.32, 1.275)",
+    easeInOutBack: "cubic-bezier(0.68, -0.55, 0.265, 1.55)"
+  };
+
+  // src/components/animation/animation.ts
+  var SlAnimation = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.hasStarted = false;
+      this.name = "none";
+      this.play = false;
+      this.delay = 0;
+      this.direction = "normal";
+      this.duration = 1e3;
+      this.easing = "linear";
+      this.endDelay = 0;
+      this.fill = "auto";
+      this.iterations = Infinity;
+      this.iterationStart = 0;
+      this.playbackRate = 1;
+    }
+    get currentTime() {
+      var _a, _b;
+      return (_b = (_a = this.animation) == null ? void 0 : _a.currentTime) != null ? _b : 0;
+    }
+    set currentTime(time) {
+      if (this.animation) {
+        this.animation.currentTime = time;
+      }
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this.createAnimation();
+      this.handleAnimationCancel = this.handleAnimationCancel.bind(this);
+      this.handleAnimationFinish = this.handleAnimationFinish.bind(this);
+    }
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.destroyAnimation();
+    }
+    handleAnimationChange() {
+      if (!this.hasUpdated) {
         return;
       }
+      this.createAnimation();
+    }
+    handleAnimationFinish() {
+      this.play = false;
+      this.hasStarted = false;
+      this.emit("sl-finish");
+    }
+    handleAnimationCancel() {
+      this.play = false;
+      this.hasStarted = false;
+      this.emit("sl-cancel");
+    }
+    handlePlayChange() {
+      if (this.animation) {
+        if (this.play && !this.hasStarted) {
+          this.hasStarted = true;
+          this.emit("sl-start");
+        }
+        if (this.play) {
+          this.animation.play();
+        } else {
+          this.animation.pause();
+        }
+        return true;
+      }
+      return false;
+    }
+    handlePlaybackRateChange() {
+      if (this.animation) {
+        this.animation.playbackRate = this.playbackRate;
+      }
+    }
+    handleSlotChange() {
+      this.destroyAnimation();
+      this.createAnimation();
+    }
+    async createAnimation() {
+      var _a, _b;
+      const easing = (_a = dist_exports.easings[this.easing]) != null ? _a : this.easing;
+      const keyframes = (_b = this.keyframes) != null ? _b : dist_exports[this.name];
+      const slot = await this.defaultSlot;
+      const element = slot.assignedElements()[0];
+      if (!element || !keyframes) {
+        return false;
+      }
+      this.destroyAnimation();
+      this.animation = element.animate(keyframes, {
+        delay: this.delay,
+        direction: this.direction,
+        duration: this.duration,
+        easing,
+        endDelay: this.endDelay,
+        fill: this.fill,
+        iterationStart: this.iterationStart,
+        iterations: this.iterations
+      });
+      this.animation.playbackRate = this.playbackRate;
+      this.animation.addEventListener("cancel", this.handleAnimationCancel);
+      this.animation.addEventListener("finish", this.handleAnimationFinish);
+      if (this.play) {
+        this.hasStarted = true;
+        this.emit("sl-start");
+      } else {
+        this.animation.pause();
+      }
+      return true;
+    }
+    destroyAnimation() {
+      if (this.animation) {
+        this.animation.cancel();
+        this.animation.removeEventListener("cancel", this.handleAnimationCancel);
+        this.animation.removeEventListener("finish", this.handleAnimationFinish);
+        this.hasStarted = false;
+      }
+    }
+    cancel() {
+      var _a;
+      (_a = this.animation) == null ? void 0 : _a.cancel();
+    }
+    finish() {
+      var _a;
+      (_a = this.animation) == null ? void 0 : _a.finish();
+    }
+    render() {
+      return $` <slot @slotchange=${this.handleSlotChange}></slot> `;
+    }
+  };
+  SlAnimation.styles = animation_styles_default;
+  __decorateClass([
+    e2$1("slot")
+  ], SlAnimation.prototype, "defaultSlot", 2);
+  __decorateClass([
+    e$1()
+  ], SlAnimation.prototype, "name", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlAnimation.prototype, "play", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlAnimation.prototype, "delay", 2);
+  __decorateClass([
+    e$1()
+  ], SlAnimation.prototype, "direction", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlAnimation.prototype, "duration", 2);
+  __decorateClass([
+    e$1()
+  ], SlAnimation.prototype, "easing", 2);
+  __decorateClass([
+    e$1({ attribute: "end-delay", type: Number })
+  ], SlAnimation.prototype, "endDelay", 2);
+  __decorateClass([
+    e$1()
+  ], SlAnimation.prototype, "fill", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlAnimation.prototype, "iterations", 2);
+  __decorateClass([
+    e$1({ attribute: "iteration-start", type: Number })
+  ], SlAnimation.prototype, "iterationStart", 2);
+  __decorateClass([
+    e$1({ attribute: false })
+  ], SlAnimation.prototype, "keyframes", 2);
+  __decorateClass([
+    e$1({ attribute: "playback-rate", type: Number })
+  ], SlAnimation.prototype, "playbackRate", 2);
+  __decorateClass([
+    watch("name"),
+    watch("delay"),
+    watch("direction"),
+    watch("duration"),
+    watch("easing"),
+    watch("endDelay"),
+    watch("fill"),
+    watch("iterations"),
+    watch("iterationsStart"),
+    watch("keyframes")
+  ], SlAnimation.prototype, "handleAnimationChange", 1);
+  __decorateClass([
+    watch("play")
+  ], SlAnimation.prototype, "handlePlayChange", 1);
+  __decorateClass([
+    watch("playbackRate")
+  ], SlAnimation.prototype, "handlePlaybackRateChange", 1);
+  SlAnimation = __decorateClass([
+    n$1("sl-animation")
+  ], SlAnimation);
 
-      const heroku = process.env.HEROKU_APP_NAME;
-      return heroku.includes("-production") ? "production" : heroku.includes("-staging") ? "staging" : "review";
-    };
+  // src/components/card/card.styles.ts
+  var card_styles_default = r$2`
+  ${component_styles_default}
 
-    const initHoneybadger = (opts = {}) => {
-      if (process.env.RAILS_ENV !== "production") return;
-      const appContext = getAppContext();
-      if (!appContext) return;
+  :host {
+    --border-color: var(--sl-color-neutral-200);
+    --border-radius: var(--sl-border-radius-medium);
+    --border-width: 1px;
+    --padding: var(--sl-spacing-large);
 
-      if (!process.env.HONEYBADGER_JS_API_KEY) {
-        console.log(`Honeybadger not configured -- set HONEYBADGER_JS_API_KEY to enable (for ${process.env.HEROKU_APP_NAME})`);
-        return;
+    display: inline-block;
+  }
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--sl-panel-background-color);
+    box-shadow: var(--sl-shadow-x-small);
+    border: solid var(--border-width) var(--border-color);
+    border-radius: var(--border-radius);
+  }
+
+  .card__image {
+    border-top-left-radius: var(--border-radius);
+    border-top-right-radius: var(--border-radius);
+    margin: calc(-1 * var(--border-width));
+    overflow: hidden;
+  }
+
+  .card__image ::slotted(img) {
+    display: block;
+    width: 100%;
+  }
+
+  .card:not(.card--has-image) .card__image {
+    display: none;
+  }
+
+  .card__header {
+    border-bottom: solid var(--border-width) var(--border-color);
+    padding: calc(var(--padding) / 2) var(--padding);
+  }
+
+  .card:not(.card--has-header) .card__header {
+    display: none;
+  }
+
+  .card__body {
+    padding: var(--padding);
+  }
+
+  .card--has-footer .card__footer {
+    border-top: solid var(--border-width) var(--border-color);
+    padding: var(--padding);
+  }
+
+  .card:not(.card--has-footer) .card__footer {
+    display: none;
+  }
+`;
+
+  // src/components/card/card.ts
+  var SlCard = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.hasSlotController = new HasSlotController(this, "footer", "header", "image");
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      card: true,
+      "card--has-footer": this.hasSlotController.test("footer"),
+      "card--has-image": this.hasSlotController.test("image"),
+      "card--has-header": this.hasSlotController.test("header")
+    })}
+      >
+        <div part="image" class="card__image">
+          <slot name="image"></slot>
+        </div>
+
+        <div part="header" class="card__header">
+          <slot name="header"></slot>
+        </div>
+
+        <div part="body" class="card__body">
+          <slot></slot>
+        </div>
+
+        <div part="footer" class="card__footer">
+          <slot name="footer"></slot>
+        </div>
+      </div>
+    `;
+    }
+  };
+  SlCard.styles = card_styles_default;
+  SlCard = __decorateClass([
+    n$1("sl-card")
+  ], SlCard);
+
+  // src/components/checkbox/checkbox.styles.ts
+  var checkbox_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .checkbox {
+    display: inline-flex;
+    align-items: top;
+    font-family: var(--sl-input-font-family);
+    font-size: var(--sl-input-font-size-medium);
+    font-weight: var(--sl-input-font-weight);
+    color: var(--sl-input-color);
+    vertical-align: middle;
+    cursor: pointer;
+  }
+
+  .checkbox__control {
+    flex: 0 0 auto;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--sl-toggle-size);
+    height: var(--sl-toggle-size);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+    border-radius: 2px;
+    background-color: var(--sl-input-background-color);
+    color: var(--sl-color-neutral-0);
+    transition: var(--sl-transition-fast) border-color, var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) color, var(--sl-transition-fast) box-shadow;
+  }
+
+  .checkbox__input {
+    position: absolute;
+    opacity: 0;
+    padding: 0;
+    margin: 0;
+    pointer-events: none;
+  }
+
+  .checkbox__control .checkbox__icon {
+    display: inline-flex;
+    width: var(--sl-toggle-size);
+    height: var(--sl-toggle-size);
+  }
+
+  .checkbox__control .checkbox__icon svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* Hover */
+  .checkbox:not(.checkbox--checked):not(.checkbox--disabled) .checkbox__control:hover {
+    border-color: var(--sl-input-border-color-hover);
+    background-color: var(--sl-input-background-color-hover);
+  }
+
+  /* Focus */
+  .checkbox:not(.checkbox--checked):not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Checked/indeterminate */
+  .checkbox--checked .checkbox__control,
+  .checkbox--indeterminate .checkbox__control {
+    border-color: var(--sl-color-primary-600);
+    background-color: var(--sl-color-primary-600);
+  }
+
+  /* Checked/indeterminate + hover */
+  .checkbox.checkbox--checked:not(.checkbox--disabled) .checkbox__control:hover,
+  .checkbox.checkbox--indeterminate:not(.checkbox--disabled) .checkbox__control:hover {
+    border-color: var(--sl-color-primary-500);
+    background-color: var(--sl-color-primary-500);
+  }
+
+  /* Checked/indeterminate + focus */
+  .checkbox.checkbox--checked:not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control,
+  .checkbox.checkbox--indeterminate:not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Disabled */
+  .checkbox--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .checkbox__label {
+    color: var(--sl-input-label-color);
+    line-height: var(--sl-toggle-size);
+    margin-inline-start: 0.5em;
+    user-select: none;
+  }
+
+  :host([required]) .checkbox__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+`;
+
+  // src/components/checkbox/checkbox.ts
+  var SlCheckbox = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.formSubmitController = new FormSubmitController(this, {
+        value: (control) => control.checked ? control.value || "on" : void 0,
+        defaultValue: (control) => control.defaultChecked,
+        setValue: (control, checked) => control.checked = checked
+      });
+      this.hasFocus = false;
+      this.disabled = false;
+      this.required = false;
+      this.checked = false;
+      this.indeterminate = false;
+      this.invalid = false;
+      this.defaultChecked = false;
+    }
+    firstUpdated() {
+      this.invalid = !this.input.checkValidity();
+    }
+    click() {
+      this.input.click();
+    }
+    focus(options) {
+      this.input.focus(options);
+    }
+    blur() {
+      this.input.blur();
+    }
+    reportValidity() {
+      return this.input.reportValidity();
+    }
+    setCustomValidity(message) {
+      this.input.setCustomValidity(message);
+      this.invalid = !this.input.checkValidity();
+    }
+    handleClick() {
+      this.checked = !this.checked;
+      this.indeterminate = false;
+      this.emit("sl-change");
+    }
+    handleBlur() {
+      this.hasFocus = false;
+      this.emit("sl-blur");
+    }
+    handleDisabledChange() {
+      this.input.disabled = this.disabled;
+      this.invalid = !this.input.checkValidity();
+    }
+    handleFocus() {
+      this.hasFocus = true;
+      this.emit("sl-focus");
+    }
+    handleStateChange() {
+      this.invalid = !this.input.checkValidity();
+    }
+    render() {
+      return $`
+      <label
+        part="base"
+        class=${o$3({
+      checkbox: true,
+      "checkbox--checked": this.checked,
+      "checkbox--disabled": this.disabled,
+      "checkbox--focused": this.hasFocus,
+      "checkbox--indeterminate": this.indeterminate
+    })}
+      >
+        <input
+          class="checkbox__input"
+          type="checkbox"
+          name=${l$2(this.name)}
+          value=${l$2(this.value)}
+          .indeterminate=${l$3(this.indeterminate)}
+          .checked=${l$3(this.checked)}
+          .disabled=${this.disabled}
+          .required=${this.required}
+          aria-checked=${this.checked ? "true" : "false"}
+          @click=${this.handleClick}
+          @blur=${this.handleBlur}
+          @focus=${this.handleFocus}
+        />
+
+        <span part="control" class="checkbox__control">
+          ${this.checked ? $`
+                <svg part="checked-icon" class="checkbox__icon" viewBox="0 0 16 16">
+                  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+                    <g stroke="currentColor" stroke-width="2">
+                      <g transform="translate(3.428571, 3.428571)">
+                        <path d="M0,5.71428571 L3.42857143,9.14285714"></path>
+                        <path d="M9.14285714,0 L3.42857143,9.14285714"></path>
+                      </g>
+                    </g>
+                  </g>
+                </svg>
+              ` : ""}
+          ${!this.checked && this.indeterminate ? $`
+                <svg part="indeterminate-icon" class="checkbox__icon" viewBox="0 0 16 16">
+                  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+                    <g stroke="currentColor" stroke-width="2">
+                      <g transform="translate(2.285714, 6.857143)">
+                        <path d="M10.2857143,1.14285714 L1.14285714,1.14285714"></path>
+                      </g>
+                    </g>
+                  </g>
+                </svg>
+              ` : ""}
+        </span>
+
+        <span part="label" class="checkbox__label">
+          <slot></slot>
+        </span>
+      </label>
+    `;
+    }
+  };
+  SlCheckbox.styles = checkbox_styles_default;
+  __decorateClass([
+    i2$2('input[type="checkbox"]')
+  ], SlCheckbox.prototype, "input", 2);
+  __decorateClass([
+    t$1()
+  ], SlCheckbox.prototype, "hasFocus", 2);
+  __decorateClass([
+    e$1()
+  ], SlCheckbox.prototype, "name", 2);
+  __decorateClass([
+    e$1()
+  ], SlCheckbox.prototype, "value", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlCheckbox.prototype, "disabled", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlCheckbox.prototype, "required", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlCheckbox.prototype, "checked", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlCheckbox.prototype, "indeterminate", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlCheckbox.prototype, "invalid", 2);
+  __decorateClass([
+    defaultValue("checked")
+  ], SlCheckbox.prototype, "defaultChecked", 2);
+  __decorateClass([
+    watch("disabled", { waitUntilFirstUpdate: true })
+  ], SlCheckbox.prototype, "handleDisabledChange", 1);
+  __decorateClass([
+    watch("checked", { waitUntilFirstUpdate: true }),
+    watch("indeterminate", { waitUntilFirstUpdate: true })
+  ], SlCheckbox.prototype, "handleStateChange", 1);
+  SlCheckbox = __decorateClass([
+    n$1("sl-checkbox")
+  ], SlCheckbox);
+
+  // src/components/badge/badge.styles.ts
+  var badge_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-flex;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--sl-font-size-x-small);
+    font-weight: var(--sl-font-weight-semibold);
+    letter-spacing: var(--sl-letter-spacing-normal);
+    line-height: 1;
+    border-radius: var(--sl-border-radius-small);
+    border: solid 1px var(--sl-color-neutral-0);
+    white-space: nowrap;
+    padding: 3px 6px;
+    user-select: none;
+    cursor: inherit;
+  }
+
+  /* Variant modifiers */
+  .badge--primary {
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .badge--success {
+    background-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .badge--neutral {
+    background-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .badge--warning {
+    background-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .badge--danger {
+    background-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Pill modifier */
+  .badge--pill {
+    border-radius: var(--sl-border-radius-pill);
+  }
+
+  /* Pulse modifier */
+  .badge--pulse {
+    animation: pulse 1.5s infinite;
+  }
+
+  .badge--pulse.badge--primary {
+    --pulse-color: var(--sl-color-primary-600);
+  }
+
+  .badge--pulse.badge--success {
+    --pulse-color: var(--sl-color-success-600);
+  }
+
+  .badge--pulse.badge--neutral {
+    --pulse-color: var(--sl-color-neutral-600);
+  }
+
+  .badge--pulse.badge--warning {
+    --pulse-color: var(--sl-color-warning-600);
+  }
+
+  .badge--pulse.badge--danger {
+    --pulse-color: var(--sl-color-danger-600);
+  }
+
+  @keyframes pulse {
+    0% {
+      box-shadow: 0 0 0 0 var(--pulse-color);
+    }
+    70% {
+      box-shadow: 0 0 0 0.5rem transparent;
+    }
+    100% {
+      box-shadow: 0 0 0 0 transparent;
+    }
+  }
+`;
+
+  // src/components/badge/badge.ts
+  var SlBadge = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.variant = "primary";
+      this.pill = false;
+      this.pulse = false;
+    }
+    render() {
+      return $`
+      <span
+        part="base"
+        class=${o$3({
+      badge: true,
+      "badge--primary": this.variant === "primary",
+      "badge--success": this.variant === "success",
+      "badge--neutral": this.variant === "neutral",
+      "badge--warning": this.variant === "warning",
+      "badge--danger": this.variant === "danger",
+      "badge--pill": this.pill,
+      "badge--pulse": this.pulse
+    })}
+        role="status"
+      >
+        <slot></slot>
+      </span>
+    `;
+    }
+  };
+  SlBadge.styles = badge_styles_default;
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlBadge.prototype, "variant", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlBadge.prototype, "pill", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlBadge.prototype, "pulse", 2);
+  SlBadge = __decorateClass([
+    n$1("sl-badge")
+  ], SlBadge);
+
+  // src/components/breadcrumb/breadcrumb.styles.ts
+  var breadcrumb_styles_default = r$2`
+  ${component_styles_default}
+
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+`;
+
+  // src/components/breadcrumb/breadcrumb.ts
+  var SlBreadcrumb = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.localize = new LocalizeController2(this);
+      this.separatorDir = this.localize.dir();
+      this.label = "Breadcrumb";
+    }
+    getSeparator() {
+      const separator = this.separatorSlot.assignedElements({ flatten: true })[0];
+      const clone = separator.cloneNode(true);
+      [clone, ...clone.querySelectorAll("[id]")].forEach((el) => el.removeAttribute("id"));
+      clone.setAttribute("data-default", "");
+      clone.slot = "separator";
+      return clone;
+    }
+    handleSlotChange() {
+      const items = [...this.defaultSlot.assignedElements({ flatten: true })].filter(
+        (item) => item.tagName.toLowerCase() === "sl-breadcrumb-item"
+      );
+      items.forEach((item, index) => {
+        const separator = item.querySelector('[slot="separator"]');
+        if (separator === null) {
+          item.append(this.getSeparator());
+        } else if (separator.hasAttribute("data-default")) {
+          separator.replaceWith(this.getSeparator());
+        } else ;
+        if (index === items.length - 1) {
+          item.setAttribute("aria-current", "page");
+        } else {
+          item.removeAttribute("aria-current");
+        }
+      });
+    }
+    render() {
+      if (this.separatorDir !== this.localize.dir()) {
+        this.separatorDir = this.localize.dir();
+        this.updateComplete.then(() => this.handleSlotChange());
+      }
+      return $`
+      <nav part="base" class="breadcrumb" aria-label=${this.label}>
+        <slot @slotchange=${this.handleSlotChange}></slot>
+      </nav>
+
+      <slot name="separator" hidden aria-hidden="true">
+        <sl-icon name=${this.localize.dir() === "rtl" ? "chevron-left" : "chevron-right"} library="system"></sl-icon>
+      </slot>
+    `;
+    }
+  };
+  SlBreadcrumb.styles = breadcrumb_styles_default;
+  __decorateClass([
+    i2$2("slot")
+  ], SlBreadcrumb.prototype, "defaultSlot", 2);
+  __decorateClass([
+    i2$2('slot[name="separator"]')
+  ], SlBreadcrumb.prototype, "separatorSlot", 2);
+  __decorateClass([
+    e$1()
+  ], SlBreadcrumb.prototype, "label", 2);
+  SlBreadcrumb = __decorateClass([
+    n$1("sl-breadcrumb")
+  ], SlBreadcrumb);
+
+  // src/components/breadcrumb-item/breadcrumb-item.styles.ts
+  var breadcrumb_item_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-flex;
+  }
+
+  .breadcrumb-item {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-small);
+    font-weight: var(--sl-font-weight-semibold);
+    color: var(--sl-color-neutral-600);
+    line-height: var(--sl-line-height-normal);
+    white-space: nowrap;
+  }
+
+  .breadcrumb-item__label {
+    display: inline-block;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    text-decoration: none;
+    color: inherit;
+    background: none;
+    border: none;
+    border-radius: var(--sl-border-radius-medium);
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    transition: var(--sl-transition-fast) --color;
+  }
+
+  :host(:not(:last-of-type)) .breadcrumb-item__label {
+    color: var(--sl-color-primary-600);
+  }
+
+  :host(:not(:last-of-type)) .breadcrumb-item__label:hover {
+    color: var(--sl-color-primary-500);
+  }
+
+  :host(:not(:last-of-type)) .breadcrumb-item__label:active {
+    color: var(--sl-color-primary-600);
+  }
+
+  .breadcrumb-item__label:focus {
+    outline: none;
+  }
+
+  .breadcrumb-item__label:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .breadcrumb-item__prefix,
+  .breadcrumb-item__suffix {
+    display: none;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .breadcrumb-item--has-prefix .breadcrumb-item__prefix {
+    display: inline-flex;
+    margin-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .breadcrumb-item--has-suffix .breadcrumb-item__suffix {
+    display: inline-flex;
+    margin-inline-start: var(--sl-spacing-x-small);
+  }
+
+  :host(:last-of-type) .breadcrumb-item__separator {
+    display: none;
+  }
+
+  .breadcrumb-item__separator {
+    display: inline-flex;
+    align-items: center;
+    margin: 0 var(--sl-spacing-x-small);
+    user-select: none;
+  }
+`;
+
+  // src/components/breadcrumb-item/breadcrumb-item.ts
+  var SlBreadcrumbItem = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.hasSlotController = new HasSlotController(this, "prefix", "suffix");
+      this.rel = "noreferrer noopener";
+    }
+    render() {
+      const isLink = this.href ? true : false;
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      "breadcrumb-item": true,
+      "breadcrumb-item--has-prefix": this.hasSlotController.test("prefix"),
+      "breadcrumb-item--has-suffix": this.hasSlotController.test("suffix")
+    })}
+      >
+        <span part="prefix" class="breadcrumb-item__prefix">
+          <slot name="prefix"></slot>
+        </span>
+
+        ${isLink ? $`
+              <a
+                part="label"
+                class="breadcrumb-item__label breadcrumb-item__label--link"
+                href="${this.href}"
+                target="${l$2(this.target ? this.target : void 0)}"
+                rel=${l$2(this.target ? this.rel : void 0)}
+              >
+                <slot></slot>
+              </a>
+            ` : $`
+              <button part="label" type="button" class="breadcrumb-item__label breadcrumb-item__label--button">
+                <slot></slot>
+              </button>
+            `}
+
+        <span part="suffix" class="breadcrumb-item__suffix">
+          <slot name="suffix"></slot>
+        </span>
+
+        <span part="separator" class="breadcrumb-item__separator" aria-hidden="true">
+          <slot name="separator"></slot>
+        </span>
+      </div>
+    `;
+    }
+  };
+  SlBreadcrumbItem.styles = breadcrumb_item_styles_default;
+  __decorateClass([
+    e$1()
+  ], SlBreadcrumbItem.prototype, "href", 2);
+  __decorateClass([
+    e$1()
+  ], SlBreadcrumbItem.prototype, "target", 2);
+  __decorateClass([
+    e$1()
+  ], SlBreadcrumbItem.prototype, "rel", 2);
+  SlBreadcrumbItem = __decorateClass([
+    n$1("sl-breadcrumb-item")
+  ], SlBreadcrumbItem);
+
+  // src/components/button-group/button-group.styles.ts
+  var button_group_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .button-group {
+    display: flex;
+    flex-wrap: nowrap;
+  }
+`;
+
+  // src/components/button-group/button-group.ts
+  var SlButtonGroup = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.disableRole = false;
+      this.label = "";
+    }
+    handleFocus(event) {
+      const button = findButton(event.target);
+      button == null ? void 0 : button.classList.add("sl-button-group__button--focus");
+    }
+    handleBlur(event) {
+      const button = findButton(event.target);
+      button == null ? void 0 : button.classList.remove("sl-button-group__button--focus");
+    }
+    handleMouseOver(event) {
+      const button = findButton(event.target);
+      button == null ? void 0 : button.classList.add("sl-button-group__button--hover");
+    }
+    handleMouseOut(event) {
+      const button = findButton(event.target);
+      button == null ? void 0 : button.classList.remove("sl-button-group__button--hover");
+    }
+    handleSlotChange() {
+      const slottedElements = [...this.defaultSlot.assignedElements({ flatten: true })];
+      slottedElements.forEach((el) => {
+        const index = slottedElements.indexOf(el);
+        const button = findButton(el);
+        if (button !== null) {
+          button.classList.add("sl-button-group__button");
+          button.classList.toggle("sl-button-group__button--first", index === 0);
+          button.classList.toggle("sl-button-group__button--inner", index > 0 && index < slottedElements.length - 1);
+          button.classList.toggle("sl-button-group__button--last", index === slottedElements.length - 1);
+          button.classList.toggle("sl-button-group__button--radio", button.tagName.toLowerCase() === "sl-radio-button");
+        }
+      });
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class="button-group"
+        role="${this.disableRole ? "presentation" : "group"}"
+        aria-label=${this.label}
+        @focusout=${this.handleBlur}
+        @focusin=${this.handleFocus}
+        @mouseover=${this.handleMouseOver}
+        @mouseout=${this.handleMouseOut}
+      >
+        <slot @slotchange=${this.handleSlotChange} role="none"></slot>
+      </div>
+    `;
+    }
+  };
+  SlButtonGroup.styles = button_group_styles_default;
+  __decorateClass([
+    i2$2("slot")
+  ], SlButtonGroup.prototype, "defaultSlot", 2);
+  __decorateClass([
+    t$1()
+  ], SlButtonGroup.prototype, "disableRole", 2);
+  __decorateClass([
+    e$1()
+  ], SlButtonGroup.prototype, "label", 2);
+  SlButtonGroup = __decorateClass([
+    n$1("sl-button-group")
+  ], SlButtonGroup);
+  function findButton(el) {
+    const children = ["sl-button", "sl-radio-button"];
+    return children.includes(el.tagName.toLowerCase()) ? el : el.querySelector(children.join(","));
+  }
+
+  // src/components/alert/alert.styles.ts
+  var alert_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: contents;
+
+    /* For better DX, we'll reset the margin here so the base part can inherit it */
+    margin: 0;
+  }
+
+  .alert {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    background-color: var(--sl-panel-background-color);
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+    border-top-width: calc(var(--sl-panel-border-width) * 3);
+    border-radius: var(--sl-border-radius-medium);
+    box-shadow: var(--box-shadow);
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-small);
+    font-weight: var(--sl-font-weight-normal);
+    line-height: 1.6;
+    color: var(--sl-color-neutral-700);
+    margin: inherit;
+  }
+
+  .alert:not(.alert--has-icon) .alert__icon,
+  .alert:not(.alert--closable) .alert__close-button {
+    display: none;
+  }
+
+  .alert__icon {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    font-size: var(--sl-font-size-large);
+    padding-inline-start: var(--sl-spacing-large);
+  }
+
+  .alert--primary {
+    border-top-color: var(--sl-color-primary-600);
+  }
+
+  .alert--primary .alert__icon {
+    color: var(--sl-color-primary-600);
+  }
+
+  .alert--success {
+    border-top-color: var(--sl-color-success-600);
+  }
+
+  .alert--success .alert__icon {
+    color: var(--sl-color-success-600);
+  }
+
+  .alert--neutral {
+    border-top-color: var(--sl-color-neutral-600);
+  }
+
+  .alert--neutral .alert__icon {
+    color: var(--sl-color-neutral-600);
+  }
+
+  .alert--warning {
+    border-top-color: var(--sl-color-warning-600);
+  }
+
+  .alert--warning .alert__icon {
+    color: var(--sl-color-warning-600);
+  }
+
+  .alert--danger {
+    border-top-color: var(--sl-color-danger-600);
+  }
+
+  .alert--danger .alert__icon {
+    color: var(--sl-color-danger-600);
+  }
+
+  .alert__message {
+    flex: 1 1 auto;
+    padding: var(--sl-spacing-large);
+    overflow: hidden;
+  }
+
+  .alert__close-button {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    font-size: var(--sl-font-size-large);
+    padding-inline-end: var(--sl-spacing-medium);
+  }
+`;
+
+  // src/components/alert/alert.ts
+  var toastStack = Object.assign(document.createElement("div"), { className: "sl-toast-stack" });
+  var SlAlert = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.hasSlotController = new HasSlotController(this, "icon", "suffix");
+      this.localize = new LocalizeController2(this);
+      this.open = false;
+      this.closable = false;
+      this.variant = "primary";
+      this.duration = Infinity;
+    }
+    firstUpdated() {
+      this.base.hidden = !this.open;
+    }
+    async show() {
+      if (this.open) {
+        return void 0;
+      }
+      this.open = true;
+      return waitForEvent(this, "sl-after-show");
+    }
+    async hide() {
+      if (!this.open) {
+        return void 0;
+      }
+      this.open = false;
+      return waitForEvent(this, "sl-after-hide");
+    }
+    async toast() {
+      return new Promise((resolve) => {
+        if (toastStack.parentElement === null) {
+          document.body.append(toastStack);
+        }
+        toastStack.appendChild(this);
+        requestAnimationFrame(() => {
+          this.clientWidth;
+          this.show();
+        });
+        this.addEventListener(
+          "sl-after-hide",
+          () => {
+            toastStack.removeChild(this);
+            resolve();
+            if (toastStack.querySelector("sl-alert") === null) {
+              toastStack.remove();
+            }
+          },
+          { once: true }
+        );
+      });
+    }
+    restartAutoHide() {
+      clearTimeout(this.autoHideTimeout);
+      if (this.open && this.duration < Infinity) {
+        this.autoHideTimeout = window.setTimeout(() => this.hide(), this.duration);
+      }
+    }
+    handleCloseClick() {
+      this.hide();
+    }
+    handleMouseMove() {
+      this.restartAutoHide();
+    }
+    async handleOpenChange() {
+      if (this.open) {
+        this.emit("sl-show");
+        if (this.duration < Infinity) {
+          this.restartAutoHide();
+        }
+        await stopAnimations(this.base);
+        this.base.hidden = false;
+        const { keyframes, options } = getAnimation(this, "alert.show", { dir: this.localize.dir() });
+        await animateTo(this.base, keyframes, options);
+        this.emit("sl-after-show");
+      } else {
+        this.emit("sl-hide");
+        clearTimeout(this.autoHideTimeout);
+        await stopAnimations(this.base);
+        const { keyframes, options } = getAnimation(this, "alert.hide", { dir: this.localize.dir() });
+        await animateTo(this.base, keyframes, options);
+        this.base.hidden = true;
+        this.emit("sl-after-hide");
+      }
+    }
+    handleDurationChange() {
+      this.restartAutoHide();
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      alert: true,
+      "alert--open": this.open,
+      "alert--closable": this.closable,
+      "alert--has-icon": this.hasSlotController.test("icon"),
+      "alert--primary": this.variant === "primary",
+      "alert--success": this.variant === "success",
+      "alert--neutral": this.variant === "neutral",
+      "alert--warning": this.variant === "warning",
+      "alert--danger": this.variant === "danger"
+    })}
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+        aria-hidden=${this.open ? "false" : "true"}
+        @mousemove=${this.handleMouseMove}
+      >
+        <span part="icon" class="alert__icon">
+          <slot name="icon"></slot>
+        </span>
+
+        <span part="message" class="alert__message">
+          <slot></slot>
+        </span>
+
+        ${this.closable ? $`
+              <sl-icon-button
+                part="close-button"
+                exportparts="base:close-button__base"
+                class="alert__close-button"
+                name="x"
+                library="system"
+                @click=${this.handleCloseClick}
+              ></sl-icon-button>
+            ` : ""}
+      </div>
+    `;
+    }
+  };
+  SlAlert.styles = alert_styles_default;
+  __decorateClass([
+    i2$2('[part="base"]')
+  ], SlAlert.prototype, "base", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlAlert.prototype, "open", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlAlert.prototype, "closable", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlAlert.prototype, "variant", 2);
+  __decorateClass([
+    e$1({ type: Number })
+  ], SlAlert.prototype, "duration", 2);
+  __decorateClass([
+    watch("open", { waitUntilFirstUpdate: true })
+  ], SlAlert.prototype, "handleOpenChange", 1);
+  __decorateClass([
+    watch("duration")
+  ], SlAlert.prototype, "handleDurationChange", 1);
+  SlAlert = __decorateClass([
+    n$1("sl-alert")
+  ], SlAlert);
+  setDefaultAnimation("alert.show", {
+    keyframes: [
+      { opacity: 0, transform: "scale(0.8)" },
+      { opacity: 1, transform: "scale(1)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+  setDefaultAnimation("alert.hide", {
+    keyframes: [
+      { opacity: 1, transform: "scale(1)" },
+      { opacity: 0, transform: "scale(0.8)" }
+    ],
+    options: { duration: 250, easing: "ease" }
+  });
+
+  // src/components/icon-button/icon-button.styles.ts
+  var icon_button_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+  }
+
+  .icon-button {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    background: none;
+    border: none;
+    border-radius: var(--sl-border-radius-medium);
+    font-size: inherit;
+    color: var(--sl-color-neutral-600);
+    padding: var(--sl-spacing-x-small);
+    cursor: pointer;
+    transition: var(--sl-transition-medium) color;
+    -webkit-appearance: none;
+  }
+
+  .icon-button:hover:not(.icon-button--disabled),
+  .icon-button:focus:not(.icon-button--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  .icon-button:active:not(.icon-button--disabled) {
+    color: var(--sl-color-primary-700);
+  }
+
+  .icon-button:focus {
+    outline: none;
+  }
+
+  .icon-button--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .icon-button:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .icon-button__icon {
+    pointer-events: none;
+  }
+`;
+
+  // src/components/icon-button/icon-button.ts
+  var SlIconButton = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.hasFocus = false;
+      this.label = "";
+      this.disabled = false;
+    }
+    click() {
+      this.button.click();
+    }
+    focus(options) {
+      this.button.focus(options);
+    }
+    blur() {
+      this.button.blur();
+    }
+    handleBlur() {
+      this.hasFocus = false;
+      this.emit("sl-blur");
+    }
+    handleFocus() {
+      this.hasFocus = true;
+      this.emit("sl-focus");
+    }
+    handleClick(event) {
+      if (this.disabled) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }
+    render() {
+      const isLink = this.href ? true : false;
+      const tag = isLink ? l$1`a` : l$1`button`;
+      return n`
+      <${tag}
+        part="base"
+        class=${o$3({
+      "icon-button": true,
+      "icon-button--disabled": !isLink && this.disabled,
+      "icon-button--focused": this.hasFocus
+    })}
+        ?disabled=${l$2(isLink ? void 0 : this.disabled)}
+        type=${l$2(isLink ? void 0 : "button")}
+        href=${l$2(isLink ? this.href : void 0)}
+        target=${l$2(isLink ? this.target : void 0)}
+        download=${l$2(isLink ? this.download : void 0)}
+        rel=${l$2(isLink && this.target ? "noreferrer noopener" : void 0)}
+        role=${l$2(isLink ? void 0 : "button")}
+        aria-disabled=${this.disabled ? "true" : "false"}
+        aria-label="${this.label}"
+        tabindex=${this.disabled ? "-1" : "0"}
+        @blur=${this.handleBlur}
+        @focus=${this.handleFocus}
+        @click=${this.handleClick}
+      >
+        <sl-icon
+          class="icon-button__icon"
+          name=${l$2(this.name)}
+          library=${l$2(this.library)}
+          src=${l$2(this.src)}
+          aria-hidden="true"
+        ></sl-icon>
+      </${tag}>
+    `;
+    }
+  };
+  SlIconButton.styles = icon_button_styles_default;
+  __decorateClass([
+    t$1()
+  ], SlIconButton.prototype, "hasFocus", 2);
+  __decorateClass([
+    i2$2(".icon-button")
+  ], SlIconButton.prototype, "button", 2);
+  __decorateClass([
+    e$1()
+  ], SlIconButton.prototype, "name", 2);
+  __decorateClass([
+    e$1()
+  ], SlIconButton.prototype, "library", 2);
+  __decorateClass([
+    e$1()
+  ], SlIconButton.prototype, "src", 2);
+  __decorateClass([
+    e$1()
+  ], SlIconButton.prototype, "href", 2);
+  __decorateClass([
+    e$1()
+  ], SlIconButton.prototype, "target", 2);
+  __decorateClass([
+    e$1()
+  ], SlIconButton.prototype, "download", 2);
+  __decorateClass([
+    e$1()
+  ], SlIconButton.prototype, "label", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlIconButton.prototype, "disabled", 2);
+  SlIconButton = __decorateClass([
+    n$1("sl-icon-button")
+  ], SlIconButton);
+
+  // src/components/animated-image/animated-image.styles.ts
+  var animated_image_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    --control-box-size: 3rem;
+    --icon-size: calc(var(--control-box-size) * 0.625);
+    display: inline-flex;
+    position: relative;
+    cursor: pointer;
+  }
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  img[aria-hidden='true'] {
+    display: none;
+  }
+
+  .animated-image__control-box {
+    display: flex;
+    position: absolute;
+    align-items: center;
+    justify-content: center;
+    top: calc(50% - var(--control-box-size) / 2);
+    right: calc(50% - var(--control-box-size) / 2);
+    width: var(--control-box-size);
+    height: var(--control-box-size);
+    font-size: var(--icon-size);
+    background: none;
+    border: solid 2px currentColor;
+    background-color: rgb(0 0 0 /50%);
+    border-radius: var(--sl-border-radius-circle);
+    color: white;
+    pointer-events: none;
+    transition: var(--sl-transition-fast) opacity;
+  }
+
+  :host([play]:hover) .animated-image__control-box {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  :host([play]:not(:hover)) .animated-image__control-box {
+    opacity: 0;
+  }
+`;
+
+  // src/components/animated-image/animated-image.ts
+  var SlAnimatedImage = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.isLoaded = false;
+    }
+    handleClick() {
+      this.play = !this.play;
+    }
+    handleLoad() {
+      const canvas = document.createElement("canvas");
+      const { width, height } = this.animatedImage;
+      canvas.width = width;
+      canvas.height = height;
+      canvas.getContext("2d").drawImage(this.animatedImage, 0, 0, width, height);
+      this.frozenFrame = canvas.toDataURL("image/gif");
+      if (!this.isLoaded) {
+        this.emit("sl-load");
+        this.isLoaded = true;
+      }
+    }
+    handleError() {
+      this.emit("sl-error");
+    }
+    handlePlayChange() {
+      if (this.play) {
+        this.animatedImage.src = "";
+        this.animatedImage.src = this.src;
+      }
+    }
+    handleSrcChange() {
+      this.isLoaded = false;
+    }
+    render() {
+      return $`
+      <div class="animated-image">
+        <img
+          class="animated-image__animated"
+          src=${this.src}
+          alt=${this.alt}
+          crossorigin="anonymous"
+          aria-hidden=${this.play ? "false" : "true"}
+          @click=${this.handleClick}
+          @load=${this.handleLoad}
+          @error=${this.handleError}
+        />
+
+        ${this.isLoaded ? $`
+              <img
+                class="animated-image__frozen"
+                src=${this.frozenFrame}
+                alt=${this.alt}
+                aria-hidden=${this.play ? "true" : "false"}
+                @click=${this.handleClick}
+              />
+
+              <div part="control-box" class="animated-image__control-box">
+                ${this.play ? $`<sl-icon part="pause-icon" name="pause-fill" library="system"></sl-icon>` : $`<sl-icon part="play-icon" name="play-fill" library="system"></sl-icon>`}
+              </div>
+            ` : ""}
+      </div>
+    `;
+    }
+  };
+  SlAnimatedImage.styles = animated_image_styles_default;
+  __decorateClass([
+    t$1()
+  ], SlAnimatedImage.prototype, "frozenFrame", 2);
+  __decorateClass([
+    t$1()
+  ], SlAnimatedImage.prototype, "isLoaded", 2);
+  __decorateClass([
+    i2$2(".animated-image__animated")
+  ], SlAnimatedImage.prototype, "animatedImage", 2);
+  __decorateClass([
+    e$1()
+  ], SlAnimatedImage.prototype, "src", 2);
+  __decorateClass([
+    e$1()
+  ], SlAnimatedImage.prototype, "alt", 2);
+  __decorateClass([
+    e$1({ type: Boolean, reflect: true })
+  ], SlAnimatedImage.prototype, "play", 2);
+  __decorateClass([
+    watch("play", { waitUntilFirstUpdate: true })
+  ], SlAnimatedImage.prototype, "handlePlayChange", 1);
+  __decorateClass([
+    watch("src")
+  ], SlAnimatedImage.prototype, "handleSrcChange", 1);
+  SlAnimatedImage = __decorateClass([
+    n$1("sl-animated-image")
+  ], SlAnimatedImage);
+
+  // src/components/avatar/avatar.styles.ts
+  var avatar_styles_default = r$2`
+  ${component_styles_default}
+
+  :host {
+    display: inline-block;
+
+    --size: 3rem;
+  }
+
+  .avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    width: var(--size);
+    height: var(--size);
+    background-color: var(--sl-color-neutral-400);
+    font-family: var(--sl-font-sans);
+    font-size: calc(var(--size) * 0.5);
+    font-weight: var(--sl-font-weight-normal);
+    color: var(--sl-color-neutral-0);
+    user-select: none;
+    vertical-align: middle;
+  }
+
+  .avatar--circle,
+  .avatar--circle .avatar__image {
+    border-radius: var(--sl-border-radius-circle);
+  }
+
+  .avatar--rounded,
+  .avatar--rounded .avatar__image {
+    border-radius: var(--sl-border-radius-medium);
+  }
+
+  .avatar--square {
+    border-radius: 0;
+  }
+
+  .avatar__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .avatar__initials {
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .avatar__image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    overflow: hidden;
+  }
+`;
+
+  // src/components/avatar/avatar.ts
+  var SlAvatar = class extends ShoelaceElement {
+    constructor() {
+      super(...arguments);
+      this.hasError = false;
+      this.image = "";
+      this.label = "";
+      this.initials = "";
+      this.shape = "circle";
+    }
+    handleImageChange() {
+      this.hasError = false;
+    }
+    render() {
+      return $`
+      <div
+        part="base"
+        class=${o$3({
+      avatar: true,
+      "avatar--circle": this.shape === "circle",
+      "avatar--rounded": this.shape === "rounded",
+      "avatar--square": this.shape === "square"
+    })}
+        role="img"
+        aria-label=${this.label}
+      >
+        ${this.initials ? $` <div part="initials" class="avatar__initials">${this.initials}</div> ` : $`
+              <div part="icon" class="avatar__icon" aria-hidden="true">
+                <slot name="icon">
+                  <sl-icon name="person-fill" library="system"></sl-icon>
+                </slot>
+              </div>
+            `}
+        ${this.image && !this.hasError ? $`
+              <img
+                part="image"
+                class="avatar__image"
+                src="${this.image}"
+                alt=""
+                @error="${() => this.hasError = true}"
+              />
+            ` : ""}
+      </div>
+    `;
+    }
+  };
+  SlAvatar.styles = avatar_styles_default;
+  __decorateClass([
+    t$1()
+  ], SlAvatar.prototype, "hasError", 2);
+  __decorateClass([
+    e$1()
+  ], SlAvatar.prototype, "image", 2);
+  __decorateClass([
+    e$1()
+  ], SlAvatar.prototype, "label", 2);
+  __decorateClass([
+    e$1()
+  ], SlAvatar.prototype, "initials", 2);
+  __decorateClass([
+    e$1({ reflect: true })
+  ], SlAvatar.prototype, "shape", 2);
+  __decorateClass([
+    watch("image")
+  ], SlAvatar.prototype, "handleImageChange", 1);
+  SlAvatar = __decorateClass([
+    n$1("sl-avatar")
+  ], SlAvatar);
+
+  /*
+  Stimulus 3.1.0
+  Copyright © 2022 Basecamp, LLC
+   */
+
+  function camelize(value) {
+      return value.replace(/(?:[_-])([a-z0-9])/g, (_, char) => char.toUpperCase());
+  }
+  function capitalize(value) {
+      return value.charAt(0).toUpperCase() + value.slice(1);
+  }
+  function dasherize(value) {
+      return value.replace(/([A-Z])/g, (_, char) => `-${char.toLowerCase()}`);
+  }
+
+  function readInheritableStaticArrayValues(constructor, propertyName) {
+      const ancestors = getAncestorsForConstructor(constructor);
+      return Array.from(ancestors.reduce((values, constructor) => {
+          getOwnStaticArrayValues(constructor, propertyName).forEach(name => values.add(name));
+          return values;
+      }, new Set));
+  }
+  function readInheritableStaticObjectPairs(constructor, propertyName) {
+      const ancestors = getAncestorsForConstructor(constructor);
+      return ancestors.reduce((pairs, constructor) => {
+          pairs.push(...getOwnStaticObjectPairs(constructor, propertyName));
+          return pairs;
+      }, []);
+  }
+  function getAncestorsForConstructor(constructor) {
+      const ancestors = [];
+      while (constructor) {
+          ancestors.push(constructor);
+          constructor = Object.getPrototypeOf(constructor);
+      }
+      return ancestors.reverse();
+  }
+  function getOwnStaticArrayValues(constructor, propertyName) {
+      const definition = constructor[propertyName];
+      return Array.isArray(definition) ? definition : [];
+  }
+  function getOwnStaticObjectPairs(constructor, propertyName) {
+      const definition = constructor[propertyName];
+      return definition ? Object.keys(definition).map(key => [key, definition[key]]) : [];
+  }
+  (() => {
+      function extendWithReflect(constructor) {
+          function extended() {
+              return Reflect.construct(constructor, arguments, new.target);
+          }
+          extended.prototype = Object.create(constructor.prototype, {
+              constructor: { value: extended }
+          });
+          Reflect.setPrototypeOf(extended, constructor);
+          return extended;
+      }
+      function testReflectExtension() {
+          const a = function () { this.a.call(this); };
+          const b = extendWithReflect(a);
+          b.prototype.a = function () { };
+          return new b;
+      }
+      try {
+          testReflectExtension();
+          return extendWithReflect;
+      }
+      catch (error) {
+          return (constructor) => class extended extends constructor {
+          };
+      }
+  })();
+
+  function ClassPropertiesBlessing(constructor) {
+      const classes = readInheritableStaticArrayValues(constructor, "classes");
+      return classes.reduce((properties, classDefinition) => {
+          return Object.assign(properties, propertiesForClassDefinition(classDefinition));
+      }, {});
+  }
+  function propertiesForClassDefinition(key) {
+      return {
+          [`${key}Class`]: {
+              get() {
+                  const { classes } = this;
+                  if (classes.has(key)) {
+                      return classes.get(key);
+                  }
+                  else {
+                      const attribute = classes.getAttributeName(key);
+                      throw new Error(`Missing attribute "${attribute}"`);
+                  }
+              }
+          },
+          [`${key}Classes`]: {
+              get() {
+                  return this.classes.getAll(key);
+              }
+          },
+          [`has${capitalize(key)}Class`]: {
+              get() {
+                  return this.classes.has(key);
+              }
+          }
+      };
+  }
+
+  function TargetPropertiesBlessing(constructor) {
+      const targets = readInheritableStaticArrayValues(constructor, "targets");
+      return targets.reduce((properties, targetDefinition) => {
+          return Object.assign(properties, propertiesForTargetDefinition(targetDefinition));
+      }, {});
+  }
+  function propertiesForTargetDefinition(name) {
+      return {
+          [`${name}Target`]: {
+              get() {
+                  const target = this.targets.find(name);
+                  if (target) {
+                      return target;
+                  }
+                  else {
+                      throw new Error(`Missing target element "${name}" for "${this.identifier}" controller`);
+                  }
+              }
+          },
+          [`${name}Targets`]: {
+              get() {
+                  return this.targets.findAll(name);
+              }
+          },
+          [`has${capitalize(name)}Target`]: {
+              get() {
+                  return this.targets.has(name);
+              }
+          }
+      };
+  }
+
+  function ValuePropertiesBlessing(constructor) {
+      const valueDefinitionPairs = readInheritableStaticObjectPairs(constructor, "values");
+      const propertyDescriptorMap = {
+          valueDescriptorMap: {
+              get() {
+                  return valueDefinitionPairs.reduce((result, valueDefinitionPair) => {
+                      const valueDescriptor = parseValueDefinitionPair(valueDefinitionPair, this.identifier);
+                      const attributeName = this.data.getAttributeNameForKey(valueDescriptor.key);
+                      return Object.assign(result, { [attributeName]: valueDescriptor });
+                  }, {});
+              }
+          }
+      };
+      return valueDefinitionPairs.reduce((properties, valueDefinitionPair) => {
+          return Object.assign(properties, propertiesForValueDefinitionPair(valueDefinitionPair));
+      }, propertyDescriptorMap);
+  }
+  function propertiesForValueDefinitionPair(valueDefinitionPair, controller) {
+      const definition = parseValueDefinitionPair(valueDefinitionPair, controller);
+      const { key, name, reader: read, writer: write } = definition;
+      return {
+          [name]: {
+              get() {
+                  const value = this.data.get(key);
+                  if (value !== null) {
+                      return read(value);
+                  }
+                  else {
+                      return definition.defaultValue;
+                  }
+              },
+              set(value) {
+                  if (value === undefined) {
+                      this.data.delete(key);
+                  }
+                  else {
+                      this.data.set(key, write(value));
+                  }
+              }
+          },
+          [`has${capitalize(name)}`]: {
+              get() {
+                  return this.data.has(key) || definition.hasCustomDefaultValue;
+              }
+          }
+      };
+  }
+  function parseValueDefinitionPair([token, typeDefinition], controller) {
+      return valueDescriptorForTokenAndTypeDefinition({
+          controller,
+          token,
+          typeDefinition,
+      });
+  }
+  function parseValueTypeConstant(constant) {
+      switch (constant) {
+          case Array: return "array";
+          case Boolean: return "boolean";
+          case Number: return "number";
+          case Object: return "object";
+          case String: return "string";
+      }
+  }
+  function parseValueTypeDefault(defaultValue) {
+      switch (typeof defaultValue) {
+          case "boolean": return "boolean";
+          case "number": return "number";
+          case "string": return "string";
+      }
+      if (Array.isArray(defaultValue))
+          return "array";
+      if (Object.prototype.toString.call(defaultValue) === "[object Object]")
+          return "object";
+  }
+  function parseValueTypeObject(payload) {
+      const typeFromObject = parseValueTypeConstant(payload.typeObject.type);
+      if (!typeFromObject)
+          return;
+      const defaultValueType = parseValueTypeDefault(payload.typeObject.default);
+      if (typeFromObject !== defaultValueType) {
+          const propertyPath = payload.controller ? `${payload.controller}.${payload.token}` : payload.token;
+          throw new Error(`The specified default value for the Stimulus Value "${propertyPath}" must match the defined type "${typeFromObject}". The provided default value of "${payload.typeObject.default}" is of type "${defaultValueType}".`);
+      }
+      return typeFromObject;
+  }
+  function parseValueTypeDefinition(payload) {
+      const typeFromObject = parseValueTypeObject({
+          controller: payload.controller,
+          token: payload.token,
+          typeObject: payload.typeDefinition
+      });
+      const typeFromDefaultValue = parseValueTypeDefault(payload.typeDefinition);
+      const typeFromConstant = parseValueTypeConstant(payload.typeDefinition);
+      const type = typeFromObject || typeFromDefaultValue || typeFromConstant;
+      if (type)
+          return type;
+      const propertyPath = payload.controller ? `${payload.controller}.${payload.typeDefinition}` : payload.token;
+      throw new Error(`Unknown value type "${propertyPath}" for "${payload.token}" value`);
+  }
+  function defaultValueForDefinition(typeDefinition) {
+      const constant = parseValueTypeConstant(typeDefinition);
+      if (constant)
+          return defaultValuesByType[constant];
+      const defaultValue = typeDefinition.default;
+      if (defaultValue !== undefined)
+          return defaultValue;
+      return typeDefinition;
+  }
+  function valueDescriptorForTokenAndTypeDefinition(payload) {
+      const key = `${dasherize(payload.token)}-value`;
+      const type = parseValueTypeDefinition(payload);
+      return {
+          type,
+          key,
+          name: camelize(key),
+          get defaultValue() { return defaultValueForDefinition(payload.typeDefinition); },
+          get hasCustomDefaultValue() { return parseValueTypeDefault(payload.typeDefinition) !== undefined; },
+          reader: readers[type],
+          writer: writers[type] || writers.default
+      };
+  }
+  const defaultValuesByType = {
+      get array() { return []; },
+      boolean: false,
+      number: 0,
+      get object() { return {}; },
+      string: ""
+  };
+  const readers = {
+      array(value) {
+          const array = JSON.parse(value);
+          if (!Array.isArray(array)) {
+              throw new TypeError(`expected value of type "array" but instead got value "${value}" of type "${parseValueTypeDefault(array)}"`);
+          }
+          return array;
+      },
+      boolean(value) {
+          return !(value == "0" || String(value).toLowerCase() == "false");
+      },
+      number(value) {
+          return Number(value);
+      },
+      object(value) {
+          const object = JSON.parse(value);
+          if (object === null || typeof object != "object" || Array.isArray(object)) {
+              throw new TypeError(`expected value of type "object" but instead got value "${value}" of type "${parseValueTypeDefault(object)}"`);
+          }
+          return object;
+      },
+      string(value) {
+          return value;
+      }
+  };
+  const writers = {
+      default: writeString,
+      array: writeJSON,
+      object: writeJSON
+  };
+  function writeJSON(value) {
+      return JSON.stringify(value);
+  }
+  function writeString(value) {
+      return `${value}`;
+  }
+
+  class Controller {
+      constructor(context) {
+          this.context = context;
+      }
+      static get shouldLoad() {
+          return true;
+      }
+      get application() {
+          return this.context.application;
+      }
+      get scope() {
+          return this.context.scope;
+      }
+      get element() {
+          return this.scope.element;
+      }
+      get identifier() {
+          return this.scope.identifier;
+      }
+      get targets() {
+          return this.scope.targets;
+      }
+      get classes() {
+          return this.scope.classes;
+      }
+      get data() {
+          return this.scope.data;
+      }
+      initialize() {
+      }
+      connect() {
+      }
+      disconnect() {
+      }
+      dispatch(eventName, { target = this.element, detail = {}, prefix = this.identifier, bubbles = true, cancelable = true } = {}) {
+          const type = prefix ? `${prefix}:${eventName}` : eventName;
+          const event = new CustomEvent(type, { detail, bubbles, cancelable });
+          target.dispatchEvent(event);
+          return event;
+      }
+  }
+  Controller.blessings = [ClassPropertiesBlessing, TargetPropertiesBlessing, ValuePropertiesBlessing];
+  Controller.targets = [];
+  Controller.values = {};
+
+  class input_clipboard_controller extends Controller {
+    copy(_event) {
+      const clipboardCopyEl = this.element;
+      clipboardCopyEl.classList.add("clicked");
+      setTimeout(() => {
+        clipboardCopyEl.classList.remove("clicked");
+      }, 5000);
+    }
+
+  }
+
+  const Inputmask = require("inputmask").default;
+
+  class input_mask_controller extends Controller {
+    connect() {
+      Inputmask(this.data.get("pattern")).mask(this.element);
+    }
+
+  }
+
+  function _defineProperty(obj, key, value) {
+    if (key in obj) {
+      Object.defineProperty(obj, key, {
+        value: value,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+    } else {
+      obj[key] = value;
+    }
+
+    return obj;
+  }
+
+  class _class$1 extends Controller {
+    connect() {
+      this.element[this.identifier] = this;
+      this.classToToggle = this.hasToggleClass ? this.toggleClass : "hidden";
+      this.externalTargets = document.getElementsByClassName(this.data.get("externalTargetClass"));
+    }
+
+    classIsApplied() {
+      return this.element.classList.contains(this.classToToggle);
+    }
+
+    toggle(event) {
+      if (!this.data.has("allowDefault")) event.preventDefault();
+      this.toggleControllerTargets();
+      this.toggleExternalTargets();
+    }
+
+    toggleOff(event) {
+      if (!this.data.has("allowDefault")) event.preventDefault();
+      if (this.classIsApplied()) this.toggle(event);
+    }
+
+    toggleControllerTargets() {
+      this.toggleableTargets.forEach(target => {
+        this.toggleElementClassList(target);
+      });
+    }
+
+    toggleExternalTargets() {
+      for (let i = 0; i < this.externalTargets.length; ++i) {
+        this.toggleElementClassList(this.externalTargets[i]);
+      }
+    }
+
+    toggleElementClassList(targetElement) {
+      targetElement.classList.toggle(this.classToToggle);
+    }
+
+  }
+
+  _defineProperty(_class$1, "targets", ["toggleable"]);
+
+  _defineProperty(_class$1, "classes", ["toggle"]);
+
+  class _class extends Controller {
+    // TODO: hardcoded to work with /for-leaders page - switch to using Values to customize active/inactive classes
+    connect() {
+      this.element[this.identifier] = this;
+    }
+
+    switch(event) {
+      if (!this.data.has("allowDefault")) {
+        event.preventDefault();
       }
 
-      const config = Object.assign({
-        apiKey: process.env.HONEYBADGER_JS_API_KEY,
-        environment: appContext
-      }, opts);
-      Honeybadger.configure(config);
-      window.Honeybadger = Honeybadger;
-    };
+      this.deactivate();
+      this.activate(event.target);
+    }
 
-    exports.InputClipboardController = input_clipboard_controller;
-    exports.InputMaskController = input_mask_controller;
-    exports.SwitchController = _class;
-    exports.ToggleController = _class$1;
-    exports.initHoneybadger = initHoneybadger;
+    deactivate() {
+      this.switchableTargets.forEach(target => {
+        target.classList.add("hidden");
+      });
+      this.clickableTargets.forEach(target => {
+        target.classList.remove("text-gray-100", "border-gray-100");
+        target.classList.add("border-gray-900");
+      });
+    }
 
-    Object.defineProperty(exports, '__esModule', { value: true });
+    activate(currentElement) {
+      currentElement.classList.remove("border-gray-900");
+      currentElement.classList.add("text-gray-100", "border-gray-100");
+      document.querySelectorAll(`.${currentElement.id}`).forEach(element => {
+        element.classList.remove("hidden");
+      });
+    }
+
+  }
+
+  _defineProperty(_class, "targets", ["switchable", "clickable"]);
+
+  const Honeybadger = require("@honeybadger-io/js");
+
+  const getAppContext = () => {
+    // TODO: Kali - remove this var once upstream Heroku/Doppler issues resolved
+    if (process.env.EXPLICIT_APP_CONTEXT) return process.env.EXPLICIT_APP_CONTEXT;
+
+    if (!process.env.HEROKU_APP_NAME) {
+      console.log("WARN: production-ish environment is missing both HEROKU_APP_NAME and EXPLICIT_APP_CONTEXT");
+      return;
+    }
+
+    const heroku = process.env.HEROKU_APP_NAME;
+    return heroku.includes("-production") ? "production" : heroku.includes("-staging") ? "staging" : "review";
+  };
+
+  const initHoneybadger = (opts = {}) => {
+    if (process.env.RAILS_ENV !== "production") return;
+    const appContext = getAppContext();
+    if (!appContext) return;
+
+    if (!process.env.HONEYBADGER_JS_API_KEY) {
+      console.log(`Honeybadger not configured -- set HONEYBADGER_JS_API_KEY to enable (for ${process.env.HEROKU_APP_NAME})`);
+      return;
+    }
+
+    const config = Object.assign({
+      apiKey: process.env.HONEYBADGER_JS_API_KEY,
+      environment: appContext
+    }, opts);
+    Honeybadger.configure(config);
+    window.Honeybadger = Honeybadger;
+  };
+
+  exports.InputClipboardController = input_clipboard_controller;
+  exports.InputMaskController = input_mask_controller;
+  exports.SwitchController = _class;
+  exports.ToggleController = _class$1;
+  exports.initHoneybadger = initHoneybadger;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@github/clipboard-copy-element": "^1.1.2",
     "@honeybadger-io/js": "^4.3.0",
     "@hotwired/stimulus": "^3.1.0",
+    "@shoelace-style/shoelace": "^2.0.0-beta.83",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.2.1",
     "@tailwindcss/line-clamp": "^0.4.0",

--- a/scss/tokens/_tokens.scss
+++ b/scss/tokens/_tokens.scss
@@ -1,0 +1,12 @@
+@import 'teamshares/ts-colors';
+@import 'teamshares/ts-typography';
+@import 'teamshares/ts-global';
+
+@import '@shoelace-style/shoelace/dist/themes/light';
+@import 'shoelace/sl-colors';
+@import 'shoelace/sl-global';
+@import 'shoelace/sl-button';
+@import 'shoelace/sl-dialog';
+@import 'shoelace/sl-divider';
+@import 'shoelace/sl-forms';
+@import 'shoelace/sl-icon';

--- a/scss/tokens/shoelace/_sl-button.scss
+++ b/scss/tokens/shoelace/_sl-button.scss
@@ -1,0 +1,156 @@
+:root,
+:host,
+sl-theme {
+  /* Button font size override */
+  --sl-button-font-size-large: var(--sl-font-size-small);
+}
+
+/** ********** **/
+/* Button custom colors */
+sl-button[variant='primary']::part(base):hover {
+  background-color: var(--sl-color-primary-700);
+  border-color: var(--sl-color-primary-600);
+}
+
+sl-button[variant='primary']::part(base):active {
+  background-color: var(--sl-color-primary-800);
+  border-color: var(--sl-color-primary-600);
+}
+
+sl-button[variant='default']::part(base) {
+  background-color: var(--sl-color-neutral-100);
+  border-color: var(--sl-color-neutral-300);
+  color: var(--ts-color-text-default);
+}
+
+sl-button[variant='default']::part(base):hover {
+  background-color: var(--sl-color-neutral-200);
+  border-color: var(--sl-color-neutral-300);
+  color: var(--ts-color-text-default);
+}
+
+sl-button[variant='default']::part(base):active {
+  background-color: var(--sl-color-neutral-300);
+  border-color: var(--sl-color-neutral-300);
+  color: var(--ts-color-text-default);
+}
+
+sl-button[variant='neutral']::part(base) {
+  background-color: transparent;
+  border-color: var(--sl-color-neutral-400);
+  color: var(--ts-color-text-default);
+}
+
+sl-button[variant='neutral']::part(base):hover {
+  background-color: var(--sl-color-neutral-200);
+  border-color: var(--sl-color-neutral-400);
+  color: var(--ts-color-text-default);
+}
+
+sl-button[variant='neutral']::part(base):active {
+  background-color: var(--sl-color-neutral-300);
+  border-color: var(--sl-color-neutral-400);
+  color: var(--ts-color-text-default);
+}
+
+sl-button[variant='warning']::part(base) {
+  background-color: var(--sl-color-warning-500);
+  border-color: var(--sl-color-warning-500);
+}
+
+sl-button[variant='warning']::part(label),
+sl-button[variant='warning']::part(caret),
+sl-button[variant='warning']::part(prefix),
+sl-button[variant='warning']::part(suffix) {
+  color: var(--ts-color-text-default);
+}
+
+sl-button[variant='warning']::part(base):hover {
+  background-color: var(--sl-color-warning-600);
+  border-color: var(--sl-color-warning-500);
+}
+
+sl-button[variant='warning']::part(base):active {
+  background-color: var(--sl-color-warning-600);
+  border-color: var(--sl-color-warning-500);
+  filter: brightness(0.95);
+}
+
+sl-button[variant='danger']::part(base) {
+  background-color: var(--sl-color-danger-700);
+  border-color: var(--sl-color-danger-700);
+}
+
+sl-button[variant='danger']::part(base):hover {
+  background-color: var(--sl-color-danger-800);
+  border-color: var(--sl-color-danger-700);
+}
+
+sl-button[variant='danger']::part(base):active {
+  background-color: var(--sl-color-danger-900);
+  border-color: var(--sl-color-danger-700);
+}
+
+sl-button[outline]::part(base) {
+  background-color: transparent;
+}
+
+/** ********** **/
+/* Button custom font size + padding */
+
+sl-button[size='medium']::part(base) {
+  padding: 0 var(--sl-spacing-medium); /* 16px */
+}
+
+sl-button[size='medium']::part(label) {
+  padding: 0 var(--sl-spacing-x-small); /* 8px */
+}
+
+sl-button[size='large']::part(base) {
+  padding: 0 20px;
+}
+
+sl-button[size='large']::part(label) {
+  padding: 0 var(--sl-spacing-small); /* 12px */
+}
+
+sl-button[size='medium']::part(caret),
+sl-button[size='medium']::part(prefix),
+sl-button[size='medium']::part(suffix) {
+  font-size: var(--ts-font-base); /* 16px */
+}
+
+sl-button[size='large']::part(caret),
+sl-button[size='large']::part(prefix),
+sl-button[size='large']::part(suffix),
+sl-button[size='medium'][circle]::part(base),
+sl-button[size='large'][circle]::part(base) {
+  font-size: var(--ts-font-xl); /* 20px */
+}
+
+sl-button.no-pad-l::part(base) {
+  padding-left: 0;
+}
+
+sl-button.no-pad-r::part(base) {
+  padding-right: 0;
+}
+
+/** ********** **/
+/* Button custom size, x-large */
+
+sl-button.x-large::part(base) {
+  height: var(--sl-spacing-4x-large); /* 64px */
+  padding: 0 var(--sl-spacing-2x-large); /* 32px */
+}
+
+sl-button.x-large::part(label) {
+  font-size: var(--ts-font-base); /* 16px */
+  line-height: calc(var(--sl-spacing-4x-large) - var(--sl-input-border-width) * 2);
+}
+
+sl-button.x-large::part(caret),
+sl-button.x-large::part(prefix),
+sl-button.x-large::part(suffix) {
+  font-size: var(--ts-font-2xl); /* 24px */
+}

--- a/scss/tokens/shoelace/_sl-colors.scss
+++ b/scss/tokens/shoelace/_sl-colors.scss
@@ -1,0 +1,68 @@
+:root,
+:host,
+.sl-theme-light {
+  --sl-color-primary-50: var(--ts-color-primary-50);
+  --sl-color-primary-100: var(--ts-color-primary-100);
+  --sl-color-primary-200: var(--ts-color-primary-200);
+  --sl-color-primary-300: var(--ts-color-primary-300);
+  --sl-color-primary-400: var(--ts-color-primary-400);
+  --sl-color-primary-500: var(--ts-color-primary-500);
+  --sl-color-primary-600: var(--ts-color-primary-600);
+  --sl-color-primary-700: var(--ts-color-primary-700);
+  --sl-color-primary-800: var(--ts-color-primary-800);
+  --sl-color-primary-900: var(--ts-color-primary-900);
+  --sl-color-primary-950: var(--ts-color-primary-950);
+
+  --sl-color-success-50: var(--ts-color-success-50);
+  --sl-color-success-100: var(--ts-color-success-100);
+  --sl-color-success-200: var(--ts-color-success-200);
+  --sl-color-success-300: var(--ts-color-success-300);
+  --sl-color-success-400: var(--ts-color-success-400);
+  --sl-color-success-500: var(--ts-color-success-500);
+  --sl-color-success-600: var(--ts-color-success-600);
+  --sl-color-success-700: var(--ts-color-success-700);
+  --sl-color-success-800: var(--ts-color-success-800);
+  --sl-color-success-900: var(--ts-color-success-900);
+  --sl-color-success-950: var(--ts-color-success-950);
+
+  --sl-color-warning-50: var(--ts-color-warning-50);
+  --sl-color-warning-100: var(--ts-color-warning-100);
+  --sl-color-warning-200: var(--ts-color-warning-200);
+  --sl-color-warning-300: var(--ts-color-warning-300);
+  --sl-color-warning-400: var(--ts-color-warning-400);
+  --sl-color-warning-500: var(--ts-color-warning-500);
+  --sl-color-warning-600: var(--ts-color-warning-600);
+  --sl-color-warning-700: var(--ts-color-warning-700);
+  --sl-color-warning-800: var(--ts-color-warning-800);
+  --sl-color-warning-900: var(--ts-color-warning-900);
+  --sl-color-warning-950: var(--ts-color-warning-950);
+
+  --sl-color-danger-50: var(--ts-color-danger-50);
+  --sl-color-danger-100: var(--ts-color-danger-100);
+  --sl-color-danger-200: var(--ts-color-danger-200);
+  --sl-color-danger-300: var(--ts-color-danger-300);
+  --sl-color-danger-400: var(--ts-color-danger-400);
+  --sl-color-danger-500: var(--ts-color-danger-500);
+  --sl-color-danger-600: var(--ts-color-danger-600);
+  --sl-color-danger-700: var(--ts-color-danger-700);
+  --sl-color-danger-800: var(--ts-color-danger-800);
+  --sl-color-danger-900: var(--ts-color-danger-900);
+  --sl-color-danger-950: var(--ts-color-danger-950);
+
+  --sl-color-neutral-50: var(--ts-color-neutral-50);
+  --sl-color-neutral-100: var(--ts-color-neutral-100);
+  --sl-color-neutral-200: var(--ts-color-neutral-200);
+  --sl-color-neutral-300: var(--ts-color-neutral-300);
+  --sl-color-neutral-400: var(--ts-color-neutral-400);
+  --sl-color-neutral-500: var(--ts-color-neutral-500);
+  --sl-color-neutral-600: var(--ts-color-neutral-600);
+  --sl-color-neutral-700: var(--ts-color-neutral-700);
+  --sl-color-neutral-800: var(--ts-color-neutral-800);
+  --sl-color-neutral-900: var(--ts-color-neutral-900);
+  --sl-color-neutral-950: var(--ts-color-neutral-950);
+
+  --sl-color-neutral-0: var(--ts-color-white);
+  --sl-color-neutral-1000: var(--ts-color-black);
+
+  color-scheme: light;
+}

--- a/scss/tokens/shoelace/_sl-dialog.scss
+++ b/scss/tokens/shoelace/_sl-dialog.scss
@@ -1,0 +1,66 @@
+sl-dialog::part(panel) {
+  --width: 480px;
+  --header-spacing: 32px 32px 0;
+  --body-spacing: 16px 32px 24px;
+  --footer-spacing: 0 32px 32px;
+  border-radius: var(--sl-border-radius-x-large);
+  box-shadow: var(--sl-shadow-x-large);
+}
+
+sl-dialog::part(close-button) {
+  padding: 32px 32px 8px;
+}
+
+sl-dialog::part(close-button__base) {
+  font-size: 32px;
+  padding: 0;
+}
+
+sl-dialog.small::part(panel) {
+  --width: 400px;
+}
+
+sl-dialog.large::part(panel) {
+  --width: 600px;
+}
+
+sl-dialog.has-icon > div > :first-child {
+  font-size: var(--ts-font-2xl); /* 24px */
+  margin-right: var(--sl-spacing-medium); /* 16px */
+}
+
+sl-dialog.has-icon > div,
+sl-dialog::part(header) {
+  align-items: center;
+  display: flex;
+}
+
+sl-dialog::part(close-button__base) {
+  padding: var(--sl-spacing-2x-small);
+}
+
+sl-dialog::part(title) {
+  /* ts-heading-6 */
+  font-size: var(--ts-font-xl); /* 20px */
+  font-weight: var(--ts-font-medium); /* 500 */
+  letter-spacing: var(--ts-tracking-tight); /* -0.025em */
+  line-height: var(--ts-leading-6); /* 1.5rem * 24px */
+}
+
+sl-dialog::part(body) {
+  color: var(--ts-color-text-subdued);
+  /* ts-body-1 */
+  font-size: var(--ts-font-base); /* 16px */
+  font-weight: var(--ts-font-normal); /* 400 */
+  letter-spacing: var(--ts-tracking-normal); /* normal */
+  line-height: var(--ts-leading-6); /* 1.5rem * 24px */
+}
+
+sl-dialog.small::part(body) {
+  color: var(--ts-color-text-subdued);
+  /* ts-body-2 */
+  font-size: var(--ts-font-sm); /* 14px */
+  font-weight: var(--ts-font-normal); /* 400 */
+  letter-spacing: var(--ts-tracking-normal); /* normal */
+  line-height: var(--ts-leading-5); /* 1.25rem * 20px */
+}

--- a/scss/tokens/shoelace/_sl-divider.scss
+++ b/scss/tokens/shoelace/_sl-divider.scss
@@ -1,0 +1,4 @@
+sl-divider {
+  --color: var(--sl-color-neutral-300);
+  // --spacing: var(--sl-spacing-2x-large); // This breaks dividers within menus
+}

--- a/scss/tokens/shoelace/_sl-forms.scss
+++ b/scss/tokens/shoelace/_sl-forms.scss
@@ -1,0 +1,31 @@
+::part(form-control-label) {
+  color: var(--ts-color-text-default);
+  font-size: var(--ts-font-sm); /* 14px */
+  font-weight: var(--ts-font-medium); /* 500 */
+  letter-spacing: var(--ts-tracking-normal); /* normal */
+  line-height: var(--ts-leading-5); /* 1.25rem * 20px */
+}
+
+::part(form-control-help-text) {
+  color: var(--ts-color-text-subdued);
+  font-size: var(--ts-font-sm); /* 14px */
+  font-weight: var(--ts-font-normal); /* 400 */
+  letter-spacing: var(--ts-tracking-normal); /* normal */
+  line-height: var(--ts-leading-5); /* 1.25rem * 20px */
+}
+
+::part(form-control-input) {
+  /* input styling */
+  border-radius: var(--sl-border-radius-large);
+  margin: var(--sl-spacing-x-small) 0;
+}
+
+::part(input),
+::part(textarea) {
+  color: var(--ts-color-text-default);
+  font-size: var(--ts-font-base); /* 16px */
+  font-weight: var(--ts-font-normal); /* 400 */
+  letter-spacing: var(--ts-tracking-normal); /* normal */
+  line-height: var(--ts-leading-6); /* 1.5rem * 24px */
+  padding: var(--sl-spacing-x-small);
+}

--- a/scss/tokens/shoelace/_sl-global.scss
+++ b/scss/tokens/shoelace/_sl-global.scss
@@ -1,0 +1,46 @@
+:root,
+:host,
+.sl-theme-light {
+
+  --sl-font-mono: var(--ts-font-mono);
+  --sl-font-sans: var(--ts-font-sans);
+  --sl-font-serif: var(--ts-font-serif);
+
+  /* Overlay */
+  --sl-overlay-background-color: rgba(var(--ts-color-blue-900-rgb), 0.5);
+
+  /* Shadows */
+  --sl-shadow-x-large: var(--ts-shadow-2xl);
+
+  /* Spacing */
+  --sl-spacing-large: var(--ts-spacing-large);
+  --sl-spacing-2x-large: var(--ts-spacing-2x-large);
+  --sl-spacing-4x-large: var(--ts-spacing-4x-large);
+
+  /* Input sizes */
+  --sl-input-height-small: var(--ts-input-height-small);
+  --sl-input-height-medium: var(--ts-input-height-medium);
+  --sl-input-height-large: var(--ts-input-height-large);
+
+  /* Focus rings */
+  --sl-focus-ring-color: rgba(var(--ts-color-blue-500-rgb), 0.5);
+  --sl-focus-ring-style: solid;
+  --sl-focus-ring-width: 4px;
+  --sl-focus-ring: var(--sl-focus-ring-style) var(--sl-focus-ring-width) var(--sl-focus-ring-color);
+  --sl-focus-ring-offset: 0;
+  --sl-input-focus-ring-color: rgba(var(--ts-color-blue-500-rgb), 0.5);
+
+  /** Necessary because of tailwind '*' resets **/
+
+  --sl-panel-background-color: var(--sl-color-neutral-0);
+  --sl-panel-border-color: var(--sl-color-neutral-200);
+  --sl-panel-border-width: 1px;
+
+  sl-menu {
+    border: solid var(--sl-panel-border-color) var(--sl-panel-border-width);
+  }
+
+  sl-divider {
+    border-top: solid var(--sl-panel-border-color) var(--sl-panel-border-width);
+  }
+}

--- a/scss/tokens/shoelace/_sl-icon.scss
+++ b/scss/tokens/shoelace/_sl-icon.scss
@@ -1,0 +1,50 @@
+sl-icon.info::part(base) {
+  color: var(--ts-color-text-info);
+}
+
+sl-icon.info {
+  background: var(--ts-color-blue-100);
+}
+
+sl-icon.warning::part(base) {
+  color: var(--ts-color-text-warning);
+}
+
+sl-icon.warning {
+  background: var(--ts-color-yellow-100);
+}
+
+sl-icon.danger::part(base) {
+  color: var(--ts-color-text-danger);
+}
+
+sl-icon.danger {
+  background: var(--ts-color-red-100);
+}
+
+sl-icon.contained {
+  border-radius: var(--sl-border-radius-circle);
+  flex-shrink: 0;
+  padding: var(--sl-spacing-small);
+}
+
+/** ********** **/
+/* Icon button custom */
+/** ********** **/
+sl-icon-button::part(base),
+sl-dialog::part(close-button__base) {
+  border-radius: var(--sl-border-radius-circle);
+  color: var(--ts-color-text-subdued);    
+}
+
+sl-icon-button::part(base):hover,
+sl-dialog::part(close-button__base):hover {
+  background-color: var(--sl-color-neutral-200);
+  color: var(--ts-color-text-default);
+}
+
+sl-icon-button::part(base):active,
+sl-dialog::part(close-button__base):active {
+  background-color: var(--sl-color-neutral-300);
+  color: var(--ts-color-text-default);
+}

--- a/scss/tokens/teamshares/_ts-colors.scss
+++ b/scss/tokens/teamshares/_ts-colors.scss
@@ -1,0 +1,289 @@
+/* stylelint-disable */
+@function hexToRGB($hex) {
+  @return red($hex), green($hex), blue($hex);
+}
+/* stylelint-enable */
+
+$ts-color-blue-50: #f6fafd;
+$ts-color-blue-100: #e1eff9;
+$ts-color-blue-200: #b7d8f0;
+$ts-color-blue-300: #84bafa;
+$ts-color-blue-400: #539ef8;
+$ts-color-blue-500: #3b74fc;
+$ts-color-blue-600: #2c5ed6;
+$ts-color-blue-700: #3a5dae;
+$ts-color-blue-800: #29427b;
+$ts-color-blue-900: #353d5f;
+$ts-color-blue-950: #2f3654;
+
+$ts-color-gray-50: #fcfcfc;
+$ts-color-gray-75: #f9fafb;
+$ts-color-gray-100: #f6f8fa;
+$ts-color-gray-200: #e0e0e0; // Modified - was too light for borders
+$ts-color-gray-300: #d0d0d0; // Modified - was too light for borders
+$ts-color-gray-400: #cdcfd1;
+$ts-color-gray-500: #b3b5b8;
+$ts-color-gray-600: #93999e;
+$ts-color-gray-700: #6d7176;
+$ts-color-gray-800: #444c59;
+$ts-color-gray-900: #2e333c;
+$ts-color-gray-950: #111;
+
+$ts-color-red-100: #fcf1ef;
+$ts-color-red-200: #f7d7d2;
+$ts-color-red-300: #eec9c1;
+$ts-color-red-400: #f0948b;
+$ts-color-red-500: #f65747;
+$ts-color-red-600: #d64e41;
+$ts-color-red-700: #d7351c;
+$ts-color-red-800: #b92e18;
+$ts-color-red-900: #9b2614;
+
+$ts-color-green-100: #eef6e8;
+$ts-color-green-200: #d4e8c3;
+$ts-color-green-300: #72d0a3;
+$ts-color-green-400: #21bc9c;
+$ts-color-green-500: #17a688;
+$ts-color-green-600: #10985f;
+$ts-color-green-700: #068466;
+$ts-color-green-800: #164e3e;
+$ts-color-green-900: #004d49;
+
+$ts-color-yellow-50: #fffbf0;
+$ts-color-yellow-100: #faf4ea;
+$ts-color-yellow-200: #f2eade;
+$ts-color-yellow-300: #fce491;
+$ts-color-yellow-400: #fad860;
+$ts-color-yellow-500: #ffc328;
+$ts-color-yellow-600: #f6af47;
+$ts-color-yellow-700: #ca861e;
+$ts-color-yellow-800: #956419;
+$ts-color-yellow-900: #694712;
+
+$ts-color-white: #fff;
+$ts-color-black: #000;
+$ts-color-default: $ts-color-gray-900;
+$ts-color-subdued: $ts-color-gray-700;
+$ts-color-success: $ts-color-green-700;
+$ts-color-error: $ts-color-red-700;
+$ts-color-primary: $ts-color-blue-600;
+
+:host,
+:root,
+sp-theme {
+
+  /** ****** **/
+  /** Colors **/
+  /** ****** **/
+
+  --ts-color-white: #{$ts-color-white};
+  --ts-color-white-rgb: #{hexToRGB($ts-color-white)};
+  --ts-color-black: #{$ts-color-black};
+  --ts-color-black-rgb: #{hexToRGB($ts-color-black)};
+
+  --ts-color-blue-50: #{$ts-color-blue-50};
+  --ts-color-blue-100: #{$ts-color-blue-100};
+  --ts-color-blue-200: #{$ts-color-blue-200};
+  --ts-color-blue-300: #{$ts-color-blue-300};
+  --ts-color-blue-400: #{$ts-color-blue-400};
+  --ts-color-blue-500: #{$ts-color-blue-500};
+  --ts-color-blue-600: #{$ts-color-blue-600};
+  --ts-color-blue-700: #{$ts-color-blue-700};
+  --ts-color-blue-800: #{$ts-color-blue-800};
+  --ts-color-blue-900: #{$ts-color-blue-900};
+  --ts-color-blue-950: #{$ts-color-blue-950};
+
+  --ts-color-gray-50: #{$ts-color-gray-50};
+  --ts-color-gray-75: #{$ts-color-gray-75};
+  --ts-color-gray-100: #{$ts-color-gray-100};
+  --ts-color-gray-200: #{$ts-color-gray-200};
+  --ts-color-gray-300: #{$ts-color-gray-300};
+  --ts-color-gray-400: #{$ts-color-gray-400};
+  --ts-color-gray-500: #{$ts-color-gray-500};
+  --ts-color-gray-600: #{$ts-color-gray-600};
+  --ts-color-gray-700: #{$ts-color-gray-700};
+  --ts-color-gray-800: #{$ts-color-gray-800};
+  --ts-color-gray-900: #{$ts-color-gray-900};
+  --ts-color-gray-950: #{$ts-color-gray-950};
+
+  --ts-color-red-100: #{$ts-color-red-100};
+  --ts-color-red-200: #{$ts-color-red-200};
+  --ts-color-red-300: #{$ts-color-red-300};
+  --ts-color-red-400: #{$ts-color-red-400};
+  --ts-color-red-500: #{$ts-color-red-500};
+  --ts-color-red-600: #{$ts-color-red-600};
+  --ts-color-red-700: #{$ts-color-red-700};
+  --ts-color-red-800: #{$ts-color-red-800};
+  --ts-color-red-900: #{$ts-color-red-900};
+
+  --ts-color-green-100: #{$ts-color-green-100};
+  --ts-color-green-200: #{$ts-color-green-200};
+  --ts-color-green-300: #{$ts-color-green-300};
+  --ts-color-green-400: #{$ts-color-green-400};
+  --ts-color-green-500: #{$ts-color-green-500};
+  --ts-color-green-600: #{$ts-color-green-600};
+  --ts-color-green-700: #{$ts-color-green-700};
+  --ts-color-green-800: #{$ts-color-green-800};
+  --ts-color-green-900: #{$ts-color-green-900};
+
+  --ts-color-yellow-50: #{$ts-color-yellow-50};
+  --ts-color-yellow-100: #{$ts-color-yellow-100};
+  --ts-color-yellow-200: #{$ts-color-yellow-200};
+  --ts-color-yellow-300: #{$ts-color-yellow-300};
+  --ts-color-yellow-400: #{$ts-color-yellow-400};
+  --ts-color-yellow-500: #{$ts-color-yellow-500};
+  --ts-color-yellow-600: #{$ts-color-yellow-600};
+  --ts-color-yellow-700: #{$ts-color-yellow-700};
+  --ts-color-yellow-800: #{$ts-color-yellow-800};
+  --ts-color-yellow-900: #{$ts-color-yellow-900};
+
+  --ts-color-blue-50-rgb: #{hexToRGB($ts-color-blue-50)};
+  --ts-color-blue-100-rgb: #{hexToRGB($ts-color-blue-100)};
+  --ts-color-blue-200-rgb: #{hexToRGB($ts-color-blue-200)};
+  --ts-color-blue-300-rgb: #{hexToRGB($ts-color-blue-300)};
+  --ts-color-blue-400-rgb: #{hexToRGB($ts-color-blue-400)};
+  --ts-color-blue-500-rgb: #{hexToRGB($ts-color-blue-500)};
+  --ts-color-blue-600-rgb: #{hexToRGB($ts-color-blue-600)};
+  --ts-color-blue-700-rgb: #{hexToRGB($ts-color-blue-700)};
+  --ts-color-blue-800-rgb: #{hexToRGB($ts-color-blue-800)};
+  --ts-color-blue-900-rgb: #{hexToRGB($ts-color-blue-900)};
+  --ts-color-blue-950-rgb: #{hexToRGB($ts-color-blue-950)};
+
+  --ts-color-gray-50-rgb: #{hexToRGB($ts-color-gray-50)};
+  --ts-color-gray-75-rgb: #{hexToRGB($ts-color-gray-75)};
+  --ts-color-gray-100-rgb: #{hexToRGB($ts-color-gray-100)};
+  --ts-color-gray-200-rgb: #{hexToRGB($ts-color-gray-200)};
+  --ts-color-gray-300-rgb: #{hexToRGB($ts-color-gray-300)};
+  --ts-color-gray-400-rgb: #{hexToRGB($ts-color-gray-400)};
+  --ts-color-gray-500-rgb: #{hexToRGB($ts-color-gray-500)};
+  --ts-color-gray-600-rgb: #{hexToRGB($ts-color-gray-600)};
+  --ts-color-gray-700-rgb: #{hexToRGB($ts-color-gray-700)};
+  --ts-color-gray-800-rgb: #{hexToRGB($ts-color-gray-800)};
+  --ts-color-gray-900-rgb: #{hexToRGB($ts-color-gray-900)};
+  --ts-color-gray-950-rgb: #{hexToRGB($ts-color-gray-950)};
+
+  --ts-color-red-100-rgb: #{hexToRGB($ts-color-red-100)};
+  --ts-color-red-200-rgb: #{hexToRGB($ts-color-red-200)};
+  --ts-color-red-300-rgb: #{hexToRGB($ts-color-red-300)};
+  --ts-color-red-400-rgb: #{hexToRGB($ts-color-red-400)};
+  --ts-color-red-500-rgb: #{hexToRGB($ts-color-red-500)};
+  --ts-color-red-600-rgb: #{hexToRGB($ts-color-red-600)};
+  --ts-color-red-700-rgb: #{hexToRGB($ts-color-red-700)};
+  --ts-color-red-800-rgb: #{hexToRGB($ts-color-red-800)};
+  --ts-color-red-900-rgb: #{hexToRGB($ts-color-red-900)};
+
+  --ts-color-green-100-rgb: #{hexToRGB($ts-color-green-100)};
+  --ts-color-green-200-rgb: #{hexToRGB($ts-color-green-200)};
+  --ts-color-green-300-rgb: #{hexToRGB($ts-color-green-300)};
+  --ts-color-green-400-rgb: #{hexToRGB($ts-color-green-400)};
+  --ts-color-green-500-rgb: #{hexToRGB($ts-color-green-500)};
+  --ts-color-green-600-rgb: #{hexToRGB($ts-color-green-600)};
+  --ts-color-green-700-rgb: #{hexToRGB($ts-color-green-700)};
+  --ts-color-green-800-rgb: #{hexToRGB($ts-color-green-800)};
+  --ts-color-green-900-rgb: #{hexToRGB($ts-color-green-900)};
+
+  --ts-color-yellow-50-rgb: #{hexToRGB($ts-color-yellow-50)};
+  --ts-color-yellow-100-rgb: #{hexToRGB($ts-color-yellow-100)};
+  --ts-color-yellow-200-rgb: #{hexToRGB($ts-color-yellow-200)};
+  --ts-color-yellow-300-rgb: #{hexToRGB($ts-color-yellow-300)};
+  --ts-color-yellow-400-rgb: #{hexToRGB($ts-color-yellow-400)};
+  --ts-color-yellow-500-rgb: #{hexToRGB($ts-color-yellow-500)};
+  --ts-color-yellow-600-rgb: #{hexToRGB($ts-color-yellow-600)};
+  --ts-color-yellow-700-rgb: #{hexToRGB($ts-color-yellow-700)};
+  --ts-color-yellow-800-rgb: #{hexToRGB($ts-color-yellow-800)};
+  --ts-color-yellow-900-rgb: #{hexToRGB($ts-color-yellow-900)};
+
+  --ts-color-primary-50: var(--ts-color-blue-50);
+  --ts-color-primary-100: var(--ts-color-blue-100);
+  --ts-color-primary-200: var(--ts-color-blue-200);
+  --ts-color-primary-300: var(--ts-color-blue-300);
+  --ts-color-primary-400: var(--ts-color-blue-400);
+  --ts-color-primary-500: var(--ts-color-blue-500);
+  --ts-color-primary-600: var(--ts-color-blue-600);
+  --ts-color-primary-700: var(--ts-color-blue-700);
+  --ts-color-primary-800: var(--ts-color-blue-800);
+  --ts-color-primary-900: var(--ts-color-blue-900);
+  --ts-color-primary-950: var(--ts-color-blue-950);
+
+  --ts-color-success-50: var(--ts-color-green-100);
+  --ts-color-success-100: var(--ts-color-green-100);
+  --ts-color-success-200: var(--ts-color-green-200);
+  --ts-color-success-300: var(--ts-color-green-300);
+  --ts-color-success-400: var(--ts-color-green-400);
+  --ts-color-success-500: var(--ts-color-green-500);
+  --ts-color-success-600: var(--ts-color-green-600);
+  --ts-color-success-700: var(--ts-color-green-700);
+  --ts-color-success-800: var(--ts-color-green-800);
+  --ts-color-success-900: var(--ts-color-green-900);
+  --ts-color-success-950: var(--ts-color-green-900);
+
+  --ts-color-warning-50: var(--ts-color-yellow-100);
+  --ts-color-warning-100: var(--ts-color-yellow-100);
+  --ts-color-warning-200: var(--ts-color-yellow-200);
+  --ts-color-warning-300: var(--ts-color-yellow-300);
+  --ts-color-warning-400: var(--ts-color-yellow-400);
+  --ts-color-warning-500: var(--ts-color-yellow-500);
+  --ts-color-warning-600: var(--ts-color-yellow-600);
+  --ts-color-warning-700: var(--ts-color-yellow-700);
+  --ts-color-warning-800: var(--ts-color-yellow-800);
+  --ts-color-warning-900: var(--ts-color-yellow-900);
+  --ts-color-warning-950: var(--ts-color-yellow-900);
+
+  --ts-color-danger-50: var(--ts-color-red-50);
+  --ts-color-danger-100: var(--ts-color-red-100);
+  --ts-color-danger-200: var(--ts-color-red-200);
+  --ts-color-danger-300: var(--ts-color-red-300);
+  --ts-color-danger-400: var(--ts-color-red-400);
+  --ts-color-danger-500: var(--ts-color-red-500);
+  --ts-color-danger-600: var(--ts-color-red-600);
+  --ts-color-danger-700: var(--ts-color-red-700);
+  --ts-color-danger-800: var(--ts-color-red-800);
+  --ts-color-danger-900: var(--ts-color-red-900);
+  --ts-color-danger-950: var(--ts-color-red-950);
+
+  --ts-color-neutral-50: var(--ts-color-gray-50);
+  --ts-color-neutral-100: var(--ts-color-gray-100);
+  --ts-color-neutral-200: var(--ts-color-gray-200);
+  --ts-color-neutral-300: var(--ts-color-gray-300);
+  --ts-color-neutral-400: var(--ts-color-gray-400);
+  --ts-color-neutral-500: var(--ts-color-gray-500);
+  --ts-color-neutral-600: var(--ts-color-gray-600);
+  --ts-color-neutral-700: var(--ts-color-gray-700);
+  --ts-color-neutral-800: var(--ts-color-gray-800);
+  --ts-color-neutral-900: var(--ts-color-gray-900);
+  --ts-color-neutral-950: var(--ts-color-gray-950);
+
+  --ts-color-neutral-0: var(--ts-color-white);
+  --ts-color-neutral-1000: var(--ts-color-black);
+
+  /* Semantic colors */
+
+  --ts-color-primary: #{$ts-color-primary};
+  --ts-color-primary-rgb: #{hexToRGB($ts-color-primary)};
+  --ts-color-default: #{$ts-color-default};
+  --ts-color-subdued: #{$ts-color-subdued};
+  --ts-color-success: #{$ts-color-success};
+  --ts-color-error: #{$ts-color-error};
+  --ts-color-link: var(--ts-color-primary);
+  --ts-color-text: var(--ts-color-default);
+  --ts-color-text-default: var(--ts-color-gray-900);
+  --ts-color-text-subdued: var(--ts-color-gray-700);
+  --ts-color-text-light: var(--ts-color-white);
+  --ts-color-text-light-subdued: var(--ts-color-gray-200);
+
+  --ts-color-text-success: var(--ts-color-success-700);
+  --ts-color-background-success: var(--ts-color-success-100);
+  --ts-color-border-success: var(--ts-color-success-200);
+
+  --ts-color-text-warning: var(--ts-color-warning-800);
+  --ts-color-background-warning: var(--ts-color-warning-50);
+  --ts-color-border-warning: var(--ts-color-warning-200);
+
+  --ts-color-text-danger: var(--ts-color-danger-800);
+  --ts-color-background-danger: var(--ts-color-danger-50);
+  --ts-color-border-danger: var(--ts-color-danger-200);
+
+  --ts-color-text-info: var(--ts-color-primary-600);
+  --ts-color-background-info: var(--ts-color-primary-50);
+  --ts-color-border-info: var(--ts-color-primary-200);
+}

--- a/scss/tokens/teamshares/_ts-global.scss
+++ b/scss/tokens/teamshares/_ts-global.scss
@@ -1,0 +1,22 @@
+
+:host,
+:root,
+sp-theme {
+  /** ************* **/
+  /** Miscellaneous **/
+  /** ************* **/
+
+  /* Shadows */
+  --ts-shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+
+  /* Spacing */
+  --ts-spacing-large: 1.5rem; /* 24px */
+  --ts-spacing-2x-large: 2rem; /* 32px */
+  --ts-spacing-4x-large: 4rem; /* 64px */
+
+  /* Input sizes */
+  --ts-input-height-small: 1.75rem; /* 28px */
+  --ts-input-height-medium: 2.5rem; /* 40px */
+  --ts-input-height-large: 3rem; /* 48px */
+  --ts-input-height-xlarge: 4rem; /* 64px */
+}

--- a/scss/tokens/teamshares/_ts-typography.scss
+++ b/scss/tokens/teamshares/_ts-typography.scss
@@ -1,0 +1,41 @@
+:host,
+:root,
+sp-theme {
+  --ts-font-sans: Inter, Helvetica, Arial, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --ts-font-serif: 'DM Serif Display', Georgia, Times, serif;
+  --ts-font-mono: 'SFMono-Regular', Menlo, monospace;
+  --ts-font-body: var(--font-sans);
+  --ts-font-display: var(--font-serif);
+
+  /* font-size */
+  --ts-font-7xl: var(--sl-font-size-4x-large); /* 72px */
+  --ts-font-6xl: 3.75rem; /* 60px */
+  --ts-font-5xl: var(--sl-font-size-3x-large); /* 48px */
+  --ts-font-4xl: var(--sl-font-size-2x-large); /* 36px */
+  --ts-font-2xl: var(--sl-font-size-x-large); /* 24px */
+  --ts-font-xl: var(--sl-font-size-large); /* 20px */
+  --ts-font-base: var(--sl-font-size-medium); /* 16px */
+  --ts-font-sm: var(--sl-font-size-small); /* 14px */
+  --ts-font-xs: var(--sl-font-size-x-small); /* 12px */
+
+  /* font-weight */
+  --ts-font-bold: var(--sl-font-weight-bold); /* 700 */
+  --ts-font-semibold: 600; /* 600 */
+  --ts-font-medium: var(--sl-font-weight-semibold); /* 500 */
+  --ts-font-normal: var(--sl-font-weight-normal); /* 400 */
+  --ts-font-light: var(--sl-font-weight-light); /* 300 */
+
+  /* line-height */
+  --ts-leading-none: var(--sl-line-height-denser); /* 1 */
+  --ts-leading-tight: 1.25;
+  --ts-leading-4: 1rem; /* 16px */
+  --ts-leading-5: 1.25rem; /* 20px */
+  --ts-leading-6: 1.5rem; /* 24px */
+  --ts-leading-7: 1.75rem; /* 28px */
+
+  /* letter-spacing */
+  --sl-letter-spacing-dense: -0.025em;
+  --ts-tracking-tight: var(--sl-letter-spacing-dense); /* -0.025em; */
+  --ts-tracking-normal: var(--sl-letter-spacing-normal); /* normal */
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,1 @@
+import "@shoelace-style/shoelace";

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,4 @@
+import "./components";
+
 export * from "./controllers";
 export * from "./_honeybadger";

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,6 +269,18 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@floating-ui/core@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.1.tgz#00e64d74e911602c8533957af0cce5af6b2e93c8"
+  integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
+
+"@floating-ui/dom@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.2.tgz#c5184c52c6f50abd11052d71204f4be2d9245237"
+  integrity sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==
+  dependencies:
+    "@floating-ui/core" "^1.0.1"
+
 "@github/clipboard-copy-element@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@github/clipboard-copy-element/-/clipboard-copy-element-1.1.2.tgz#7a6e8042749471504d4e7cfcc47097a781db2bdb"
@@ -348,6 +360,16 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@lit-labs/react@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@lit-labs/react/-/react-1.0.9.tgz#0703ed89fcdfd2766bc71c18ccb6b06c4bbe6019"
+  integrity sha512-yjkdcciypTIJ6vUXzZJHTAwt2fdATUAfZMkHRbLpbgEnr8OwpwVOQ04me1Y7p5Vwtmcd4GWY0/BQ6G8jUgCK1w==
+
+"@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.4.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.4.1.tgz#3f587eec5708692135bc9e94cf396130604979f3"
+  integrity sha512-qDv4851VFSaBWzpS02cXHclo40jsbAjRXnebNXpm0uVg32kCneZPo9RYVQtrTNICtZ+1wAYHu1ZtxWSWMbKrBw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -396,6 +418,29 @@
   dependencies:
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
+
+"@shoelace-style/animations@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@shoelace-style/animations/-/animations-1.1.0.tgz#17539abafd6dcbf2a79e089e1593175e9f7835b5"
+  integrity sha512-Be+cahtZyI2dPKRm8EZSx3YJQ+jLvEcn3xzRP7tM4tqBnvd/eW/64Xh0iOf0t2w5P8iJKfdBbpVNE9naCaOf2g==
+
+"@shoelace-style/localize@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@shoelace-style/localize/-/localize-3.0.1.tgz#a6eda8ae29ac32fb59df50f3db14652a23f492c9"
+  integrity sha512-nmv1syJ3ormbGq29GsuxGRK6BFq7Jhx+kVFyuuozz0Pckkvk1SGk2vpZZcdnj2vRZCETvlVB7KYgakUwgGmn+A==
+
+"@shoelace-style/shoelace@^2.0.0-beta.83":
+  version "2.0.0-beta.83"
+  resolved "https://registry.yarnpkg.com/@shoelace-style/shoelace/-/shoelace-2.0.0-beta.83.tgz#9ea923e969a2cfc7c0b8ad46c81822b04a1c1520"
+  integrity sha512-dHVBtapuqxSRu3klBZhf9/LtEtircaLLnDajNbhuiBiY7PVCxjjf/9Kyd/S/BpbhKwMICqJr+PaKoCTd2iWDJA==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+    "@lit-labs/react" "^1.0.7"
+    "@shoelace-style/animations" "^1.1.0"
+    "@shoelace-style/localize" "^3.0.1"
+    color "4.2"
+    lit "^2.2.8"
+    qr-creator "^1.0.0"
 
 "@tailwindcss/aspect-ratio@^0.4.0":
   version "0.4.0"
@@ -453,6 +498,11 @@
   version "1.20.2"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
   integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
+
+"@types/trusted-types@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
+  integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
 "@webcomponents/custom-elements@^1.5.0":
   version "1.5.0"
@@ -828,6 +878,14 @@ color-string@^1.9.0:
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
+
+color@4.2:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 color@^4.0.1:
   version "4.2.1"
@@ -1996,6 +2054,30 @@ listr2@^4.0.5:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
+lit-element@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.2.2.tgz#d148ab6bf4c53a33f707a5168e087725499e5f2b"
+  integrity sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==
+  dependencies:
+    "@lit/reactive-element" "^1.3.0"
+    lit-html "^2.2.0"
+
+lit-html@^2.2.0, lit-html@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.4.0.tgz#b510430f39a56ec959167ed1187241a4e3ab1574"
+  integrity sha512-G6qXu4JNUpY6aaF2VMfaszhO9hlWw0hOTRFDmuMheg/nDYGB+2RztUSOyrzALAbr8Nh0Y7qjhYkReh3rPnplVg==
+  dependencies:
+    "@types/trusted-types" "^2.0.2"
+
+lit@^2.2.8:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-2.4.0.tgz#e33a0f463e17408f6e7f71464e6a266e60a5bb77"
+  integrity sha512-fdgzxEtLrZFQU/BqTtxFQCLwlZd9bdat+ltzSFjvWkZrs7eBmeX0L5MHUMb3kYIkuS8Xlfnii/iI5klirF8/Xg==
+  dependencies:
+    "@lit/reactive-element" "^1.4.0"
+    lit-element "^3.2.0"
+    lit-html "^2.4.0"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -2587,6 +2669,11 @@ purgecss@^4.0.3:
     glob "^7.1.7"
     postcss "^8.3.5"
     postcss-selector-parser "^6.0.6"
+
+qr-creator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/qr-creator/-/qr-creator-1.0.0.tgz#f350a8f0b5be02bd1fc1ef133a038a06ef8bc5ef"
+  integrity sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"


### PR DESCRIPTION
## Ticket
I _think_ this [Notion](https://www.notion.so/teamshares/Export-assets-3d343c6f42304f35b1ccd9f84722fe1b) ticket? 

## Description
Part of helping Daross extract custom web components into shared-ui (mostly copying his code, built in OS, over to the shared repo). 

## Usage
- For now, I *think* still need `yarn add @shoelace-style/shoelace` in consuming apps
- Add separate CSS entrypoint (for now) to `application.scss`:
    - `@import '~@teamshares/ui/scss/tokens/tokens';`
- Somehow trigger the shoelace JS? base path need configuring?
    - Just needs to import *something* from `"@teamshares/ui"` into `application.js` — e.g. `import { initHoneybadger } from "@teamshares/ui";`