### PR TITLE
Shoelace import fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tailwindcss/forms": "0.5.3",
     "@tailwindcss/line-clamp": "0.4.2",
     "@tailwindcss/typography": "0.5.9",
-    "@teamshares/shoelace": "1.0.5",
+    "@teamshares/shoelace": "1.0.6",
     "cssnano": "5.1.15",
     "esbuild": "0.17.10",
     "esbuild-plugin-copy": "^2.0.2",

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -7,4 +7,6 @@
 @import 'includes';
 
 @import '@teamshares/shoelace/dist/themes/light';
-@import '@teamshares/shoelace/dist/styles/index';
+@import '@teamshares/shoelace/dist/styles/tokens';
+@import '@teamshares/shoelace/dist/styles/overrides';
+@import '@teamshares/shoelace/dist/styles/vendor';


### PR DESCRIPTION
This is another attempt (hopefully final!) to fix the imports for design tokens that seemed to have been broken somewhere in the recent update to shoelace and/or recent squashing / renovate / build pipeline changes. For some reason, the previous import style stopped working. This style of importing the files directly, as opposed to through an index file, works locally and allows public-website to compile and have the tokens available.