### PR TITLE
Revert @teamshares/shoelace: 1.2.2 -> 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@rails/ujs": "7.0.7",
     "@tailwindcss/forms": "0.5.4",
     "@tailwindcss/typography": "0.5.9",
-    "@teamshares/shoelace": "1.2.2",
+    "@teamshares/shoelace": "1.2.1",
     "cssnano": "6.0.1",
     "esbuild": "0.19.2",
     "esbuild-plugin-copy": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,10 +606,10 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@teamshares/shoelace@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-1.2.2.tgz#2225cdf35f8947f238c7100f9ab0ed1d0c7f4822"
-  integrity sha512-rfvhITqQbPaIN3L6sSIJVzy9ILbL6tzyW2x8m1EB6woHV4mZsmSbu1kmi+zYfYtGL4X2zl+L9tL6K2UGMTq4+Q==
+"@teamshares/shoelace@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-1.2.1.tgz#2be02148d45fbfa0eaba6c003be0da2efcf783ed"
+  integrity sha512-vKUK4ObJ22mUn0YceDm9zbD45Eg+5rNbvHFxE9t21pTIIBQXdg65EXrrvlSpgsfVHHIZJJs2oJapnAcmCHv1qw==
   dependencies:
     "@ctrl/tinycolor" "^3.5.0"
     "@floating-ui/dom" "^1.2.1"


### PR DESCRIPTION
@kathleenteamshares discovered a UI reversion (colors start showing with default, non-TS versions), we tracked it down to this @teamshares/shoelace update.