### PR TITLE
Bump shoelace version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@rails/ujs": "7.0.4",
     "@tailwindcss/forms": "0.5.3",
     "@tailwindcss/typography": "0.5.9",
-    "@teamshares/shoelace": "1.2.0",
+    "@teamshares/shoelace": "1.2.1",
     "cssnano": "6.0.1",
     "esbuild": "0.17.19",
     "esbuild-plugin-copy": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,10 +518,10 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@teamshares/shoelace@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@teamshares/shoelace/-/shoelace-1.2.0.tgz#3957e709a23c8650e2e083a44869e0fd35614385"
-  integrity sha512-6lxkDMI9e/9XItrBBYPHVwKr/mjm3SYCug10s8oAe+lVv2gSGjNA71lUzTaxJUY258HyXt2YXw3dehJdxYYa/Q==
+"@teamshares/shoelace@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-1.2.1.tgz#2be02148d45fbfa0eaba6c003be0da2efcf783ed"
+  integrity sha512-vKUK4ObJ22mUn0YceDm9zbD45Eg+5rNbvHFxE9t21pTIIBQXdg65EXrrvlSpgsfVHHIZJJs2oJapnAcmCHv1qw==
   dependencies:
     "@ctrl/tinycolor" "^3.5.0"
     "@floating-ui/dom" "^1.2.1"


### PR DESCRIPTION
## Description
- non-critical for all consuming apps to upgrade to immediately
- related Teamshares Shoelace fork release: https://github.com/teamshares/shoelace/releases/tag/v.1.2.1