### PR TITLE
Mad/rails as param

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,8 @@
 import * as Shoelace from "@teamshares/shoelace";
 import { initHoneybadger } from "./_honeybadger";
-import Rails from "@rails/ujs"; // Still importing this as a default param so the init doesn't break, but should now be passed in
+// Importing this as a default param so the init doesn't break if apps don't pass it in
+// Alternatively, the apps should stop importing it at all and this should be the single source of truth (via returning the instance)
+import Rails from "@rails/ujs";
 
 export * from "./controllers";
 export * from "./_honeybadger"; // Leaving this for legacy sake; should be removed once everyone is calling initialize below

--- a/js/index.js
+++ b/js/index.js
@@ -1,7 +1,6 @@
 import * as Shoelace from "@teamshares/shoelace";
 import { initHoneybadger } from "./_honeybadger";
 // Importing this as a default param so the init doesn't break if apps don't pass it in
-// Alternatively, the apps should stop importing it at all and this should be the single source of truth (via returning the instance)
 import Rails from "@rails/ujs";
 
 export * from "./controllers";
@@ -60,8 +59,5 @@ export default class Teamshares {
       },
       mutator: svg => svg.setAttribute("fill", "currentColor"),
     });
-
-    // This allows us to transition gracefully to letting apps not import Rails at all, and get it from here instead.
-    return railsObj;
   }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,6 @@
 import * as Shoelace from "@teamshares/shoelace";
 import { initHoneybadger } from "./_honeybadger";
-import Rails from "@rails/ujs";
+import Rails from "@rails/ujs"; // Still importing this as a default param so the init doesn't break, but should now be passed in
 
 export * from "./controllers";
 export * from "./_honeybadger"; // Leaving this for legacy sake; should be removed once everyone is calling initialize below
