### PR TITLE
Shared App Switcher Styles

### DIFF
--- a/scss/includes/_shared_app_switcher.scss
+++ b/scss/includes/_shared_app_switcher.scss
@@ -1,108 +1,129 @@
-sl-dropdown.app-switcher-dropdown,
-sl-button.app-switcher-dropdown-trigger {
-  display: block;
+sl-dropdown.app-switcher-dropdown {
+  @apply block;
+
+  &::part(panel) {
+    @apply bg-white;
+    @apply border border-gray-300;
+    @apply p-4;
+    @apply w-[400px];
+  }
 }
 
-sl-button.app-switcher-dropdown-trigger::part(base) {
-  border: 1px solid var(--sl-color-neutral-400);
-  border-radius: var(--ts-border-radius-small);
-  box-shadow: var(--ts-shadow-small);
-  height: var(--ts-input-height-x-large);
-  justify-content: space-between;
-  padding: var(--sl-spacing-small);
+sl-button.app-switcher-dropdown-trigger {
+  @apply block;
+
+  &::part(base) {
+    @apply border border-gray-400;
+    @apply rounded-md;
+    @apply h-16;
+    @apply justify-between;
+    @apply p-3;
+    box-shadow: var(--ts-shadow-small);
+  }
+
+  &::part(label) {
+    @apply items-center;
+    @apply text-blue-700;
+    @apply flex;
+    width: 100%;
+    @apply text-sm; /* 14px */
+    @apply font-semibold; /* 600 */
+    @apply justify-start;
+    @apply tracking-tight; /* -0.025em */
+    @apply leading-5;
+    @apply whitespace-normal;
+  }
+
+  &::part(caret) {
+    @apply flex-[0_0_auto];
+    @apply text-xl;
+  }
+
+  .dropdown-open::part(base) {
+    @apply bg-blue-50;
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
 }
 
 sl-button[outline].app-switcher-dropdown-trigger:hover::part(base) {
-  background: var(--sl-color-primary-50);
-}
-
-sl-button.app-switcher-dropdown-trigger.dropdown-open::part(base) {
-  background: var(--sl-color-primary-50);
-  outline: var(--sl-focus-ring);
-  outline-offset: var(--sl-focus-ring-offset);
-}
-
-sl-button.app-switcher-dropdown-trigger::part(label) {
-  align-items: center;
-  color: var(--sl-color-primary-700);
-  display: flex;
-  width: 100%;
-  font-size: var(--ts-font-sm); /* 14px */
-  font-weight: var(--ts-font-semibold); /* 600 */
-  justify-content: flex-start;
-  letter-spacing: var(--ts-tracking-tight); /* -0.025em */
-  line-height: 20px;
-  white-space: normal;
+  @apply bg-blue-50;
 }
 
 #app-icon {
-  color: var(--sl-color-primary-700);
-  padding-left: var(--sl-spacing-x-small);
-  padding-right: var(--sl-spacing-2x-small);
+  @apply text-blue-700;
+  @apply pl-2;
+  @apply pr-1;
 }
 
 #selected-app {
-  text-align: left;
+  @apply text-left
 }
 
-sl-button.app-switcher-dropdown-trigger::part(caret) {
-  flex: 0 0 auto;
-  font-size: 20px;
+.app-switcher-nav-items {
+  a {
+    @apply items-center;
+    @apply text-blue-700;
+    @apply flex;
+    @apply justify-between;
+    @apply mb-1;
+    @apply py-4 px-3;
+    @apply no-underline;
+    @apply transition-all duration-300;
+
+    &:hover {
+      @apply bg-blue-50;
+      @apply rounded;
+
+      .app-icon {
+        @apply opacity-100;
+        @apply transition-opacity duration-[600ms];
+      }
+    }
+
+    .app-icon {
+      @apply text-blue-700;
+      @apply opacity-[.65];
+    }
+  }
+
+  .app-switcher-nav-item-main-column {
+    @apply flex-1;
+    @apply mt-0 mr-4 mb-0 ml-5;
+  }
+
+  .app-switcher-app-name {
+    @apply ts-text-default ;
+    @apply mb-1;
+  }
+
 }
 
-sl-dropdown.app-switcher-dropdown::part(panel) {
-  background-color: white;
-  border: 1px solid var(--sl-color-neutral-300);
-  padding: var(--sl-spacing-medium);
-  width: 400px;
+sl-button.app-switcher-dropdown-trigger::part(label) .mobile {
+  font-size: var(--ts-font-base); /* @apply text-base */
+  font-weight: var(--ts-font-semibold); /* @apply font-semibold */
 }
 
-.app-switcher-nav-items a {
-  align-items: center;
-  color: var(--sl-color-primary-700);
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: var(--sl-spacing-2x-small);
-  padding: var(--sl-spacing-medium) var(--sl-spacing-small);
-  text-decoration: none;
-  transition: background 0.3s;
-}
-
-.app-switcher-nav-items a:hover {
-  background: var(--sl-color-primary-50);
-  border-radius: var(--sl-border-radius-medium);
-}
-
-.app-switcher-nav-items a:hover .app-icon {
-  opacity: 1;
-  transition: opacity 0.6s;
+sl-dropdown.app-switcher-dropdown::part(panel) .mobile {
+  margin-right: 24px; /* @apply mr-6 */
+  width: auto; /* @apply w-auto */
 }
 
 .app-switcher-nav-items a.selected {
-  background: var(--sl-color-primary-50);
-  border: 1px solid var(--sl-color-primary-200);
-  border-radius: var(--sl-border-radius-medium);
+  @apply bg-blue-50;
+  @apply border border-blue-200;
+  @apply rounded;
+
+  .app-icon {
+    @apply opacity-100;
+  }
 }
 
 .app-switcher-nav-items .app-switcher-nav-item-main-column {
-  flex: 1;
-  margin: 0 var(--sl-spacing-medium) 0 var(--sl-spacing-large);
-}
-
-.app-switcher-nav-items a.selected .app-icon {
-  opacity: 1;
-}
-
-.app-switcher-nav-items a .app-icon {
-  color: var(--sl-color-primary-700);
-  opacity: 0.65;
-}
-
-.app-switcher-nav-items .app-switcher-app-name {
-  color: var(--ts-color-text-default);
-  margin-bottom: var(--sl-spacing-2x-small);
+  @apply flex-1;
+  @apply mt-0 mr-4 mb-0 ml-5;
 }
 
 .app-switcher-nav-items a:not(.selected) .app-selected-check {
-  opacity: 0;
+  @apply opacity-0;
 }

--- a/scss/includes/_shared_app_switcher.scss
+++ b/scss/includes/_shared_app_switcher.scss
@@ -3,9 +3,8 @@ sl-dropdown.app-switcher-dropdown {
 
   &::part(panel) {
     @apply bg-white;
-    @apply border border-gray-300;
-    @apply p-4;
-    @apply w-[400px];
+    @apply mr-6;
+    @apply w-auto;
   }
 }
 
@@ -25,13 +24,13 @@ sl-button.app-switcher-dropdown-trigger {
     @apply items-center;
     @apply text-blue-700;
     @apply flex;
-    width: 100%;
-    @apply text-sm; /* 14px */
+    @apply text-base; /* 16px */
     @apply font-semibold; /* 600 */
     @apply justify-start;
     @apply tracking-tight; /* -0.025em */
     @apply leading-5;
     @apply whitespace-normal;
+    width: 100%;
   }
 
   &::part(caret) {
@@ -43,6 +42,16 @@ sl-button.app-switcher-dropdown-trigger {
     @apply bg-blue-50;
     outline: var(--sl-focus-ring);
     outline-offset: var(--sl-focus-ring-offset);
+  }
+}
+
+@media (min-width: 768px) {
+  sl-button.app-switcher-dropdown::part(panel) {
+    @apply w-[400px];
+  }
+
+  sl-button.app-switcher-dropdown-trigger::part(label) {
+    @apply text-sm;
   }
 }
 
@@ -61,6 +70,10 @@ sl-button[outline].app-switcher-dropdown-trigger:hover::part(base) {
 }
 
 .app-switcher-nav-items {
+  @apply border border-gray-300;
+  @apply p-4;
+  @apply rounded-lg;
+
   a {
     @apply items-center;
     @apply text-blue-700;
@@ -97,16 +110,6 @@ sl-button[outline].app-switcher-dropdown-trigger:hover::part(base) {
     @apply mb-1;
   }
 
-}
-
-sl-button.app-switcher-dropdown-trigger::part(label) .mobile {
-  font-size: var(--ts-font-base); /* @apply text-base */
-  font-weight: var(--ts-font-semibold); /* @apply font-semibold */
-}
-
-sl-dropdown.app-switcher-dropdown::part(panel) .mobile {
-  margin-right: 24px; /* @apply mr-6 */
-  width: auto; /* @apply w-auto */
 }
 
 .app-switcher-nav-items a.selected {

--- a/scss/includes/_shared_app_switcher.scss
+++ b/scss/includes/_shared_app_switcher.scss
@@ -21,15 +21,8 @@ sl-button.app-switcher-dropdown-trigger {
   }
 
   &::part(label) {
-    @apply items-center;
-    @apply text-blue-700;
-    @apply flex;
-    @apply text-base; /* 16px */
-    @apply font-semibold; /* 600 */
-    @apply justify-start;
-    @apply tracking-tight; /* -0.025em */
-    @apply leading-5;
-    @apply whitespace-normal;
+    @apply flex items-center justify-start;
+    @apply text-blue-700 text-base font-semibold tracking-tight leading-5 whitespace-normal; /* 16px */
     width: 100%;
   }
 
@@ -61,8 +54,7 @@ sl-button[outline].app-switcher-dropdown-trigger:hover::part(base) {
 
 #app-icon {
   @apply text-blue-700;
-  @apply pl-2;
-  @apply pr-1;
+  @apply pl-2 pr-1;
 }
 
 #selected-app {
@@ -75,13 +67,10 @@ sl-button[outline].app-switcher-dropdown-trigger:hover::part(base) {
   @apply rounded-lg;
 
   a {
-    @apply items-center;
-    @apply text-blue-700;
-    @apply flex;
-    @apply justify-between;
+    @apply text-blue-700 no-underline;
+    @apply flex justify-between items-center;
     @apply mb-1;
     @apply py-4 px-3;
-    @apply no-underline;
     @apply transition-all duration-300;
 
     &:hover {
@@ -114,8 +103,7 @@ sl-button[outline].app-switcher-dropdown-trigger:hover::part(base) {
 
 .app-switcher-nav-items a.selected {
   @apply bg-blue-50;
-  @apply border border-blue-200;
-  @apply rounded;
+  @apply border border-blue-200 rounded;
 
   .app-icon {
     @apply opacity-100;

--- a/scss/includes/_shared_app_switcher.scss
+++ b/scss/includes/_shared_app_switcher.scss
@@ -1,0 +1,108 @@
+sl-dropdown.app-switcher-dropdown,
+sl-button.app-switcher-dropdown-trigger {
+  display: block;
+}
+
+sl-button.app-switcher-dropdown-trigger::part(base) {
+  border: 1px solid var(--sl-color-neutral-400);
+  border-radius: var(--ts-border-radius-small);
+  box-shadow: var(--ts-shadow-small);
+  height: var(--ts-input-height-x-large);
+  justify-content: space-between;
+  padding: var(--sl-spacing-small);
+}
+
+sl-button[outline].app-switcher-dropdown-trigger:hover::part(base) {
+  background: var(--sl-color-primary-50);
+}
+
+sl-button.app-switcher-dropdown-trigger.dropdown-open::part(base) {
+  background: var(--sl-color-primary-50);
+  outline: var(--sl-focus-ring);
+  outline-offset: var(--sl-focus-ring-offset);
+}
+
+sl-button.app-switcher-dropdown-trigger::part(label) {
+  align-items: center;
+  color: var(--sl-color-primary-700);
+  display: flex;
+  width: 100%;
+  font-size: var(--ts-font-sm); /* 14px */
+  font-weight: var(--ts-font-semibold); /* 600 */
+  justify-content: flex-start;
+  letter-spacing: var(--ts-tracking-tight); /* -0.025em */
+  line-height: 20px;
+  white-space: normal;
+}
+
+#app-icon {
+  color: var(--sl-color-primary-700);
+  padding-left: var(--sl-spacing-x-small);
+  padding-right: var(--sl-spacing-2x-small);
+}
+
+#selected-app {
+  text-align: left;
+}
+
+sl-button.app-switcher-dropdown-trigger::part(caret) {
+  flex: 0 0 auto;
+  font-size: 20px;
+}
+
+sl-dropdown.app-switcher-dropdown::part(panel) {
+  background-color: white;
+  border: 1px solid var(--sl-color-neutral-300);
+  padding: var(--sl-spacing-medium);
+  width: 400px;
+}
+
+.app-switcher-nav-items a {
+  align-items: center;
+  color: var(--sl-color-primary-700);
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: var(--sl-spacing-2x-small);
+  padding: var(--sl-spacing-medium) var(--sl-spacing-small);
+  text-decoration: none;
+  transition: background 0.3s;
+}
+
+.app-switcher-nav-items a:hover {
+  background: var(--sl-color-primary-50);
+  border-radius: var(--sl-border-radius-medium);
+}
+
+.app-switcher-nav-items a:hover .app-icon {
+  opacity: 1;
+  transition: opacity 0.6s;
+}
+
+.app-switcher-nav-items a.selected {
+  background: var(--sl-color-primary-50);
+  border: 1px solid var(--sl-color-primary-200);
+  border-radius: var(--sl-border-radius-medium);
+}
+
+.app-switcher-nav-items .app-switcher-nav-item-main-column {
+  flex: 1;
+  margin: 0 var(--sl-spacing-medium) 0 var(--sl-spacing-large);
+}
+
+.app-switcher-nav-items a.selected .app-icon {
+  opacity: 1;
+}
+
+.app-switcher-nav-items a .app-icon {
+  color: var(--sl-color-primary-700);
+  opacity: 0.65;
+}
+
+.app-switcher-nav-items .app-switcher-app-name {
+  color: var(--ts-color-text-default);
+  margin-bottom: var(--sl-spacing-2x-small);
+}
+
+.app-switcher-nav-items a:not(.selected) .app-selected-check {
+  opacity: 0;
+}

--- a/scss/includes/_shared_app_switcher.scss
+++ b/scss/includes/_shared_app_switcher.scss
@@ -22,7 +22,7 @@ sl-button.app-switcher-dropdown-trigger {
 
   &::part(label) {
     @apply flex items-center justify-start;
-    @apply text-blue-700 text-base font-semibold tracking-tight leading-5 whitespace-normal; /* 16px */
+    @apply text-blue-700 text-base font-semibold tracking-tight leading-5 whitespace-normal;
     width: 100%;
   }
 

--- a/scss/includes/index.scss
+++ b/scss/includes/index.scss
@@ -1,3 +1,4 @@
 @import 'typography';
 @import 'teamshares';
+@import 'shared_app_switcher';
 


### PR DESCRIPTION
## Ticket
This work is a part of setting up the app switcher dropdown component that will be shared among all of the apps.

## Description
Since we don't have a clean way (yet!) to house both the styling alongside a view component within the shared rails engine codebase, we're housing the styling for that component here instead of keeping it as embedded css within the slim file of the component. It keeps the slim file clean and houses the styling where it makes the most sense for right now, here in shared-ui!

[The companion PR for the component itself is here](https://github.com/teamshares/shared-rails-engine/pull/262)

## Screenshots (if relevant)


<img width="1886" alt="image" src="https://github.com/teamshares/shared-rails-engine/assets/50687671/4b059621-d563-43ce-84f9-5590c628b310">

<img width="1897" alt="image" src="https://github.com/teamshares/shared-rails-engine/assets/50687671/6a0e57b1-8849-441f-864b-72d9e5dad320">


## Release Reminder (delete before submitting PR)
*Consider whether or not you'll need to manually redeploy any consuming apps (e.g. Buyout, OS) as soon as this change is merged.*

**Note OS will need to be redeployed!**

**Reminder:** these changes won't be pulled into any downstream apps until you merge _this_ PR, and _then_ merge a PR _on that app_ checking in an updated `yarn.lock` (i.e. after having run `yarn upgrade @teamshares/ui`).
