### PR TITLE
Revert turbo 7.3.0 -> 7.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@honeybadger-io/js": "5.1.1",
     "@hotwired/stimulus": "3.2.1",
     "@hotwired/turbo-rails": "7.2.5",
+    "@hotwired/turbo": "7.2.5",
     "@rails/ujs": "7.0.4",
     "@tailwindcss/forms": "0.5.3",
     "@tailwindcss/line-clamp": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "@honeybadger-io/js": "5.1.1",
     "@hotwired/stimulus": "3.2.1",
-    "@hotwired/turbo-rails": "7.2.5",
     "@hotwired/turbo": "7.2.5",
+    "@hotwired/turbo-rails": "7.2.5",
     "@rails/ujs": "7.0.4",
     "@tailwindcss/forms": "0.5.3",
     "@tailwindcss/line-clamp": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@honeybadger-io/js": "5.1.1",
     "@hotwired/stimulus": "3.2.1",
-    "@hotwired/turbo-rails": "7.3.0",
+    "@hotwired/turbo-rails": "7.2.5",
     "@rails/ujs": "7.0.4",
     "@tailwindcss/forms": "0.5.3",
     "@tailwindcss/line-clamp": "0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,6 +365,11 @@
     "@hotwired/turbo" "^7.2.5"
     "@rails/actioncable" "^7.0"
 
+"@hotwired/turbo@7.2.5":
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.2.5.tgz#2d9d6bde8a9549c3aea8970445ade16ffd56719a"
+  integrity sha512-o5PByC/mWkmTe4pWnKrixhPECJUxIT/NHtxKqjq7n9Fj6JlNza1pgxdTCJVIq+PI0j95U+7mA3N4n4A/QYZtZQ==
+
 "@hotwired/turbo@^7.2.5":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.3.0.tgz#2226000fff1aabda9fd9587474565c9929dbf15d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,9 +371,9 @@
   integrity sha512-o5PByC/mWkmTe4pWnKrixhPECJUxIT/NHtxKqjq7n9Fj6JlNza1pgxdTCJVIq+PI0j95U+7mA3N4n4A/QYZtZQ==
 
 "@hotwired/turbo@^7.2.5":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.3.0.tgz#2226000fff1aabda9fd9587474565c9929dbf15d"
-  integrity sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.2.5.tgz#2d9d6bde8a9549c3aea8970445ade16ffd56719a"
+  integrity sha512-o5PByC/mWkmTe4pWnKrixhPECJUxIT/NHtxKqjq7n9Fj6JlNza1pgxdTCJVIq+PI0j95U+7mA3N4n4A/QYZtZQ==
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,15 +357,15 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.1.tgz#e3de23623b0c52c247aba4cd5d530d257008676b"
   integrity sha512-HGlzDcf9vv/EQrMJ5ZG6VWNs8Z/xMN+1o2OhV1gKiSG6CqZt5MCBB1gRg5ILiN3U0jEAxuDTNPRfBcnZBDmupQ==
 
-"@hotwired/turbo-rails@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.3.0.tgz#422c21752509f3edcd6c7b2725bbe9e157815f51"
-  integrity sha512-fvhO64vp/a2UVQ3jue9WTc2JisMv9XilIC7ViZmXAREVwiQ2S4UC7Go8f9A1j4Xu7DBI6SbFdqILk5ImqVoqyA==
+"@hotwired/turbo-rails@7.2.5":
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.2.5.tgz#74fc3395a29a76df2bb8835aa88c86885cffde4c"
+  integrity sha512-F8ztmARxd/XBdevRa//HoJGZ7u+Unb0J7cQUeUP+pBvt9Ta2TJJ7a2TORAOhjC8Zgxx+LKwm/1UUHqN3ojjiGw==
   dependencies:
-    "@hotwired/turbo" "^7.3.0"
+    "@hotwired/turbo" "^7.2.5"
     "@rails/actioncable" "^7.0"
 
-"@hotwired/turbo@^7.3.0":
+"@hotwired/turbo@^7.2.5":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.3.0.tgz#2226000fff1aabda9fd9587474565c9929dbf15d"
   integrity sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Revert-Turbo-7-3-d6cceaa1209e45f1bed65affe3559f59?pvs=4)

## Description
Reverting problematic `@hotwired/turbo` upgrade (changes a warning to an exception when linking _out_ of a `turbo_frame` and intending to do a whole page refresh, which breaks at least OS).