### PR TITLE
Fix: Increase ts-input font size to prevent zoom on mobile

### DIFF
--- a/scss/includes/_teamshares.scss
+++ b/scss/includes/_teamshares.scss
@@ -392,7 +392,7 @@ ul a {
     border-radius: 0.375rem;
     border-style: solid;
     border-width: 1px;
-    font-size: 0.8125rem;
+    font-size: 1rem;
     height: 2.25rem;
     line-height: 2rem;
     padding: 0 0.75rem;


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/83b-Shareholder-Grant-Agreement-for-Presidents-c9227dd12da84506b20e3df4bef76c4e?pvs=4)
[Notion](https://www.notion.so/teamshares/Screen-zooms-in-to-enter-text-into-the-field-but-doesn-t-zoom-back-out-when-done-i-ve-seen-this-be8744e9d1b94c6facd38d52d9dd066d?pvs=4)

## Description
While working on the 83(b) ticket above, we had to override the `ts-input` styling to set the font size to 1rem so that Safari wouldn't automatically zoom in the entire window and never zoom back out. This fix should be applied globally across all instances of `ts-input`, as reflected in this PR.

Sara checked with the designers and did a sweep of all known instances of `ts-input`, and for the most part this size is either already being overridden to 1px or we're not using `ts-input` at all. This should cover the remaining cases where we have legacy code that's still using that old style. 

Obviously this will become obsolete when we switch inputs over to Shoelace.
