### PR TITLE
Remove EXPLICIT_APP_CONTEXT (rely on HEROKU_APP_NAME being set)

### DIFF
--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -18811,22 +18811,19 @@ _defineProperty(_class, "targets", ["switchable", "clickable"]);
 const Honeybadger = require("@honeybadger-io/js");
 
 const getAppContext = () => {
-  // TODO: Kali - remove this var once upstream Heroku/Doppler issues resolved
-  if (process.env.EXPLICIT_APP_CONTEXT) return process.env.EXPLICIT_APP_CONTEXT;
-
-  if (!process.env.HEROKU_APP_NAME) {
-    console.log("WARN: production-ish environment is missing both HEROKU_APP_NAME and EXPLICIT_APP_CONTEXT");
-    return;
-  }
-
-  const heroku = process.env.HEROKU_APP_NAME;
+  const heroku = process.env.HEROKU_APP_NAME || "";
+  if (heroku.length === 0) return;
   return heroku.includes("-production") ? "production" : heroku.includes("-staging") ? "staging" : "review";
 };
 
 const initHoneybadger = (opts = {}) => {
   if (process.env.RAILS_ENV !== "production") return;
   const appContext = getAppContext();
-  if (!appContext) return;
+
+  if (!appContext) {
+    console.log("WARN: production-ish environment is missing HEROKU_APP_NAME -- NOT initializing Honeybadger");
+    return;
+  }
 
   if (!process.env.HONEYBADGER_JS_API_KEY) {
     console.log(`Honeybadger not configured -- set HONEYBADGER_JS_API_KEY to enable (for ${process.env.HEROKU_APP_NAME})`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -18817,22 +18817,19 @@
   const Honeybadger = require("@honeybadger-io/js");
 
   const getAppContext = () => {
-    // TODO: Kali - remove this var once upstream Heroku/Doppler issues resolved
-    if (process.env.EXPLICIT_APP_CONTEXT) return process.env.EXPLICIT_APP_CONTEXT;
-
-    if (!process.env.HEROKU_APP_NAME) {
-      console.log("WARN: production-ish environment is missing both HEROKU_APP_NAME and EXPLICIT_APP_CONTEXT");
-      return;
-    }
-
-    const heroku = process.env.HEROKU_APP_NAME;
+    const heroku = process.env.HEROKU_APP_NAME || "";
+    if (heroku.length === 0) return;
     return heroku.includes("-production") ? "production" : heroku.includes("-staging") ? "staging" : "review";
   };
 
   const initHoneybadger = (opts = {}) => {
     if (process.env.RAILS_ENV !== "production") return;
     const appContext = getAppContext();
-    if (!appContext) return;
+
+    if (!appContext) {
+      console.log("WARN: production-ish environment is missing HEROKU_APP_NAME -- NOT initializing Honeybadger");
+      return;
+    }
 
     if (!process.env.HONEYBADGER_JS_API_KEY) {
       console.log(`Honeybadger not configured -- set HONEYBADGER_JS_API_KEY to enable (for ${process.env.HEROKU_APP_NAME})`);

--- a/src/_honeybadger.js
+++ b/src/_honeybadger.js
@@ -1,22 +1,20 @@
 const Honeybadger = require("@honeybadger-io/js");
 
 const getAppContext = () => {
-  // TODO: Kali - remove this var once upstream Heroku/Doppler issues resolved
-  if (process.env.EXPLICIT_APP_CONTEXT) return process.env.EXPLICIT_APP_CONTEXT;
+  const heroku = process.env.HEROKU_APP_NAME || "";
+  if (heroku.length === 0) return;
 
-  if (!process.env.HEROKU_APP_NAME) {
-    console.log("WARN: production-ish environment is missing both HEROKU_APP_NAME and EXPLICIT_APP_CONTEXT");
-    return;
-  }
-
-  const heroku = process.env.HEROKU_APP_NAME;
   return heroku.includes("-production") ? "production" : (heroku.includes("-staging") ? "staging" : "review");
 };
 
 export const initHoneybadger = (opts = {}) => {
   if (process.env.RAILS_ENV !== "production") return;
+
   const appContext = getAppContext();
-  if (!appContext) return;
+  if (!appContext) {
+    console.log("WARN: production-ish environment is missing HEROKU_APP_NAME -- NOT initializing Honeybadger");
+    return;
+  }
 
   if (!process.env.HONEYBADGER_JS_API_KEY) {
     console.log(`Honeybadger not configured -- set HONEYBADGER_JS_API_KEY to enable (for ${process.env.HEROKU_APP_NAME})`);


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Fix-app_context-detection-5401ca4694f54fc68ae23592a6b9dea9)

## Description
I've talked w/ Heroku and Doppler, we can finally rely on HEROKU_APP_NAME being set. This PR removes the workarounds I'd added in the meantime.