### PR TITLE
[Elektra] Update ts-alert styling

### DIFF
--- a/scss/includes/_teamshares.scss
+++ b/scss/includes/_teamshares.scss
@@ -750,14 +750,14 @@ ul a {
   // Notifications
 
   .ts-alert {
-    @apply border border-yellow-400 bg-yellow-100 flex px-5 py-3 relative rounded text-yellow-800 z-50;
+    @apply border border-yellow-300 bg-yellow-50 flex px-5 py-3 relative rounded-lg text-yellow-800 z-50 ts-body-2;
 
     div {
       @apply flex-auto;
     }
 
     svg {
-      @apply fill-current h-5 w-5;
+      @apply fill-current h-5 w-5 text-gray-700;
     }
 
     .close-notification {

--- a/scss/includes/_teamshares.scss
+++ b/scss/includes/_teamshares.scss
@@ -748,6 +748,7 @@ ul a {
   }
 
   // Notifications
+  // (note these are *currently* only used in buyout; we may want to extract them eventually?)
 
   .ts-alert {
     @apply border border-yellow-300 bg-yellow-50 flex px-5 py-3 relative rounded-lg text-yellow-800 z-50 ts-body-2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,10 +459,10 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@teamshares/shoelace@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/@teamshares/shoelace/-/shoelace-1.0.5.tgz#51cc8bbb73801c8aadef497254c9069706917227"
-  integrity sha512-0dwY8nAu1xAQBgBK0e9So0gdIFy2ih8wpJKUd0o+4Y+0AlW3kcSAdL6hGGFNuK4wixBNCh+vUOJ3PsrM6BBCiw==
+"@teamshares/shoelace@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-1.0.6.tgz#0bf214f63d1dee862352dcccb0c4b03dace798b7"
+  integrity sha512-tIQR+wcZplM439ESRPhnRDM5by5eYaD7N55sO11S1nqdtuzIUlYtBAjekMx73FnAHdP4T2GTlsj5YyLoFDa1lw==
   dependencies:
     "@ctrl/tinycolor" "^3.5.0"
     "@floating-ui/dom" "^1.1.0"


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Add-Flash-Message-in-Current-Step-Partial-For-Limbo-and-Rejected-Leads-b1dff1ff2fe94a5a8ef206c329e41b8d)

## Description
Update the ts-alert styles for the underwriting steps redesign epic

## Screenshots
<img width="1473" alt="Screen Shot 2023-02-24 at 2 24 40 PM" src="https://user-images.githubusercontent.com/40578238/221272914-10bb0734-b4d9-41d0-88d5-f8f2ff875d20.png">
