### PR TITLE
Add remaining Shoelace elements to UJS selectors

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -15,10 +15,17 @@ export default class Teamshares {
 
     // Overwrite Rails UJS's selectors to include Shoelace elements
     Rails.buttonClickSelector = {
-      selector: "button[data-remote]:not([form]), button[data-confirm]:not([form]), sl-button[data-remote]:not([form]), sl-button[data-confirm]:not([form])",
+      selector: Rails.buttonClickSelector.selector + ", sl-button[data-remote]:not([form]), sl-button[data-confirm]:not([form])",
       exclude: "form button, form sl-button",
     };
-    Rails.linkClickSelector = "a[data-confirm], a[data-method], a[data-remote]:not([disabled]), a[data-disable-with], a[data-disable], sl-button[href][data-confirm], sl-button[href][data-method], sl-button[href][data-remote]:not([disabled]), sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    Rails.linkClickSelector += ", sl-button[href][data-confirm], sl-button[href][data-method], sl-button[href][data-remote]:not([disabled]), sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    Rails.inputChangeSelector += ", sl-select[data-remote], sl-input[data-remote], sl-textarea[data-remote]";
+    Rails.formInputClickSelector += ", form:not([data-turbo=true]) sl-input[type=submit], form:not([data-turbo=true]) sl-input[type=image], form:not([data-turbo=true]) sl-button[type=submit], form:not([data-turbo=true]) sl-button:not([type]), sl-input[type=submit][form], sl-input[type=image][form], sl-button[type=submit][form], sl-button[form]:not([type])";
+    Rails.formDisableSelector += ", sl-input[data-disable-with]:enabled, sl-button[data-disable-with]:enabled, sl-textarea[data-disable-with]:enabled, sl-input[data-disable]:enabled, sl-button[data-disable]:enabled, sl-textarea[data-disable]:enabled";
+    Rails.formEnableSelector += ", sl-input[data-disable-with]:disabled, sl-button[data-disable-with]:disabled, sl-textarea[data-disable-with]:disabled, sl-input[data-disable]:disabled, sl-button[data-disable]:disabled, sl-textarea[data-disable]:disabled";
+    Rails.fileInputSelector += ", sl-input[name][type=file]:not([disabled])";
+    Rails.linkDisableSelector += ", sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    Rails.buttonDisableSelector += ", sl-button[data-remote][data-disable-with], sl-button[data-remote][data-disable]";
 
     Rails.start();
   }


### PR DESCRIPTION
This is a continuation of the previous work that enabled Shoelace buttons to launch modals by adding them to the UJS selectors. While we're at it, might as well add equivalent Shoelace elements to all the UJS selectors, which will help unlock things like link_to and button_to.