### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @kdonovan @lizziekoshelev @rkcrisafi @ebabian
+* @kdonovan @teamshares/design-system-admins
 
 # Only ping Kali for dependabots
 package.json @kdonovan


### PR DESCRIPTION
Expectation is people that open PRs should tag @teamshares/design-system for visibility to designers and engineers, but this CODEOWNER change will auto assign PRs to the @teamshares/design-system-admins users specifically.