### PR TITLE
As of Tailwind CSS v3.3, the '@tailwindcss/line-clamp' plugin is now …

### DIFF
--- a/configs/tailwind.config.js
+++ b/configs/tailwind.config.js
@@ -11,7 +11,6 @@ const tailwindConfig = {
   plugins: [
     require("@tailwindcss/forms"),
     require("@tailwindcss/typography"),
-    require("@tailwindcss/line-clamp"),
   ],
   theme: {
     extend: {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@hotwired/turbo-rails": ">= 7.2.5",
     "@rails/ujs": "7.0.4",
     "@tailwindcss/forms": "0.5.3",
-    "@tailwindcss/line-clamp": "0.4.2",
     "@tailwindcss/typography": "0.5.9",
     "@teamshares/shoelace": "1.1.0",
     "cssnano": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -454,11 +454,6 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
-"@tailwindcss/line-clamp@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz#f353c5a8ab2c939c6267ac5b907f012e5ee130f9"
-  integrity sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==
-
 "@tailwindcss/typography@0.5.9":
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.9.tgz#027e4b0674929daaf7c921c900beee80dbad93e8"


### PR DESCRIPTION
…included by default
