### PR TITLE
Rails UJS update

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -26,7 +26,5 @@ export default class Teamshares {
     Rails.fileInputSelector += ", sl-input[name][type=file]:not([disabled])";
     Rails.linkDisableSelector += ", sl-button[href][data-disable-with], sl-button[href][data-disable]";
     Rails.buttonDisableSelector += ", sl-button[data-remote][data-disable-with], sl-button[data-remote][data-disable]";
-
-    Rails.start();
   }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -15,10 +15,17 @@ export default class Teamshares {
 
     // Overwrite Rails UJS's selectors to include Shoelace elements
     Rails.buttonClickSelector = {
-      selector: "button[data-remote]:not([form]), button[data-confirm]:not([form]), sl-button[data-remote]:not([form]), sl-button[data-confirm]:not([form])",
+      selector: Rails.buttonClickSelector.selector + ", sl-button[data-remote]:not([form]), sl-button[data-confirm]:not([form])",
       exclude: "form button, form sl-button",
     };
-    Rails.linkClickSelector = "a[data-confirm], a[data-method], a[data-remote]:not([disabled]), a[data-disable-with], a[data-disable], sl-button[href][data-confirm], sl-button[href][data-method], sl-button[href][data-remote]:not([disabled]), sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    Rails.linkClickSelector += ", sl-button[href][data-confirm], sl-button[href][data-method], sl-button[href][data-remote]:not([disabled]), sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    Rails.inputChangeSelector += ", sl-select[data-remote], sl-input[data-remote], sl-textarea[data-remote]";
+    Rails.formInputClickSelector += ", form:not([data-turbo=true]) sl-input[type=submit], form:not([data-turbo=true]) sl-input[type=image], form:not([data-turbo=true]) sl-button[type=submit], form:not([data-turbo=true]) sl-button:not([type]), sl-input[type=submit][form], sl-input[type=image][form], sl-button[type=submit][form], sl-button[form]:not([type])";
+    Rails.formDisableSelector += ", sl-input[data-disable-with]:enabled, sl-button[data-disable-with]:enabled, sl-textarea[data-disable-with]:enabled, sl-input[data-disable]:enabled, sl-button[data-disable]:enabled, sl-textarea[data-disable]:enabled";
+    Rails.formEnableSelector += ", sl-input[data-disable-with]:disabled, sl-button[data-disable-with]:disabled, sl-textarea[data-disable-with]:disabled, sl-input[data-disable]:disabled, sl-button[data-disable]:disabled, sl-textarea[data-disable]:disabled";
+    Rails.fileInputSelector += ", sl-input[name][type=file]:not([disabled])";
+    Rails.linkDisableSelector += ", sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    Rails.buttonDisableSelector += ", sl-button[data-remote][data-disable-with], sl-button[data-remote][data-disable]";
 
     Rails.start();
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@honeybadger-io/js": "5.1.1",
     "@hotwired/stimulus": "3.2.1",
     "@hotwired/turbo-rails": "7.2.5",
-    "@rails/ujs": "^7.0.4-2",
+    "@rails/ujs": "7.0.4",
     "@tailwindcss/forms": "0.5.3",
     "@tailwindcss/line-clamp": "0.4.2",
     "@tailwindcss/typography": "0.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,10 +427,10 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.4.tgz#70a3ca56809f7aaabb80af2f9c01ae51e1a8ed41"
   integrity sha512-tz4oM+Zn9CYsvtyicsa/AwzKZKL+ITHWkhiu7x+xF77clh2b4Rm+s6xnOgY/sGDWoFWZmtKsE95hxBPkgQQNnQ==
 
-"@rails/ujs@^7.0.4-2":
-  version "7.0.4-2"
-  resolved "https://registry.npmjs.org/@rails/ujs/-/ujs-7.0.4-2.tgz#62b108cc297c0c60f415720295673ee73f08e210"
-  integrity sha512-ec6e2+YSfg4DgrVzIYzpo7ayze6dOu+lZ6RsIR+COkuZCp2QGMEyHZQzNdHt065FjCtpv6wRZQIybAtWrzPqlQ==
+"@rails/ujs@7.0.4":
+  version "7.0.4"
+  resolved "https://registry.npmjs.org/@rails/ujs/-/ujs-7.0.4.tgz#7fe5387d2d82b0547fdfc6667b424ec119c86b1e"
+  integrity sha512-UY9yQxBvtqXzXScslgPwZoQd16T0+z3P6BQS4lZDJFg5xVuMIgHkHQI6dhyWEt5l/qwbGaYX+YiZu6J+oxWPOw==
 
 "@shoelace-style/animations@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
Follow up on UJS injection. Turns out that the apps still need to import Rails directly because they're calling .ajax and other methods on it. Eventually, we will move all of that into `shared-ui` and export everything from there, but that will require PRs into a number of apps. This change will allow us to move forward as-is.