### PR TITLE
MAD - Tokens from shoelace

### DIFF
--- a/configs/tailwind.config.js
+++ b/configs/tailwind.config.js
@@ -1,7 +1,41 @@
 // Provides a shared base tailwind config for all Teamshares apps
 // Note: to load new changes in this file, the consuming app's asset pipeline may need to be restarted
 
+// Load the JSON tokens from Shoelace; they are already structured in Tailwind config format
 const tokens = require("@teamshares/shoelace/dist/styles/tokens.json");
+// Then inject the typography plugin config
+tokens.typography = {
+  tsprose: {
+    css: {
+      "--tw-prose-body": "var(--ts-colors-gray-900)",
+      "--tw-prose-headings": "var(--ts-colors-gray-900)",
+      "--tw-prose-lead": "var(--ts-colors-gray-700)",
+      "--tw-prose-links": "var(--ts-colors-blue-700)",
+      "--tw-prose-bold": "var(--ts-colors-gray-900)",
+      "--tw-prose-counters": "var(--ts-colors-gray-600)",
+      "--tw-prose-bullets": "var(--ts-colors-gray-600)",
+      "--tw-prose-hr": "var(--ts-colors-gray-300)",
+      "--tw-prose-quotes": "var(--ts-colors-gray-900)",
+      "--tw-prose-quote-borders": "var(--ts-colors-gray-300)",
+      "--tw-prose-captions": "var(--ts-colors-gray-700)",
+      "--tw-prose-code": "var(--ts-colors-gray-900)",
+      "--tw-prose-pre-code": "var(--ts-colors-gray-100)",
+      "--tw-prose-pre-bg": "var(--ts-colors-gray-900)",
+      "--tw-prose-th-borders": "var(--ts-colors-gray-300)",
+      "--tw-prose-td-borders": "var(--ts-colors-gray-200)",
+      a: {
+        color: "var(--ts-colors-blue-600)",
+        fontWeight: "400",
+        textUnderlineOffset: "4px",
+        transition: "all 300ms ease-in-out",
+        "&:hover": {
+          color: "var(--ts-colors-blue-700)",
+          textDecorationColor: "transparent",
+        },
+      },
+    },
+  },
+};
 
 const tailwindConfig = {
   content: [ // NOTE: When used within Rails apps, shared-ui and shared-rails-engine paths are dynamically injected as well

--- a/configs/tailwind.config.js
+++ b/configs/tailwind.config.js
@@ -1,6 +1,8 @@
 // Provides a shared base tailwind config for all Teamshares apps
 // Note: to load new changes in this file, the consuming app's asset pipeline may need to be restarted
 
+const tokens = require("@teamshares/shoelace/dist/styles/tokens.json");
+
 const tailwindConfig = {
   content: [ // NOTE: When used within Rails apps, shared-ui and shared-rails-engine paths are dynamically injected as well
     "app/**/*.{html,js,rb,erb,slim}",
@@ -13,110 +15,7 @@ const tailwindConfig = {
     require("@tailwindcss/typography"),
   ],
   theme: {
-    extend: {
-      colors: {
-        current: "currentColor",
-        blue: {
-          50: "#F6FAFD",
-          100: "#e1eff9",
-          200: "#b7d8f0",
-          300: "#84bafa",
-          400: "#539ef8",
-          500: "#3b74fc",
-          600: "#2c5ed6",
-          700: "#3a5dae",
-          800: "#29427b",
-          900: "#353d5f",
-          1000: "#2f3654",
-        },
-        gray: {
-          100: "#f6f8fa",
-          200: "#f0f0f0",
-          300: "#e8e8e8",
-          400: "#cdcfd1",
-          500: "#b3b5b8",
-          600: "#93999e",
-          700: "#6d7176",
-          800: "#444c59",
-          900: "#2e333c",
-        },
-        red: {
-          100: "#fcf1ef",
-          200: "#f7d7d2",
-          300: "#eec9c1",
-          400: "#f0948b",
-          500: "#f65747",
-          600: "#d64e41",
-          700: "#d7351c",
-          800: "#b92e18",
-          900: "#9b2614",
-        },
-        green: {
-          100: "#eef6e8",
-          200: "#d4e8c3",
-          300: "#72d0a3",
-          400: "#21bc9c",
-          500: "#17a688",
-          600: "#10985f",
-          700: "#068466",
-          800: "#164e3e",
-          900: "#004d49",
-        },
-        yellow: {
-          50: "#FFFBF0",
-          100: "#faf4ea",
-          200: "#f2eade",
-          300: "#fce491",
-          400: "#fad860",
-          500: "#ffc328",
-          600: "#f6af47",
-          700: "#ca861e",
-          800: "#956419",
-          900: "#694712",
-        },
-        teal: {
-          100: "#F0FAFA",
-          200: "#CAEBEC",
-          300: "#A4DBDD",
-          400: "#80CBCE",
-          500: "#5CBABD",
-          600: "#39A8AC",
-          700: "#288286",
-          800: "#1A5B5D",
-          900: "#0D3233",
-        },
-        subdued: "#6d7176",
-        default: "#2e333c",
-        white: "#ffffff",
-        success: "#068466",
-        error: "#d7351c",
-      },
-      fontFamily: {
-        sans: "Inter, Helvetica, Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-        serif: "DM Serif Display, Georgia, Times, serif",
-        mono: "SFMono-Regular, Menlo, mono",
-        display: "DM Serif Display, Georgia, Times, serif",
-        body: "Inter, Helvetica, Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-      },
-      fontSize: {
-        "10px": ["0.625rem", "1.5em"],
-        "13px": ["0.8125rem", "1.5em"],
-      },
-      fontWeight: {
-        light: 300,
-        normal: 400,
-        medium: 500,
-        semibold: 600,
-        bold: 700,
-      },
-      spacing: {
-        15: "3.75rem",
-      },
-      // Not in Buyout
-      transitionProperty: {
-        height: "height",
-      },
-    },
+    extend: tokens,
   },
 };
 

--- a/configs/tailwind.config.js
+++ b/configs/tailwind.config.js
@@ -3,39 +3,40 @@
 
 // Load the JSON tokens from Shoelace; they are already structured in Tailwind config format
 const tokens = require("@teamshares/shoelace/dist/styles/tokens.json");
-// Then inject the typography plugin config
-tokens.typography = {
+
+// Inject the typography plugin config
+tokens.typography = ({ theme }) => ({
   tsprose: {
     css: {
-      "--tw-prose-body": "var(--ts-colors-gray-900)",
-      "--tw-prose-headings": "var(--ts-colors-gray-900)",
-      "--tw-prose-lead": "var(--ts-colors-gray-700)",
-      "--tw-prose-links": "var(--ts-colors-blue-700)",
-      "--tw-prose-bold": "var(--ts-colors-gray-900)",
-      "--tw-prose-counters": "var(--ts-colors-gray-600)",
-      "--tw-prose-bullets": "var(--ts-colors-gray-600)",
-      "--tw-prose-hr": "var(--ts-colors-gray-300)",
-      "--tw-prose-quotes": "var(--ts-colors-gray-900)",
-      "--tw-prose-quote-borders": "var(--ts-colors-gray-300)",
-      "--tw-prose-captions": "var(--ts-colors-gray-700)",
-      "--tw-prose-code": "var(--ts-colors-gray-900)",
-      "--tw-prose-pre-code": "var(--ts-colors-gray-100)",
-      "--tw-prose-pre-bg": "var(--ts-colors-gray-900)",
-      "--tw-prose-th-borders": "var(--ts-colors-gray-300)",
-      "--tw-prose-td-borders": "var(--ts-colors-gray-200)",
+      "--tw-prose-body": theme("colors.gray[900]"),
+      "--tw-prose-headings": theme("colors.gray[900]"),
+      "--tw-prose-lead": theme("colors.gray[700]"),
+      "--tw-prose-links": theme("colors.blue[700]"),
+      "--tw-prose-bold": theme("colors.gray[900]"),
+      "--tw-prose-counters": theme("colors.gray[600]"),
+      "--tw-prose-bullets": theme("colors.gray[600]"),
+      "--tw-prose-hr": theme("colors.gray[300]"),
+      "--tw-prose-quotes": theme("colors.gray[900]"),
+      "--tw-prose-quote-borders": theme("colors.gray[300]"),
+      "--tw-prose-captions": theme("colors.gray[700]"),
+      "--tw-prose-code": theme("colors.gray[900]"),
+      "--tw-prose-pre-code": theme("colors.gray[100]"),
+      "--tw-prose-pre-bg": theme("colors.gray[900]"),
+      "--tw-prose-th-borders": theme("colors.gray[300]"),
+      "--tw-prose-td-borders": theme("colors.gray[200]"),
       a: {
-        color: "var(--ts-colors-blue-600)",
+        color: theme("colors.blue[600]"),
         fontWeight: "400",
         textUnderlineOffset: "4px",
         transition: "all 300ms ease-in-out",
         "&:hover": {
-          color: "var(--ts-colors-blue-700)",
+          color: theme("colors.blue[700]"),
           textDecorationColor: "transparent",
         },
       },
     },
   },
-};
+});
 
 const tailwindConfig = {
   content: [ // NOTE: When used within Rails apps, shared-ui and shared-rails-engine paths are dynamically injected as well

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -7,7 +7,4 @@
 @import 'includes';
 
 @import '@teamshares/shoelace/dist/themes/light';
-@import '@teamshares/shoelace/dist/styles/generated';
-@import '@teamshares/shoelace/dist/styles/tokens';
-@import '@teamshares/shoelace/dist/styles/overrides';
-@import '@teamshares/shoelace/dist/styles/vendor';
+@import '@teamshares/shoelace/dist/styles/index';


### PR DESCRIPTION
## Ticket
[Pull tailwind config colors into Shoelace, unify](https://www.notion.so/teamshares/Pull-tailwind-config-colors-into-Shoelace-unify-d2c8a9ffae234bdcb2adff5b63a52a3c?pvs=4)
[Make Shoelace the single-source-of-truth for tokens](https://www.notion.so/teamshares/Make-Shoelace-the-single-source-of-truth-for-tokens-5ccbccf543aa48c9ac8bf686611b28e3?pvs=4)

## Description
* Shared-ui now just imports the tokens directly from shoelace
* Also injects the new typography config from Sara. This will allow use of `prose` and `prose-tsprose` classes.
* Consolidated import for other tokens, to avoid the problem we saw last week (generated.css not being included)

## Screenshots (if relevant)

Prose classes applied:
<img width="666" alt="image" src="https://github.com/teamshares/shared-ui/assets/1148607/19bc7316-40ab-4a09-a996-8ee2f0df55f5">