### PR TITLE
Load Shoelace icon assets directly instead of via CDN

### DIFF
--- a/configs/esbuild.config.js
+++ b/configs/esbuild.config.js
@@ -2,12 +2,13 @@
 const path = require("path");
 const esbuild = require("esbuild");
 const { stimulusPlugin } = require("esbuild-plugin-stimulus");
+const { copy } = require("esbuild-plugin-copy");
 
 const isProd = process.env.RAILS_ENV === "production" || process.env.NODE_ENV === "production";
 const isWatch = process.argv.includes("--watch");
 
 const sharedConfig = {
-  logLevel: "info",
+  logLevel: "warning",
   entryPoints: [
     "application.js",
   ],
@@ -30,6 +31,16 @@ const sharedConfig = {
   },
   plugins: [
     stimulusPlugin(),
+    copy({
+      // this is equal to process.cwd(), which means we use cwd path as base path to resolve `to` path
+      // if not specified, this plugin uses ESBuild.build outdir/outfile options as base path.
+      resolveFrom: "cwd",
+      assets: {
+        from: ["./node_modules/@teamshares/shoelace/dist/assets/icons/*"],
+        to: ["./public/assets/icons"],
+      },
+    },
+    ),
   ],
 };
 

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,4 @@
+import * as Shoelace from "@teamshares/shoelace"; // eslint-disable-line no-unused-vars
 import { initHoneybadger } from "./_honeybadger";
 
 export * from "./controllers";

--- a/js/index.js
+++ b/js/index.js
@@ -11,5 +11,7 @@ export default class Teamshares {
   static init () {
     console.log("Initializing Teamshares JS");
     initHoneybadger({ debug: true });
+
+    Shoelace.getBasePath(); // Trigger library initialization
   }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,3 @@
-import * as Shoelace from "@teamshares/shoelace";
 import { initHoneybadger } from "./_honeybadger";
 
 export * from "./controllers";
@@ -11,10 +10,5 @@ export default class Teamshares {
   static init () {
     console.log("Initializing Teamshares JS");
     initHoneybadger({ debug: true });
-
-    // Registers Heroicons as the default icon library in Shoelace
-    Shoelace.registerIconLibrary("default", {
-      resolver: name => `https://cdn.jsdelivr.net/npm/heroicons@2.0.14/24/outline/${name}.svg`,
-    });
   }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -11,7 +11,5 @@ export default class Teamshares {
   static init () {
     console.log("Initializing Teamshares JS");
     initHoneybadger({ debug: true });
-
-    Shoelace.getBasePath(); // Trigger library initialization
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@teamshares/shoelace": "1.0.1-alpha.4",
     "cssnano": "5.1.14",
     "esbuild": "0.17.5",
+    "esbuild-plugin-copy": "^2.0.2",
     "esbuild-plugin-stimulus": "^0.1.5",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-n": "15.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -770,7 +770,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1177,6 +1177,15 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+esbuild-plugin-copy@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/esbuild-plugin-copy/-/esbuild-plugin-copy-2.0.2.tgz#3c215c421b35a4e48a3b3c5362e75a95602d9c4f"
+  integrity sha512-HlDgkHXagBCwaoB8tlQFeH08/i5a2ey6Pc26annV1YcG5CkAHzzRzmCwp3wdi5KHI//HVUgipS+Zsy2tQmn9gQ==
+  dependencies:
+    chalk "^4.1.2"
+    fs-extra "^10.0.1"
+    globby "^11.0.3"
+
 esbuild-plugin-stimulus@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/esbuild-plugin-stimulus/-/esbuild-plugin-stimulus-0.1.5.tgz#6e4ba834ed8fcf9d662f1df8f709e05328b6b92c"
@@ -1475,6 +1484,15 @@ fraction.js@^4.2.0:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
+fs-extra@^10.0.1:
+  version "10.1.0"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^11.0.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.0.tgz#5784b102104433bb0e090f48bfc4a30742c357ed"
@@ -1575,7 +1593,7 @@ globals@^13.19.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.1.0:
+globby@^11.0.3, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Solve-asset-bundling-for-icons-with-esbuild-0339b4ef0ad544a5941dfc919e8ac2fd)

## Description
Solves the issue whereby icon assets were not being packaged with the app, and the app was still loading assets from the CDN. This will:

- Load the icons much faster
- Allow us to add or modify icons via our Shoelace fork (which consumes our Heroicons fork)
