### PR TITLE
Add two shades of teal

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -74,6 +74,10 @@ module.exports = {
           800: "#956419",
           900: "#694712"
         },
+        teal: {
+          100: "#F0FAFA",
+          700: "#288286"
+        },
         subdued: "#6d7176",
         default: "#2e333c",
         white: "#ffffff",


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Phase-1-Preferred-shares-purchase-Pending-request-card-Cancel-functionality-6baa6256b7a1420997d53a3de6b657f1)

## Description
Adding two custom colors to support a new cap table event type and its related pending event card

## Screenshots
See label component and text - `Preferred shares purchase`
![Screen Shot 2022-12-06 at 4 42 27 PM](https://user-images.githubusercontent.com/6422641/206051782-5b5827a9-1131-4db3-b7e3-f9eeb633c1b1.png)

**Reminder:** these changes won't be pulled into any downstream apps until you merge _this_ PR, and _then_ merge a PR _on that app_ checking in an updated `yarn.lock` (i.e. after having run `yarn upgrade @teamshares/ui`).
