### PR TITLE
Importing Rails in shared-ui and adding shoelace selectors

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,6 @@
 import * as Shoelace from "@teamshares/shoelace"; // eslint-disable-line no-unused-vars
 import { initHoneybadger } from "./_honeybadger";
+import Rails from "@rails/ujs";
 
 export * from "./controllers";
 export * from "./_honeybadger"; // Leaving this for legacy sake; should be removed once everyone is calling initialize below
@@ -11,5 +12,14 @@ export default class Teamshares {
   static init () {
     console.log("Initializing Teamshares JS");
     initHoneybadger({ debug: true });
+
+    // Overwrite Rails UJS's selectors to include Shoelace elements
+    Rails.buttonClickSelector = {
+      selector: "button[data-remote]:not([form]), button[data-confirm]:not([form]), sl-button[data-remote]:not([form]), sl-button[data-confirm]:not([form])",
+      exclude: "form button, form sl-button",
+    };
+    Rails.linkClickSelector = "a[data-confirm], a[data-method], a[data-remote]:not([disabled]), a[data-disable-with], a[data-disable], sl-button[href][data-confirm], sl-button[href][data-method], sl-button[href][data-remote]:not([disabled]), sl-button[href][data-disable-with], sl-button[href][data-disable]";
+
+    Rails.start();
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@honeybadger-io/js": "5.1.1",
     "@hotwired/stimulus": "3.2.1",
     "@hotwired/turbo-rails": "7.2.5",
+    "@rails/ujs": "^7.0.4-2",
     "@tailwindcss/forms": "0.5.3",
     "@tailwindcss/line-clamp": "0.4.2",
     "@tailwindcss/typography": "0.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,6 +427,11 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.4.tgz#70a3ca56809f7aaabb80af2f9c01ae51e1a8ed41"
   integrity sha512-tz4oM+Zn9CYsvtyicsa/AwzKZKL+ITHWkhiu7x+xF77clh2b4Rm+s6xnOgY/sGDWoFWZmtKsE95hxBPkgQQNnQ==
 
+"@rails/ujs@^7.0.4-2":
+  version "7.0.4-2"
+  resolved "https://registry.npmjs.org/@rails/ujs/-/ujs-7.0.4-2.tgz#62b108cc297c0c60f415720295673ee73f08e210"
+  integrity sha512-ec6e2+YSfg4DgrVzIYzpo7ayze6dOu+lZ6RsIR+COkuZCp2QGMEyHZQzNdHt065FjCtpv6wRZQIybAtWrzPqlQ==
+
 "@shoelace-style/animations@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@shoelace-style/animations/-/animations-1.1.0.tgz#17539abafd6dcbf2a79e089e1593175e9f7835b5"


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Investigate-Ways-To-Get-data-remote-true-working-for-shoelace-buttons-fa313abfe7c04d0faffffc7b2342168c?pvs=4)

## Description

This pulls our Rails UJS dependency out of the apps and into shared-ui, which allows us to easily override UJS's selectors and include Shoelace elements, enabling us to use Shoelace buttons with our existing modals.