### PR TITLE
Renaming Teamshares init

### DIFF
--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -1,3 +1,18 @@
+function _defineProperty(obj, key, value) {
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  } else {
+    obj[key] = value;
+  }
+
+  return obj;
+}
+
 // node_modules/@lit/reactive-element/css-tag.js
 var t$3 = window.ShadowRoot && (void 0 === window.ShadyCSS || window.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype;
 var e$3 = Symbol();
@@ -18758,21 +18773,6 @@ class input_mask_controller extends Controller {
 
 }
 
-function _defineProperty(obj, key, value) {
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-
-  return obj;
-}
-
 class _class$1 extends Controller {
   connect() {
     this.element[this.identifier] = this;
@@ -18860,13 +18860,15 @@ _defineProperty(_class, "targets", ["switchable", "clickable"]);
 
 /** ***************************************** */
 
-const initialize = () => {
+class Teamshares {}
+
+_defineProperty(Teamshares, "init", () => {
   initHoneybadger({
     debug: true
   });
   registerIconLibrary("default", {
     resolver: name => `https://cdn.jsdelivr.net/npm/heroicons@2.0.1/24/outline/${name}.svg`
   });
-};
+});
 
-export { input_clipboard_controller as InputClipboardController, input_mask_controller as InputMaskController, _class as SwitchController, _class$1 as ToggleController, initHoneybadger, initialize };
+export { input_clipboard_controller as InputClipboardController, input_mask_controller as InputMaskController, _class as SwitchController, _class$1 as ToggleController, Teamshares as default, initHoneybadger };

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -18854,18 +18854,19 @@ class _class extends Controller {
 
 _defineProperty(_class, "targets", ["switchable", "clickable"]);
 
-/** ***************************************** */
+/** ********************************************************** */
 
-/**  Apps should call this method on startup  */
+/**  Apps should import Teamshares and call init() on startup  */
 
-/** ***************************************** */
+/** ********************************************************** */
 
 class Teamshares {}
 
 _defineProperty(Teamshares, "init", () => {
   initHoneybadger({
     debug: true
-  });
+  }); // Registers Heroicons as the default icon library in Shoelace
+
   registerIconLibrary("default", {
     resolver: name => `https://cdn.jsdelivr.net/npm/heroicons@2.0.1/24/outline/${name}.svg`
   });

--- a/dist/index.js
+++ b/dist/index.js
@@ -18860,18 +18860,19 @@
 
   _defineProperty(_class, "targets", ["switchable", "clickable"]);
 
-  /** ***************************************** */
+  /** ********************************************************** */
 
-  /**  Apps should call this method on startup  */
+  /**  Apps should import Teamshares and call init() on startup  */
 
-  /** ***************************************** */
+  /** ********************************************************** */
 
   class Teamshares {}
 
   _defineProperty(Teamshares, "init", () => {
     initHoneybadger({
       debug: true
-    });
+    }); // Registers Heroicons as the default icon library in Shoelace
+
     registerIconLibrary("default", {
       resolver: name => `https://cdn.jsdelivr.net/npm/heroicons@2.0.1/24/outline/${name}.svg`
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,6 +4,21 @@
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.TeamsharesUI = {}));
 })(this, (function (exports) { 'use strict';
 
+  function _defineProperty(obj, key, value) {
+    if (key in obj) {
+      Object.defineProperty(obj, key, {
+        value: value,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+    } else {
+      obj[key] = value;
+    }
+
+    return obj;
+  }
+
   // node_modules/@lit/reactive-element/css-tag.js
   var t$3 = window.ShadowRoot && (void 0 === window.ShadyCSS || window.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype;
   var e$3 = Symbol();
@@ -18764,21 +18779,6 @@
 
   }
 
-  function _defineProperty(obj, key, value) {
-    if (key in obj) {
-      Object.defineProperty(obj, key, {
-        value: value,
-        enumerable: true,
-        configurable: true,
-        writable: true
-      });
-    } else {
-      obj[key] = value;
-    }
-
-    return obj;
-  }
-
   class _class$1 extends Controller {
     connect() {
       this.element[this.identifier] = this;
@@ -18866,21 +18866,23 @@
 
   /** ***************************************** */
 
-  const initialize = () => {
+  class Teamshares {}
+
+  _defineProperty(Teamshares, "init", () => {
     initHoneybadger({
       debug: true
     });
     registerIconLibrary("default", {
       resolver: name => `https://cdn.jsdelivr.net/npm/heroicons@2.0.1/24/outline/${name}.svg`
     });
-  };
+  });
 
   exports.InputClipboardController = input_clipboard_controller;
   exports.InputMaskController = input_mask_controller;
   exports.SwitchController = _class;
   exports.ToggleController = _class$1;
+  exports["default"] = Teamshares;
   exports.initHoneybadger = initHoneybadger;
-  exports.initialize = initialize;
 
   Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,12 @@ export * from "./_honeybadger"; // Leaving this for legacy sake; should be remov
 /** ***************************************** */
 /**  Apps should call this method on startup  */
 /** ***************************************** */
-export const initialize = () => {
-  initHoneybadger({ debug: true });
+export default class Teamshares {
+  static init = () => {
+    initHoneybadger({ debug: true });
 
-  registerIconLibrary("default", {
-    resolver: name => `https://cdn.jsdelivr.net/npm/heroicons@2.0.1/24/outline/${name}.svg`
-  });
+    registerIconLibrary("default", {
+      resolver: name => `https://cdn.jsdelivr.net/npm/heroicons@2.0.1/24/outline/${name}.svg`
+    });
+  };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,14 @@ import { initHoneybadger } from "./_honeybadger";
 export * from "./controllers";
 export * from "./_honeybadger"; // Leaving this for legacy sake; should be removed once everyone is calling initialize below
 
-/** ***************************************** */
-/**  Apps should call this method on startup  */
-/** ***************************************** */
+/** ********************************************************** */
+/**  Apps should import Teamshares and call init() on startup  */
+/** ********************************************************** */
 export default class Teamshares {
   static init = () => {
     initHoneybadger({ debug: true });
 
+    // Registers Heroicons as the default icon library in Shoelace
     registerIconLibrary("default", {
       resolver: name => `https://cdn.jsdelivr.net/npm/heroicons@2.0.1/24/outline/${name}.svg`
     });


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Component-library-Theming-0cd8a15f57544121b0d039d55890b3a5)

## Description
Renaming to Teamshares class, which also makes room for additional static scripts to run if we want to add them later. Consuming apps can now just `import Teamshares from "@teamshares/ui"` and `Teamshares.init()`. Shouldn't affect any code currently deployed.

Forgot this was in flight before merging the previous PR. 