### PR TITLE
Register Font Awesome Pro resolver

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -38,5 +38,25 @@ export default class Teamshares {
       },
       mutator: svg => svg.setAttribute("fill", "currentColor"),
     });
+
+    // Register FontAwesome Pro and point at our bespoke "kit" URL, including the token in the querystring
+    // See https://fontawesome.com/kits/44da2a9d09/setup
+    // Note that the kit allows us to whitelist / deny specific URL patterns
+    Shoelace.registerIconLibrary("fa", {
+      resolver: name => {
+        const filename = name.replace(/^fa([rsltdb]|(ss))-/, "");
+        const sub = name.substring(0, 4);
+        const folderHash = {
+          "fas-": "solid",
+          "fal-": "light",
+          "fat-": "thin",
+          "fad-": "duotone",
+          "fab-": "brands",
+        };
+        const folder = folderHash[sub] || "regular";
+        return `https://ka-p.fontawesome.com/releases/v6.4.0/svgs/${folder}/${filename}.svg?token=44da2a9d09`;
+      },
+      mutator: svg => svg.setAttribute("fill", "currentColor"),
+    });
   }
 }


### PR DESCRIPTION
## Ticket
[Spike: host Font Awesome Pro ourselves ](https://www.notion.so/teamshares/Spike-host-Font-Awesome-Pro-ourselves-58bd48c4f82f4aacbdab8b0f00dad5f6?pvs=4)

## Description
This enables us to use our Font Awesome Pro icons in production, via a "kit", which Font Awesome provides as a sort of customized CDN. The it allows us to tailor the set of icons we serve as well as which domains are whitelisted (currently *.teamshares.com). See https://fontawesome.com/kits/44da2a9d09/setup.

The Shoelace docs will also be updated to reflect this change.