### PR TITLE
Fix shoelace styling regression (missing tokens)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@rails/ujs": "7.0.7",
     "@tailwindcss/forms": "0.5.4",
     "@tailwindcss/typography": "0.5.9",
-    "@teamshares/shoelace": "1.2.1",
+    "@teamshares/shoelace": "^1.2.3",
     "cssnano": "6.0.1",
     "esbuild": "0.19.2",
     "esbuild-plugin-copy": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,10 +606,10 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@teamshares/shoelace@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-1.2.1.tgz#2be02148d45fbfa0eaba6c003be0da2efcf783ed"
-  integrity sha512-vKUK4ObJ22mUn0YceDm9zbD45Eg+5rNbvHFxE9t21pTIIBQXdg65EXrrvlSpgsfVHHIZJJs2oJapnAcmCHv1qw==
+"@teamshares/shoelace@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-1.2.3.tgz#7d18ec2d5895756662e98f8c19971eb267ab6958"
+  integrity sha512-yjJCYGQ9xTHnyUgitgd2hV7Dm8XMQxIO8jLOOnivB8ySKtFUvXmweJ47MKWBE2tcQKuTFpTkSuC2235WUKdBww==
   dependencies:
     "@ctrl/tinycolor" "^3.5.0"
     "@floating-ui/dom" "^1.2.1"


### PR DESCRIPTION
## Ticket
[Fix shoelace styling regression](https://www.notion.so/teamshares/Fix-shoelace-styling-regression-in-v1-2-2-0770b818a7dc497a9fd2173a355310aa?pvs=4)

## Description
Re-published Shoelace to deploy missing tokens. Really not sure how they ended up not in the published version before, but they're there now. You can verify by pulling in this version of shoelace and looking at `generated.css` in node_modules and noting the `Shoelace color overrides` section.

