### PR TITLE
Fix safari education button styling

### DIFF
--- a/scss/_teamshares.scss
+++ b/scss/_teamshares.scss
@@ -1123,8 +1123,6 @@ a.icon-button-view-component {
 .button-view-component {
   // The following lines are required for buttons to render properly in older versions of safari
   appearance: none;
-  appearance: none;
-  appearance: none;
 
   @apply rounded-full border;
 

--- a/scss/_teamshares.scss
+++ b/scss/_teamshares.scss
@@ -1121,10 +1121,8 @@ a.icon-button-view-component {
 }
 
 .button-view-component {
-  // The following line is required for buttons to render properly in older versions of safari
-  appearance: none;
-
-  @apply rounded-full border;
+  // appearance-none is required for buttons to render properly in older versions of safari
+  @apply rounded-full border appearance-none;
 
   &.small {
     @apply px-3 ts-body-3;

--- a/scss/_teamshares.scss
+++ b/scss/_teamshares.scss
@@ -1121,6 +1121,11 @@ a.icon-button-view-component {
 }
 
 .button-view-component {
+  // The following lines are required for buttons to render properly in older versions of safari
+  appearance: none;
+  appearance: none;
+  appearance: none;
+
   @apply rounded-full border;
 
   &.small {

--- a/scss/_teamshares.scss
+++ b/scss/_teamshares.scss
@@ -1121,7 +1121,7 @@ a.icon-button-view-component {
 }
 
 .button-view-component {
-  // The following lines are required for buttons to render properly in older versions of safari
+  // The following line is required for buttons to render properly in older versions of safari
   appearance: none;
 
   @apply rounded-full border;


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Fix-Safari-Styling-For-Education-3f0567a9d87645179a0c94da3f70816a)

## Description
Right now outlined buttons aren't rendering correctly for os education in safari, this is a pr to fix it. The other issue of spacing being messed up is due to flexgaps not working in older version of safari (see [this article](https://www.falldowngoboone.com/blog/the-curious-case-of-flexbox-gap-and-safari/)) and will be resolved in a separate PR

## Screenshots (if relevant)
Before: 
<img width="1792" alt="Screen Shot 2022-11-07 at 3 58 51 PM" src="https://user-images.githubusercontent.com/83985302/200455496-253270d7-d809-47cc-9051-fa7a0119c16b.png">

After:
<img width="1792" alt="Screen Shot 2022-11-07 at 3 58 05 PM" src="https://user-images.githubusercontent.com/83985302/200455140-b550eaed-7531-403b-b5d5-e3f3d3eed0b4.png">

## Release Reminder (delete before submitting PR)
*Consider whether or not you'll need to manually redeploy any consuming apps (e.g. Buyout, OS) as soon as this change is merged.*

**Reminder:** these changes won't be pulled into any downstream apps until you merge _this_ PR, and _then_ merge a PR _on that app_ checking in an updated `yarn.lock` (i.e. after having run `yarn upgrade @teamshares/ui`).