@@ -9,23 +9,23 @@ export * from "./_honeybadger"; // Leaving this for legacy sake; should be remov
 /**  Apps should import Teamshares and call init() on startup  */
 /** ********************************************************** */
 export default class Teamshares {
-  static init () {
+  static init (railsObj = Rails) {
     console.log("Initializing Teamshares JS");
     initHoneybadger({ debug: true });
 
     // Overwrite Rails UJS's selectors to include Shoelace elements
-    Rails.buttonClickSelector = {
-      selector: Rails.buttonClickSelector.selector + ", sl-button[data-remote]:not([form]), sl-button[data-confirm]:not([form])",
+    railsObj.buttonClickSelector = {
+      selector: railsObj.buttonClickSelector.selector + ", sl-button[data-remote]:not([form]), sl-button[data-confirm]:not([form])",
       exclude: "form button, form sl-button",
     };
-    Rails.linkClickSelector += ", sl-button[href][data-confirm], sl-button[href][data-method], sl-button[href][data-remote]:not([disabled]), sl-button[href][data-disable-with], sl-button[href][data-disable]";
-    Rails.inputChangeSelector += ", sl-select[data-remote], sl-input[data-remote], sl-textarea[data-remote]";
-    Rails.formInputClickSelector += ", form:not([data-turbo=true]) sl-input[type=submit], form:not([data-turbo=true]) sl-input[type=image], form:not([data-turbo=true]) sl-button[type=submit], form:not([data-turbo=true]) sl-button:not([type]), sl-input[type=submit][form], sl-input[type=image][form], sl-button[type=submit][form], sl-button[form]:not([type])";
-    Rails.formDisableSelector += ", sl-input[data-disable-with]:enabled, sl-button[data-disable-with]:enabled, sl-textarea[data-disable-with]:enabled, sl-input[data-disable]:enabled, sl-button[data-disable]:enabled, sl-textarea[data-disable]:enabled";
-    Rails.formEnableSelector += ", sl-input[data-disable-with]:disabled, sl-button[data-disable-with]:disabled, sl-textarea[data-disable-with]:disabled, sl-input[data-disable]:disabled, sl-button[data-disable]:disabled, sl-textarea[data-disable]:disabled";
-    Rails.fileInputSelector += ", sl-input[name][type=file]:not([disabled])";
-    Rails.linkDisableSelector += ", sl-button[href][data-disable-with], sl-button[href][data-disable]";
-    Rails.buttonDisableSelector += ", sl-button[data-remote][data-disable-with], sl-button[data-remote][data-disable]";
+    railsObj.linkClickSelector += ", sl-button[href][data-confirm], sl-button[href][data-method], sl-button[href][data-remote]:not([disabled]), sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    railsObj.inputChangeSelector += ", sl-select[data-remote], sl-input[data-remote], sl-textarea[data-remote]";
+    railsObj.formInputClickSelector += ", form:not([data-turbo=true]) sl-input[type=submit], form:not([data-turbo=true]) sl-input[type=image], form:not([data-turbo=true]) sl-button[type=submit], form:not([data-turbo=true]) sl-button:not([type]), sl-input[type=submit][form], sl-input[type=image][form], sl-button[type=submit][form], sl-button[form]:not([type])";
+    railsObj.formDisableSelector += ", sl-input[data-disable-with]:enabled, sl-button[data-disable-with]:enabled, sl-textarea[data-disable-with]:enabled, sl-input[data-disable]:enabled, sl-button[data-disable]:enabled, sl-textarea[data-disable]:enabled";
+    railsObj.formEnableSelector += ", sl-input[data-disable-with]:disabled, sl-button[data-disable-with]:disabled, sl-textarea[data-disable-with]:disabled, sl-input[data-disable]:disabled, sl-button[data-disable]:disabled, sl-textarea[data-disable]:disabled";
+    railsObj.fileInputSelector += ", sl-input[name][type=file]:not([disabled])";
+    railsObj.linkDisableSelector += ", sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    railsObj.buttonDisableSelector += ", sl-button[data-remote][data-disable-with], sl-button[data-remote][data-disable]";
 
     // Register free font-awesome icons
     Shoelace.registerIconLibrary("fa-free", {

--- a/js/index.js
+++ b/js/index.js
@@ -58,5 +58,8 @@ export default class Teamshares {
       },
       mutator: svg => svg.setAttribute("fill", "currentColor"),
     });
+
+    // This allows us to transition gracefully to letting apps not import Rails at all, and get it from here instead.
+    return railsObj;
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@honeybadger-io/js": "6.1.1",
     "@hotwired/stimulus": "3.2.1",
     "@hotwired/turbo-rails": ">= 7.2.5",
-    "@rails/ujs": "7.0.4",
+    "@rails/ujs": "7.0.5",
     "@tailwindcss/forms": "0.5.3",
     "@tailwindcss/typography": "0.5.9",
     "@teamshares/shoelace": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@honeybadger-io/js": "6.1.1",
     "@hotwired/stimulus": "3.2.1",
     "@hotwired/turbo-rails": ">= 7.2.5",
-    "@rails/ujs": "7.0.5",
+    "@rails/ujs": "7.0.6",
     "@tailwindcss/forms": "0.5.3",
     "@tailwindcss/typography": "0.5.9",
     "@teamshares/shoelace": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,10 +486,10 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.4.tgz#70a3ca56809f7aaabb80af2f9c01ae51e1a8ed41"
   integrity sha512-tz4oM+Zn9CYsvtyicsa/AwzKZKL+ITHWkhiu7x+xF77clh2b4Rm+s6xnOgY/sGDWoFWZmtKsE95hxBPkgQQNnQ==
 
-"@rails/ujs@7.0.5":
-  version "7.0.5"
-  resolved "https://registry.npmjs.org/@rails/ujs/-/ujs-7.0.5.tgz#d35a71fe6ecd4ab88bbe4bc6c2f287c992c2de4c"
-  integrity sha512-/wQ6v4DGxhxflPWoLwGkOQoKbtIXx/LsVNKd8shRM+/HXxlVBEb+F5znN99TlxX8e/R3dN6anTPAqA+mfA5YtQ==
+"@rails/ujs@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.npmjs.org/@rails/ujs/-/ujs-7.0.6.tgz#fd8937c92335f3da9495e07292511ad5f7547a6a"
+  integrity sha512-s5v3AC6AywOIFMz0RIMW83Xc8FPIvKMkP3ZHFlM4ISNkhdUwP9HdhVtxxo6z3dIhe9vI0Our2A8kN/QpUV02Qg==
 
 "@shoelace-style/animations@^1.1.0":
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,10 +486,10 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.4.tgz#70a3ca56809f7aaabb80af2f9c01ae51e1a8ed41"
   integrity sha512-tz4oM+Zn9CYsvtyicsa/AwzKZKL+ITHWkhiu7x+xF77clh2b4Rm+s6xnOgY/sGDWoFWZmtKsE95hxBPkgQQNnQ==
 
-"@rails/ujs@7.0.4":
-  version "7.0.4"
-  resolved "https://registry.npmjs.org/@rails/ujs/-/ujs-7.0.4.tgz#7fe5387d2d82b0547fdfc6667b424ec119c86b1e"
-  integrity sha512-UY9yQxBvtqXzXScslgPwZoQd16T0+z3P6BQS4lZDJFg5xVuMIgHkHQI6dhyWEt5l/qwbGaYX+YiZu6J+oxWPOw==
+"@rails/ujs@7.0.5":
+  version "7.0.5"
+  resolved "https://registry.npmjs.org/@rails/ujs/-/ujs-7.0.5.tgz#d35a71fe6ecd4ab88bbe4bc6c2f287c992c2de4c"
+  integrity sha512-/wQ6v4DGxhxflPWoLwGkOQoKbtIXx/LsVNKd8shRM+/HXxlVBEb+F5znN99TlxX8e/R3dN6anTPAqA+mfA5YtQ==
 
 "@shoelace-style/animations@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## Ticket
[Investigate why rails/ujs 7.0.5 breaks sl-buttons](https://www.notion.so/teamshares/Investigate-why-rails-ujs-7-0-5-breaks-sl-buttons-d7df5b5fdf6e4a188c5496d86ae87730?pvs=4)

## Description
For some as-yet-undiscovered reason, the update from Rails 7.0.4 -> 7.0.5 changed something about how Rails was being bundled/passed into the apps such that the Rails object shared-ui knew about and the Rails object in the apps became two separate objects. This meant that modifying the Rails selectors to allow UJS to pick up `sl-` elements was being done on the wrong object.

This PR just has the apps passing in their Rails instance, which ensures that it's the correct one. Note that shared-ui is still packaging and importing Rails as a fallback, but we might want to either 
a) get rid of that import in shared-ui once all the apps are passing it in or 
b) make all the apps get their instance of Rails from shared-ui instead, by returning the Rails instance from `Teamshares.init`. 

Option (b) is appealing if we want to standardize on the version of Rails for all the apps. But I'm not sure if we can do that.

