### PR TITLE
Include SimpleForm + Shoelace error styling

### DIFF
--- a/scss/includes/_teamshares.scss
+++ b/scss/includes/_teamshares.scss
@@ -895,3 +895,39 @@ ul a {
     }
   }
 }
+
+// SimpleForm + Shoelace error styling
+sl-input[data-user-invalid]::part(base),
+sl-select[data-user-invalid]::part(combobox),
+sl-checkbox[data-user-invalid]::part(control),
+sl-textarea[data-user-invalid]::part(textarea) {
+  @apply border-red-700;
+}
+
+[data-user-invalid]::part(form-control-help-text) {
+  @apply text-red-700;
+}
+
+[data-user-invalid]::part(form-control-label) {
+  @apply border border-red-700;
+}
+
+
+.field_with_errors {
+  @apply text-red-700;
+
+  sl-input::part(base),
+  sl-select::part(combobox),
+  sl-checkbox::part(control),
+  sl-textarea::part(textarea) {
+    @apply border-red-700;
+  }
+
+  ::part(form-control-help-text), .ts-input__help {
+    @apply text-red-700;
+  }
+
+  ::part(form-control-label) {
+    @apply border border-red-700;
+  }
+}


### PR DESCRIPTION
## Description

Related pull-request: https://github.com/teamshares/shared-rails-engine/pull/252

Moving styles that would have to be repeated in each Rails app that mounts our shared rails engine into our shared UI so that it's set consistently for any consumer of shared UI (and shared-rails-engine).